### PR TITLE
refactor(missions): rename the generate phase to build

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -868,7 +868,7 @@ func (h *missionAPI) routeUnusable(ctx context.Context, route, harness string) (
 }
 
 // unusableCreateRoute walks the phase axes a create request's flow
-// actually runs (D-100): generate on the harness axis, discover/plan on
+// actually runs (D-100): build on the harness axis, discover/plan on
 // the oversight route and prove on the review route (chat axis) unless
 // the flow skips them, escalate when set. Returns the first route with
 // zero usable entries and its reason.
@@ -1295,7 +1295,7 @@ func (h *missionAPI) baseRoute(ctx context.Context, kind, explicitRoute, agentID
 	return "", "none"
 }
 
-// resolveHarness resolves the generate phase's harness via
+// resolveHarness resolves the build phase's harness via
 // missions.ResolveHarness, the same precedence chain create() and the
 // scheduler's fire path use: explicit -> agent -> settings -> native.
 // Only kind=coding can ever delegate (mirrors policy.go's
@@ -1366,12 +1366,12 @@ func (h *missionAPI) resolveEntries(ctx context.Context, route, harness, modelPi
 }
 
 const (
-	lightSkipReason   = "light missions run generate only"
-	escalateOffReason = "no escalation route set; failures retry on the generate route"
+	lightSkipReason   = "light missions run build only"
+	escalateOffReason = "no escalation route set; failures retry on the build route"
 )
 
 // executionPlan serves GET /v1/missions/execution-plan, resolving
-// every phase (discover, plan, generate, prove, escalate) server-side
+// every phase (discover, plan, build, prove, escalate) server-side
 // so the web UI never recomputes route/harness precedence itself
 // (docs/2026-08-26-mission-execution-plan.md, slice 1). Query params
 // mirror createMissionRequest's own route fields; all are optional.
@@ -1393,7 +1393,7 @@ func (h *missionAPI) executionPlan(w http.ResponseWriter, r *http.Request) {
 	escalationRoute := q.Get("escalation_route")
 	light := q.Get("light") == "true"
 	// Model pins (D-078) mirror runner.go's own precedence: routeModel
-	// backs generate, planRouteModel backs discover/plan, reviewModel
+	// backs build, planRouteModel backs discover/plan, reviewModel
 	// falls back reviewRouteModel > planRouteModel > routeModel, see
 	// oversightModel/reviewModel.
 	routeModel := q.Get("route_model")
@@ -1448,7 +1448,7 @@ func (h *missionAPI) missionExecutionPlan(w http.ResponseWriter, r *http.Request
 	})})
 }
 
-// buildExecutionPlan resolves every phase (discover, plan, generate,
+// buildExecutionPlan resolves every phase (discover, plan, build,
 // prove, escalate) for one route/harness set.
 func (h *missionAPI) buildExecutionPlan(ctx context.Context, in executionPlanInput) []executionPlanPhase {
 	base, baseSource := in.route, in.routeSource
@@ -1478,12 +1478,12 @@ func (h *missionAPI) buildExecutionPlan(ctx context.Context, in executionPlanInp
 
 	// reviewRoute mirrors runner.go's own helper: review_route, else
 	// plan_route (as "inherited-from-plan"), else the base route (as
-	// "inherited-from-generate"). oversight already equals planRoute
+	// "inherited-from-build"). oversight already equals planRoute
 	// when planRoute is set (see above), so that's the discriminator,
 	// oversightSource itself may also read "explicit" when it fell
 	// through to an explicit base route, which must not be confused
 	// with plan_route actually being set.
-	review, reviewSource := oversight, "inherited-from-generate"
+	review, reviewSource := oversight, "inherited-from-build"
 	if planRoute != "" {
 		reviewSource = "inherited-from-plan"
 	}
@@ -1509,7 +1509,7 @@ func (h *missionAPI) buildExecutionPlan(ctx context.Context, in executionPlanInp
 
 	generateEntries, generateErr := h.resolveEntries(ctx, base, harness, routeModel)
 	phases = append(phases, executionPlanPhase{
-		Phase: "generate", Route: base, RouteSource: baseSource, Axis: executeAxis,
+		Phase: "build", Route: base, RouteSource: baseSource, Axis: executeAxis,
 		Harness: harness, HarnessSource: harnessSource,
 		SkipReason: generateErr,
 		Entries:    emptyEntries(generateEntries),
@@ -1743,7 +1743,7 @@ func (h *missionAPI) permission(w http.ResponseWriter, r *http.Request) {
 }
 
 // approvePlan handles POST /v1/missions/{id}/approve-plan: the operator
-// accepts the plan as landed, advancing straight to generate (D-087,
+// accepts the plan as landed, advancing straight to build (D-087,
 // issue #456). Plain HTTP handler only, never a tool: the model
 // cannot call this.
 func (h *missionAPI) approvePlan(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -291,8 +291,8 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 }
 
 // TestMissionsNoteAcceptedOnEveryNonTerminalPhase confirms the note
-// endpoint (D-089, issue #458) is not generate-only: discover, plan,
-// prove, and generate all accept a note, and the mission.steered event
+// endpoint (D-089, issue #458) is not build-only: discover, plan,
+// prove, and build all accept a note, and the mission.steered event
 // records which phase it landed in.
 func TestMissionsNoteAcceptedOnEveryNonTerminalPhase(t *testing.T) {
 	store := testMissionStore(t)
@@ -524,7 +524,7 @@ func TestMissionsApprovePlanRejectedWhenNotParked(t *testing.T) {
 
 // TestMissionsApprovePlanAdvancesToGenerate confirms the full round
 // trip: a mission parked on PauseApproval, approve-plan advances it to
-// generate.
+// build.
 func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
 	store := testMissionStore(t)
 	ctx := context.Background()
@@ -559,7 +559,7 @@ func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 	if got.Phase != missions.PhaseBuild || got.Status != missions.StatusIdle && got.Status != missions.StatusWorking {
-		t.Fatalf("mission after approve-plan = %s/%s, want generate/idle-or-working (Drive may have already claimed it)", got.Phase, got.Status)
+		t.Fatalf("mission after approve-plan = %s/%s, want build/idle-or-working (Drive may have already claimed it)", got.Phase, got.Status)
 	}
 }
 

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -125,7 +125,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	// transition leaves behind, so Signal(InputResume) has something
 	// legal to resume from.
 	if err := store.ApplyTransition(ctx, id, missions.Transition{
-		Next: missions.StepState{Phase: missions.PhaseGenerate, Status: missions.StatusWaitingForInput},
+		Next: missions.StepState{Phase: missions.PhaseBuild, Status: missions.StatusWaitingForInput},
 	}); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if err := store.ApplyTransition(ctx, id, missions.Transition{
-		Next: missions.StepState{Phase: missions.PhaseGenerate, Status: missions.StatusPaused, PauseReason: missions.PauseInfra},
+		Next: missions.StepState{Phase: missions.PhaseBuild, Status: missions.StatusPaused, PauseReason: missions.PauseInfra},
 	}); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if err := store.ApplyTransition(ctx, id, missions.Transition{
-		Next: missions.StepState{Phase: missions.PhaseGenerate, Status: missions.StatusIdle},
+		Next: missions.StepState{Phase: missions.PhaseBuild, Status: missions.StatusIdle},
 	}); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Phase != missions.PhaseGenerate || got.Status != missions.StatusIdle {
+	if got.Phase != missions.PhaseBuild || got.Status != missions.StatusIdle {
 		t.Fatalf("phase/status after note = %s/%s, want unchanged execute/idle", got.Phase, got.Status)
 	}
 	if len(got.Progress) != 1 || !strings.Contains(got.Progress[0].Note, "Operator note: focus on the staging config next") {
@@ -302,7 +302,7 @@ func TestMissionsNoteAcceptedOnEveryNonTerminalPhase(t *testing.T) {
 	m := mux(a)
 	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, "", nil)
 
-	for _, phase := range []missions.Phase{missions.PhaseDiscover, missions.PhasePlan, missions.PhaseGenerate, missions.PhaseProve} {
+	for _, phase := range []missions.Phase{missions.PhaseDiscover, missions.PhasePlan, missions.PhaseBuild, missions.PhaseProve} {
 		phase := phase
 		t.Run(string(phase), func(t *testing.T) {
 			id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission note phase test", Kind: "general"})
@@ -558,7 +558,7 @@ func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Phase != missions.PhaseGenerate || got.Status != missions.StatusIdle && got.Status != missions.StatusWorking {
+	if got.Phase != missions.PhaseBuild || got.Status != missions.StatusIdle && got.Status != missions.StatusWorking {
 		t.Fatalf("mission after approve-plan = %s/%s, want generate/idle-or-working (Drive may have already claimed it)", got.Phase, got.Status)
 	}
 }
@@ -598,7 +598,7 @@ func TestMissionsAnswerValidatesMCQOption(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if err := store.SetPendingInput(ctx, id, missions.PendingInput{
-		Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: missions.PhaseGenerate,
+		Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: missions.PhaseBuild,
 	}); err != nil {
 		t.Fatalf("SetPendingInput: %v", err)
 	}
@@ -628,12 +628,12 @@ func TestMissionsAnswerResumesMission(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if err := store.ApplyTransition(ctx, id, missions.Transition{
-		Next: missions.StepState{Phase: missions.PhaseGenerate, Status: missions.StatusWaitingForInput},
+		Next: missions.StepState{Phase: missions.PhaseBuild, Status: missions.StatusWaitingForInput},
 	}); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
 	if err := store.SetPendingInput(ctx, id, missions.PendingInput{
-		Question: "continue?", Kind: "yes_no", ProposedDefault: "yes", Phase: missions.PhaseGenerate,
+		Question: "continue?", Kind: "yes_no", ProposedDefault: "yes", Phase: missions.PhaseBuild,
 	}); err != nil {
 		t.Fatalf("SetPendingInput: %v", err)
 	}

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -345,13 +345,13 @@ func TestMissionsCreateFlowNormalization(t *testing.T) {
 	if code, body := post(`{"goal":"g","kind":"general","flow":"light"}`); code != 400 || strings.Contains(body, "flow") {
 		t.Fatalf("flow=light, light omitted: code=%d body=%q, want a generic 400 (passed validation)", code, body)
 	}
-	// Explicit flow=no_prove / discover_generate on kind=general both
+	// Explicit flow=no_prove / discover_build on kind=general both
 	// pass validation.
 	if code, body := post(`{"goal":"g","kind":"general","flow":"no_prove"}`); code != 400 || strings.Contains(body, "flow") {
 		t.Fatalf("flow=no_prove on general: code=%d body=%q, want a generic 400 (passed validation)", code, body)
 	}
-	if code, body := post(`{"goal":"g","kind":"general","flow":"discover_generate"}`); code != 400 || strings.Contains(body, "flow") {
-		t.Fatalf("flow=discover_generate on general: code=%d body=%q, want a generic 400 (passed validation)", code, body)
+	if code, body := post(`{"goal":"g","kind":"general","flow":"discover_build"}`); code != 400 || strings.Contains(body, "flow") {
+		t.Fatalf("flow=discover_build on general: code=%d body=%q, want a generic 400 (passed validation)", code, body)
 	}
 	// Unknown flow value is rejected by ValidateCreate before Driver.Create
 	// ever touches the degraded store.
@@ -1353,7 +1353,7 @@ func getExecutionPlan(t *testing.T, h *missionAPI, query string) map[string]exec
 	for _, p := range body.Phases {
 		byPhase[p.Phase] = p
 	}
-	wantOrder := []string{"discover", "plan", "generate", "prove", "escalate"}
+	wantOrder := []string{"discover", "plan", "build", "prove", "escalate"}
 	for i, p := range body.Phases {
 		if p.Phase != wantOrder[i] {
 			t.Fatalf("phase[%d] = %q, want %q (phases must always appear in this order)", i, p.Phase, wantOrder[i])
@@ -1376,7 +1376,7 @@ func TestExecutionPlanNotFoundWhenResolveRouteNil(t *testing.T) {
 // TestExecutionPlanRouteSourceExplicit confirms an explicit ?route=
 // wins the base route and propagates unchanged to discover/plan (no
 // plan_route override) and generate; prove carries the same route
-// value but its own provenance label is "inherited-from-generate"
+// value but its own provenance label is "inherited-from-build"
 // (prove never itself set), not "explicit".
 func TestExecutionPlanRouteSourceExplicit(t *testing.T) {
 	t.Parallel()
@@ -1388,14 +1388,14 @@ func TestExecutionPlanRouteSourceExplicit(t *testing.T) {
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general&route=mine")
 
-	for _, phase := range []string{"discover", "plan", "generate"} {
+	for _, phase := range []string{"discover", "plan", "build"} {
 		p := byPhase[phase]
 		if p.Route != "mine" || p.RouteSource != "explicit" {
 			t.Fatalf("%s = route %q source %q, want mine/explicit", phase, p.Route, p.RouteSource)
 		}
 	}
-	if p := byPhase["prove"]; p.Route != "mine" || p.RouteSource != "inherited-from-generate" {
-		t.Fatalf("review = route %q source %q, want mine/inherited-from-generate", p.Route, p.RouteSource)
+	if p := byPhase["prove"]; p.Route != "mine" || p.RouteSource != "inherited-from-build" {
+		t.Fatalf("review = route %q source %q, want mine/inherited-from-build", p.Route, p.RouteSource)
 	}
 }
 
@@ -1416,7 +1416,7 @@ func TestExecutionPlanRouteSourceAgent(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general&agent=coder")
-	if p := byPhase["generate"]; p.Route != "agent-route" || p.RouteSource != "agent" {
+	if p := byPhase["build"]; p.Route != "agent-route" || p.RouteSource != "agent" {
 		t.Fatalf("execute = route %q source %q, want agent-route/agent", p.Route, p.RouteSource)
 	}
 }
@@ -1435,7 +1435,7 @@ func TestExecutionPlanRouteSourceNamedCoding(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=coding")
-	if p := byPhase["generate"]; p.Route != "coding" || p.RouteSource != "named-coding" {
+	if p := byPhase["build"]; p.Route != "coding" || p.RouteSource != "named-coding" {
 		t.Fatalf("execute = route %q source %q, want coding/named-coding", p.Route, p.RouteSource)
 	}
 }
@@ -1453,14 +1453,14 @@ func TestExecutionPlanRouteSourceDefaultRole(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general")
-	if p := byPhase["generate"]; p.Route != "default" || p.RouteSource != "default-role" {
+	if p := byPhase["build"]; p.Route != "default" || p.RouteSource != "default-role" {
 		t.Fatalf("execute = route %q source %q, want default/default-role", p.Route, p.RouteSource)
 	}
 
 	// kind=coding but no "coding" route exists (absent from the stub
 	// map, so resolveRoute errors on it) must also fall back here.
 	byPhaseCoding := getExecutionPlan(t, h, "kind=coding")
-	if p := byPhaseCoding["generate"]; p.Route != "default" || p.RouteSource != "default-role" {
+	if p := byPhaseCoding["build"]; p.Route != "default" || p.RouteSource != "default-role" {
 		t.Fatalf("execute (coding, no coding route) = route %q source %q, want default/default-role", p.Route, p.RouteSource)
 	}
 }
@@ -1474,7 +1474,7 @@ func TestExecutionPlanRouteSourceNone(t *testing.T) {
 		resolveRoute: stubResolveRoute(map[string]*gwclient.ResolvedRoute{}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general")
-	p := byPhase["generate"]
+	p := byPhase["build"]
 	if p.Route != "" || p.RouteSource != "none" {
 		t.Fatalf("execute = route %q source %q, want \"\"/none", p.Route, p.RouteSource)
 	}
@@ -1512,7 +1512,7 @@ func TestExecutionPlanOversightRoutes(t *testing.T) {
 	if p := byPhase["prove"]; p.Route != "strong" || p.RouteSource != "inherited-from-plan" {
 		t.Fatalf("review = route %q source %q, want strong/inherited-from-plan", p.Route, p.RouteSource)
 	}
-	if p := byPhase["generate"]; p.Route != "base" {
+	if p := byPhase["build"]; p.Route != "base" {
 		t.Fatalf("execute = route %q, want base (unaffected by plan_route)", p.Route)
 	}
 
@@ -1526,11 +1526,11 @@ func TestExecutionPlanOversightRoutes(t *testing.T) {
 	}
 
 	// review_route provenance without an explicit plan_route reports
-	// inherited-from-generate, matching runner.go's reviewRoute falling
+	// inherited-from-build, matching runner.go's reviewRoute falling
 	// through oversightRoute straight to Route.
 	byPhase3 := getExecutionPlan(t, h, "kind=general&route=base")
-	if p := byPhase3["prove"]; p.Route != "base" || p.RouteSource != "inherited-from-generate" {
-		t.Fatalf("review = route %q source %q, want base/inherited-from-generate", p.Route, p.RouteSource)
+	if p := byPhase3["prove"]; p.Route != "base" || p.RouteSource != "inherited-from-build" {
+		t.Fatalf("review = route %q source %q, want base/inherited-from-build", p.Route, p.RouteSource)
 	}
 }
 
@@ -1548,19 +1548,19 @@ func TestExecutionPlanHarnessAxis(t *testing.T) {
 	}
 
 	coding := getExecutionPlan(t, h, "kind=coding&route=base&harness=claude-cli")
-	if p := coding["generate"]; p.Axis != "harness" || p.Harness != "claude-cli" || p.HarnessSource != "explicit" {
+	if p := coding["build"]; p.Axis != "harness" || p.Harness != "claude-cli" || p.HarnessSource != "explicit" {
 		t.Fatalf("coding execute = axis %q harness %q source %q, want harness/claude-cli/explicit", p.Axis, p.Harness, p.HarnessSource)
 	}
 
 	general := getExecutionPlan(t, h, "kind=general&route=base&harness=claude-cli")
-	if p := general["generate"]; p.Axis != "native" || p.Harness != "" {
+	if p := general["build"]; p.Axis != "native" || p.Harness != "" {
 		t.Fatalf("general execute = axis %q harness %q, want native/\"\" (harness ignored for non-coding)", p.Axis, p.Harness)
 	}
 
 	// "native" is the settings sentinel for off: normalizes to axis
 	// native with no harness, same as create()'s own req.Harness == "native".
 	nativeSentinel := getExecutionPlan(t, h, "kind=coding&route=base&harness=native")
-	if p := nativeSentinel["generate"]; p.Axis != "native" || p.Harness != "" {
+	if p := nativeSentinel["build"]; p.Axis != "native" || p.Harness != "" {
 		t.Fatalf("coding execute with harness=native = axis %q harness %q, want native/\"\"", p.Axis, p.Harness)
 	}
 }
@@ -1578,7 +1578,7 @@ func TestExecutionPlanHarnessSourceSettings(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=coding&route=base")
-	if p := byPhase["generate"]; p.Harness != "opencode" || p.HarnessSource != "settings" {
+	if p := byPhase["build"]; p.Harness != "opencode" || p.HarnessSource != "settings" {
 		t.Fatalf("execute = harness %q source %q, want opencode/settings", p.Harness, p.HarnessSource)
 	}
 }
@@ -1604,13 +1604,13 @@ func TestExecutionPlanHarnessSourceAgent(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=coding&route=base&agent=coder")
-	if p := byPhase["generate"]; p.Harness != "pi" || p.HarnessSource != "agent" {
+	if p := byPhase["build"]; p.Harness != "pi" || p.HarnessSource != "agent" {
 		t.Fatalf("execute = harness %q source %q, want pi/agent", p.Harness, p.HarnessSource)
 	}
 
 	// An explicit ?harness= still wins over the agent's own harness.
 	explicit := getExecutionPlan(t, h, "kind=coding&route=base&agent=coder&harness=claude-cli")
-	if p := explicit["generate"]; p.Harness != "claude-cli" || p.HarnessSource != "explicit" {
+	if p := explicit["build"]; p.Harness != "claude-cli" || p.HarnessSource != "explicit" {
 		t.Fatalf("execute with explicit harness = harness %q source %q, want claude-cli/explicit", p.Harness, p.HarnessSource)
 	}
 }
@@ -1633,7 +1633,7 @@ func TestExecutionPlanLightSkipsOversightOnly(t *testing.T) {
 			t.Fatalf("%s = skipped %v reason %q, want true/%q", phase, p.Skipped, p.SkipReason, lightSkipReason)
 		}
 	}
-	if p := byPhase["generate"]; p.Skipped {
+	if p := byPhase["build"]; p.Skipped {
 		t.Fatalf("execute = skipped %v, want false (execute never skips)", p.Skipped)
 	}
 }
@@ -1687,7 +1687,7 @@ func TestExecutionPlanSelectedFirstUsable(t *testing.T) {
 	}
 
 	mixed := getExecutionPlan(t, h, "kind=general&route=mixed")
-	entries := mixed["generate"].Entries
+	entries := mixed["build"].Entries
 	if len(entries) != 3 {
 		t.Fatalf("entries = %d, want 3", len(entries))
 	}
@@ -1702,7 +1702,7 @@ func TestExecutionPlanSelectedFirstUsable(t *testing.T) {
 	}
 
 	noneUsable := getExecutionPlan(t, h, "kind=general&route=none-usable")
-	for i, e := range noneUsable["generate"].Entries {
+	for i, e := range noneUsable["build"].Entries {
 		if e.Selected {
 			t.Fatalf("entries[%d] selected = true, want false (no entry is usable)", i)
 		}
@@ -1724,7 +1724,7 @@ func TestExecutionPlanRouteModelPinSelectsPinnedEntry(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general&route=mixed&route_model="+url.QueryEscape("C/c"))
-	entries := byPhase["generate"].Entries
+	entries := byPhase["build"].Entries
 	if entries[0].Selected {
 		t.Fatalf("entries[0] (B/b, unpinned) selected = true, want false")
 	}
@@ -1750,7 +1750,7 @@ func TestExecutionPlanRouteModelPinUnusableDegradesToFirstUsable(t *testing.T) {
 		}),
 	}
 	byPhase := getExecutionPlan(t, h, "kind=general&route=mixed&route_model="+url.QueryEscape("A/a"))
-	entries := byPhase["generate"].Entries
+	entries := byPhase["build"].Entries
 	if entries[0].Selected {
 		t.Fatalf("entries[0] (A/a, pinned but unusable) selected = true, want false")
 	}
@@ -1839,7 +1839,7 @@ func TestExecutionPlanPricesOmittedWhenNil(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	for _, p := range decoded.Phases {
-		if p.Phase != "generate" {
+		if p.Phase != "build" {
 			continue
 		}
 		for _, e := range p.Entries {
@@ -1880,7 +1880,7 @@ func TestExecutionPlanResolveErrorIsolatedToOnePhase(t *testing.T) {
 		t.Fatalf("escalate skipped = true, want false (it wasn't skipped, it failed to resolve)")
 	}
 
-	execute := byPhase["generate"]
+	execute := byPhase["build"]
 	if len(execute.Entries) != 1 || execute.Entries[0].ProviderName != "A" {
 		t.Fatalf("execute = %+v, want the base route's entry unaffected by escalate's failure", execute)
 	}

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -1375,7 +1375,7 @@ func TestExecutionPlanNotFoundWhenResolveRouteNil(t *testing.T) {
 
 // TestExecutionPlanRouteSourceExplicit confirms an explicit ?route=
 // wins the base route and propagates unchanged to discover/plan (no
-// plan_route override) and generate; prove carries the same route
+// plan_route override) and build; prove carries the same route
 // value but its own provenance label is "inherited-from-build"
 // (prove never itself set), not "explicit".
 func TestExecutionPlanRouteSourceExplicit(t *testing.T) {
@@ -1484,7 +1484,7 @@ func TestExecutionPlanRouteSourceNone(t *testing.T) {
 }
 
 // TestExecutionPlanOversightRoutes confirms plan_route, when set,
-// covers discover/plan/prove (oversight phases) while generate stays on
+// covers discover/plan/prove (oversight phases) while build stays on
 // the base route, and review_route independently overrides prove
 // alone (precedence: review_route > plan_route > route).
 func TestExecutionPlanOversightRoutes(t *testing.T) {
@@ -1499,7 +1499,7 @@ func TestExecutionPlanOversightRoutes(t *testing.T) {
 	}
 
 	// plan_route alone covers discover/plan/prove's route value,
-	// generate keeps base. discover/plan carry plan_route's own
+	// build keeps base. discover/plan carry plan_route's own
 	// "explicit" provenance; prove's value matches but its provenance
 	// is "inherited-from-plan" (prove never itself set plan_route).
 	byPhase := getExecutionPlan(t, h, "kind=general&route=base&plan_route=strong")
@@ -1535,8 +1535,8 @@ func TestExecutionPlanOversightRoutes(t *testing.T) {
 }
 
 // TestExecutionPlanHarnessAxis confirms kind=coding with a harness set
-// resolves generate on the harness axis, and kind=general with the same
-// harness set never delegates (D-072's canDelegate rule): generate
+// resolves build on the harness axis, and kind=general with the same
+// harness set never delegates (D-072's canDelegate rule): build
 // stays native regardless.
 func TestExecutionPlanHarnessAxis(t *testing.T) {
 	t.Parallel()
@@ -1616,7 +1616,7 @@ func TestExecutionPlanHarnessSourceAgent(t *testing.T) {
 }
 
 // TestExecutionPlanLightSkipsOversightOnly confirms light=true skips
-// discover/plan/prove with the fixed reason while generate is never
+// discover/plan/prove with the fixed reason while build is never
 // skipped.
 func TestExecutionPlanLightSkipsOversightOnly(t *testing.T) {
 	t.Parallel()

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -81,7 +81,7 @@ func Render(m missions.Mission, webBaseURL string, events []missions.Event, loc 
 	}
 	body := "Mission complete: " + name
 	if m.RunsPlanless() && m.FinalOutput != "" {
-		// D-069/D-090: a planless mission (light, or flow=discover_generate)
+		// D-069/D-090: a planless mission (light, or flow=discover_build)
 		// has no plan/artifacts, only its final worker message; that IS the
 		// result recipients want, not a completion line pointing them
 		// elsewhere.

--- a/internal/brain/missions/CLAUDE.md
+++ b/internal/brain/missions/CLAUDE.md
@@ -12,19 +12,19 @@ CLAUDE.md so other work does not pay for it every session.
   `scheduler.go`, `notify.go`, `sweep.go`, `memory.go`. Schema:
   `migrations/0001_init.sql` (edited in place pre-release, never new
   ALTER migrations).
-- Mission phases (D-086, issue #455): discover -> plan -> generate ->
-  prove -> result -> done|failed. `parsePhase` (statemachine.go) still
-  accepts the pre-rename names (explore/execute/review) at read time,
-  mapping them to discover/generate/prove, so a new binary reads old
-  rows safely before the data migration in `scripts/pending-alters.md`
-  runs; historical `mission_events` payloads keep their old phase
+- Mission phases (D-086 issue #455, renamed again by issue #611):
+  discover -> plan -> build -> prove -> result -> done|failed.
+  `parsePhase` (statemachine.go) still accepts the pre-rename names
+  (explore/execute/review, and generate) at read time, mapping them to
+  discover/build/prove, so a new binary reads old rows safely before
+  the data migration in `scripts/pending-alters.md` runs; historical `mission_events` payloads keep their old phase
   names forever, tolerated by the web timeline renderer. Result is
   deterministic harness code (zero LLM turns): destinations delivery
   (including github push/PR, issue #561), artifact copy, and KB
   promotion all run there now, not on the old done transition; a
   failure parks the mission IN result with a visible pause reason
   instead of being lost.
-- Light missions (D-069, kind=general only): born in phase=generate,
+- Light missions (D-069, kind=general only): born in phase=build,
   skip discover/plan/prove; the deliverable travels in mission_status's
   `final_output` argument (reasoning models emit tool calls with no
   plain text). Digest schedules run light.
@@ -64,7 +64,7 @@ CLAUDE.md so other work does not pay for it every session.
   must exist, non-empty, inside the workspace) runs BEFORE any
   model-authored `verify_cmd`. `passes` flags flip only on harness
   evidence, never on model claims.
-- Batch verification (D-094, issue #518): after every generate turn
+- Batch verification (D-094, issue #518): after every build turn
   `verifier.verifyAll` checks every unit (unverified ones fully,
   already-passed ones as the regression subset) and the driver hands
   the outcomes to `Step` via `StepInput.Verified`; `applyVerification`
@@ -72,8 +72,10 @@ CLAUDE.md so other work does not pay for it every session.
   the plan units, persisted only by `ApplyTransition`. A failing or
   regressed unit costs a worker turn (`worker_retry`), never a review;
   `stepReviewApprove` flips `passes` on harness-passed units only; a
-  generate phase with every unit harness-passed and no open finding
-  skips the worker turn (`mission.generate_skipped`).
+  build phase with every unit harness-passed and no open finding
+  skips the worker turn (`mission.generate_skipped`: event type
+  names are stable identifiers and keep their pre-#611 spelling, the
+  same way `mission.review_*` survived the review -> prove rename).
 - Unit criteria and scoped review (D-095, issue #520): every plan unit
   carries `criteria` (2 to 6 lines, `parsePlan` rejects the plan with
   `plan_invalid` otherwise, one planner retry) and `scope` (paths,
@@ -89,8 +91,8 @@ CLAUDE.md so other work does not pay for it every session.
   and no unresolved prior blocking one counts as approval. Light
   missions never plan, so none of this applies to them.
 - One review round, findings-only re-review (D-096, issue #524): a
-  generate turn that leaves units without harness evidence and no
-  finding open stays in generate (`mission.generate_continued`); prove
+  build turn that leaves units without harness evidence and no
+  finding open stays in build (`mission.generate_continued`); prove
   runs one full round once every unit is harness-passed (or a finding
   is open). A rework records the worktree HEAD in the plan jsonb as
   `last_review_commit` (written only by `ApplyTransition`); every later

--- a/internal/brain/missions/artifact_copy_test.go
+++ b/internal/brain/missions/artifact_copy_test.go
@@ -26,7 +26,7 @@ func TestDriverCopiesArtifactsBeforeDestinationDelivery(t *testing.T) {
 	deliverRec := &recordingDeliver{}
 	d.SetDestinationDeliver(deliverRec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	if got := deliverRec.count(); got != 1 {
 		t.Fatalf("deliver calls = %d, want 1", got)

--- a/internal/brain/missions/artifact_copy_test.go
+++ b/internal/brain/missions/artifact_copy_test.go
@@ -48,7 +48,7 @@ func TestDriverCopiesArtifactsBeforeDestinationDelivery(t *testing.T) {
 // never runs.
 func TestDriverSkipsArtifactCopyOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}

--- a/internal/brain/missions/asktool_test.go
+++ b/internal/brain/missions/asktool_test.go
@@ -106,7 +106,7 @@ func TestAskUserToolExecute(t *testing.T) {
 					t.Fatalf("ProposedDefault = %q, want %q", parker.parked[0].ProposedDefault, tc.wantDefault)
 				}
 				if parker.parked[0].Phase != PhaseBuild {
-					t.Fatalf("Phase = %q, want generate", parker.parked[0].Phase)
+					t.Fatalf("Phase = %q, want build", parker.parked[0].Phase)
 				}
 			}
 		})

--- a/internal/brain/missions/asktool_test.go
+++ b/internal/brain/missions/asktool_test.go
@@ -92,7 +92,7 @@ func TestAskUserToolExecute(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			parker := &fakeAskUserParker{}
-			tool := AskUserTool("m1", PhaseGenerate, tc.asksUsed, tc.budget, parker)
+			tool := AskUserTool("m1", PhaseBuild, tc.asksUsed, tc.budget, parker)
 			_, err := tool.Execute(context.Background(), json.RawMessage(tc.args))
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("Execute() error = %v, wantErr %v", err, tc.wantErr)
@@ -105,7 +105,7 @@ func TestAskUserToolExecute(t *testing.T) {
 				if parker.parked[0].ProposedDefault != tc.wantDefault {
 					t.Fatalf("ProposedDefault = %q, want %q", parker.parked[0].ProposedDefault, tc.wantDefault)
 				}
-				if parker.parked[0].Phase != PhaseGenerate {
+				if parker.parked[0].Phase != PhaseBuild {
 					t.Fatalf("Phase = %q, want generate", parker.parked[0].Phase)
 				}
 			}

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -717,7 +717,7 @@ var (
 
 // cliRun is the per-run context the shared D-052 protocol threads
 // through launch, poll, finish and bookkeeping (issue #582): a worker
-// run (phase generate) and a review run (phase prove) differ only in
+// run (phase build) and a review run (phase prove) differ only in
 // these fields. Every executor.* event a run records carries phase.
 type cliRun struct {
 	phase    string
@@ -734,7 +734,7 @@ type cliRun struct {
 // workerRun builds the cliRun for a worker turn.
 func workerRun(m Mission, entry gwclient.ResolvedRouteEntry, adapter executor.Adapter, authMode executor.AuthMode) cliRun {
 	return cliRun{
-		phase: string(PhaseGenerate), harness: m.Harness, entry: entry, adapter: adapter,
+		phase: string(PhaseBuild), harness: m.Harness, entry: entry, adapter: adapter,
 		authMode: authMode, route: workerRoute(m), agent: "mission-worker", steer: true,
 	}
 }
@@ -753,7 +753,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	authMode, apiKey, err := r.resolveCredential(ctx, entry.CredentialRef, adapter.Capabilities())
 	if err != nil {
 		r.coolDown(m.Harness, entry)
-		r.recordAuthFailed(ctx, m.ID, string(PhaseGenerate), m.Harness)
+		r.recordAuthFailed(ctx, m.ID, string(PhaseBuild), m.Harness)
 		return WorkerVerdict{}, "", err
 	}
 	run := workerRun(m, entry, adapter, authMode)
@@ -864,7 +864,7 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 	probeCmd := fmt.Sprintf("cd %s && { [ -f exit_code ] || [ -f pid ]; }", shQuote(state.RunDir))
 	code, perr := r.sandboxExec(ctx, m.ID, m.Environment, workRoot, probeCmd, nil, launchTimeout, &probe)
 	if perr != nil || code != 0 {
-		r.recordDied(ctx, m.ID, string(PhaseGenerate), "lost_run", nil, "run directory or pid missing after restart")
+		r.recordDied(ctx, m.ID, string(PhaseBuild), "lost_run", nil, "run directory or pid missing after restart")
 		return true, forcedRetryVerdict("the executor's run was lost across a restart"), "", nil
 	}
 
@@ -1252,7 +1252,7 @@ func (r *delegatedRunner) injectSteering(ctx context.Context, m Mission, workRoo
 			return delivered
 		}
 		delivered++
-		r.recordEventForce(ctx, m.ID, "executor.steered", map[string]any{"note": note, "harness": m.Harness, "phase": string(PhaseGenerate)})
+		r.recordEventForce(ctx, m.ID, "executor.steered", map[string]any{"note": note, "harness": m.Harness, "phase": string(PhaseBuild)})
 	}
 	return newWatermark
 }
@@ -1684,7 +1684,7 @@ func (r *delegatedRunner) recordAuthFailed(ctx context.Context, missionID, phase
 // skip_reasons); nil for unknown_harness, which needs nothing beyond
 // harness+reason.
 func (r *delegatedRunner) recordSkipped(ctx context.Context, missionID, harness, reason string, extra map[string]any) {
-	payload := map[string]any{"harness": harness, "reason": reason, "phase": string(PhaseGenerate)}
+	payload := map[string]any{"harness": harness, "reason": reason, "phase": string(PhaseBuild)}
 	for k, v := range extra {
 		payload[k] = v
 	}

--- a/internal/brain/missions/delegated_review_test.go
+++ b/internal/brain/missions/delegated_review_test.go
@@ -218,7 +218,7 @@ func TestDelegatedRunReview_FallsBackToNative(t *testing.T) {
 
 // TestDelegatedRunWorker_EventsCarryPhaseBuild pins the worker side
 // of issue #582's phase field: every worker run's executor events say
-// generate, so the timeline can tell them from review runs.
+// build, so the timeline can tell them from review runs.
 func TestDelegatedRunWorker_EventsCarryPhaseBuild(t *testing.T) {
 	sandbox := newFakeSandbox()
 	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
@@ -239,7 +239,7 @@ func TestDelegatedRunWorker_EventsCarryPhaseBuild(t *testing.T) {
 		var payload map[string]any
 		_ = json.Unmarshal(ev.Payload, &payload)
 		if payload["phase"] != "build" {
-			t.Fatalf("%s phase = %v, want generate", kind, payload["phase"])
+			t.Fatalf("%s phase = %v, want build", kind, payload["phase"])
 		}
 	}
 }

--- a/internal/brain/missions/delegated_review_test.go
+++ b/internal/brain/missions/delegated_review_test.go
@@ -216,10 +216,10 @@ func TestDelegatedRunReview_FallsBackToNative(t *testing.T) {
 	}
 }
 
-// TestDelegatedRunWorker_EventsCarryPhaseGenerate pins the worker side
+// TestDelegatedRunWorker_EventsCarryPhaseBuild pins the worker side
 // of issue #582's phase field: every worker run's executor events say
 // generate, so the timeline can tell them from review runs.
-func TestDelegatedRunWorker_EventsCarryPhaseGenerate(t *testing.T) {
+func TestDelegatedRunWorker_EventsCarryPhaseBuild(t *testing.T) {
 	sandbox := newFakeSandbox()
 	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
 	sandbox.seedExitCode = 0
@@ -238,7 +238,7 @@ func TestDelegatedRunWorker_EventsCarryPhaseGenerate(t *testing.T) {
 		}
 		var payload map[string]any
 		_ = json.Unmarshal(ev.Payload, &payload)
-		if payload["phase"] != "generate" {
+		if payload["phase"] != "build" {
 			t.Fatalf("%s phase = %v, want generate", kind, payload["phase"])
 		}
 	}

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -714,7 +714,7 @@ func TestDelegatedRunWorker_AuthFailure_ReturnsErrExecutorAuth(t *testing.T) {
 // runner must pause the mission as infra on the FIRST turn.
 func TestDriverErrExecutorAuthPausesImmediately(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: stderr said please run /login", ErrExecutorAuth)}
 	d := testDriver(store, runner)
 
@@ -737,7 +737,7 @@ func TestDriverErrExecutorAuthPausesImmediately(t *testing.T) {
 // run may still be alive in the sandbox.
 func TestDriverErrGatewayUnavailablePausesImmediately(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: gwclient: gateway unavailable: gateway http 503: config_unavailable", ErrGatewayUnavailable)}
 	d := testDriver(store, runner)
 
@@ -2599,7 +2599,7 @@ func TestRecordLedgerPrefersReportedModel(t *testing.T) {
 			r := &delegatedRunner{ledger: led, log: slog.Default()}
 			entry := gwclient.ResolvedRouteEntry{ProviderName: "Cursor", Model: tc.entryModel}
 
-			run := cliRun{phase: string(PhaseGenerate), entry: entry, authMode: executor.AuthSubscription, route: "default", agent: "mission-worker"}
+			run := cliRun{phase: string(PhaseBuild), entry: entry, authMode: executor.AuthSubscription, route: "default", agent: "mission-worker"}
 			r.recordLedger(context.Background(), Mission{ID: "m1"}, run, nil, time.Now(), true, "", tc.reportedModel)
 
 			if len(led.entries) != 1 {

--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -65,7 +65,7 @@ func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
 	rec := &recordingDeliver{}
 	d.SetDestinationDeliver(rec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	if got := rec.count(); got != 1 {
 		t.Fatalf("deliver calls = %d, want 1", got)
@@ -141,7 +141,7 @@ func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
 	deliverRec := &recordingDeliver{}
 	d.SetDestinationDeliver(deliverRec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	if got := deliverRec.count(); got != 1 {
 		t.Fatalf("deliver calls = %d, want 1", got)
@@ -187,7 +187,7 @@ func TestDriverParksInResultOnDeliveryFailure(t *testing.T) {
 	rec := &recordingDeliver{err: errors.New("destination unreachable")}
 	d.SetDestinationDeliver(rec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result(parked)
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result(parked)
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseResult {

--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -81,7 +81,7 @@ func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
 
 func TestDriverSkipsDeliveryOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1018,7 +1018,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		"phase": string(m.Phase), "duration_ms": turnMs,
 		"ok": err == nil, "input": string(in.Input), "reason": in.Reason,
 	}
-	if m.Phase == PhaseGenerate && workerRoute(m) != m.Route {
+	if m.Phase == PhaseBuild && workerRoute(m) != m.Route {
 		payload["escalated_route"] = workerRoute(m)
 	}
 	// Route/agent context (issue #473): route is the mission's own
@@ -1334,11 +1334,11 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 // its outcome maps to. It does not itself decide pass/fail semantics
 // beyond what each phase's contract already defines (worker sentinel,
 // review verdict, planner output). Light missions (D-069) are born in
-// PhaseGenerate and short-circuit out of runExecute's done branch
+// PhaseBuild and short-circuit out of runExecute's done branch
 // straight to InputReviewApprove, so they never reach the discover/plan/
-// prove cases below by construction. flow=discover_generate (D-090,
+// prove cases below by construction. flow=discover_build (D-090,
 // issue #459) DOES reach PhaseDiscover (it runs discover as normal),
-// but its own PhaseGenerate turn takes the same planless short-circuit
+// but its own PhaseBuild turn takes the same planless short-circuit
 // as light, so it never reaches PhasePlan or PhaseProve either.
 func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 	switch m.Phase {
@@ -1346,7 +1346,7 @@ func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 		return d.runDiscover(ctx, m)
 	case PhasePlan:
 		return d.runPlan(ctx, m)
-	case PhaseGenerate:
+	case PhaseBuild:
 		return d.runExecute(ctx, m)
 	case PhaseProve:
 		return d.runReview(ctx, m)
@@ -1364,8 +1364,8 @@ func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 const discoverNotesCap = 8000
 
 // runDiscover runs one discover turn: a tool-using session that
-// explores the goal before planning (or, for flow=discover_generate,
-// D-090, the planless generate pass) commits to a shape. The findings
+// explores the goal before planning (or, for flow=discover_build,
+// D-090, the planless build pass) commits to a shape. The findings
 // are stored on the mission (SetDiscoverNotes) so the next phase's own
 // (separate) Advance call reads them back via a fresh Get.
 func (d *Driver) runDiscover(ctx context.Context, m Mission) (StepInput, error) {
@@ -1589,7 +1589,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 		}
 		if m.RunsPlanless() {
 			// D-069/D-090: a planless mission (light, or
-			// flow=discover_generate) has no plan/artifacts for
+			// flow=discover_build) has no plan/artifacts for
 			// routeVerified to check (it would bail into review for want
 			// of them); the worker's final message IS the deliverable,
 			// so approve directly instead. FinalMessage is the text
@@ -1612,8 +1612,8 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 				d.log.Warn("driver: record final output failed", "mission_id", m.ID, "error", err)
 			}
 			reason := "light"
-			if m.Flow == FlowDiscoverGenerate {
-				reason = "discover_generate"
+			if m.Flow == FlowDiscoverBuild {
+				reason = "discover_build"
 			}
 			if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{"reason": reason, "verified": false}); err != nil {
 				d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
@@ -2009,7 +2009,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		// runs again (no citations: the worker turn's seenURLs are gone)
 		// and a unit failing it, reviewed or regressed, routes through the
 		// SAME rework path a reviewer's own rejection takes, as a
-		// harness-authored blocking finding (D-092): back to generate with
+		// harness-authored blocking finding (D-092): back to build with
 		// the failure in the worker's packet, counted against the rework
 		// ceiling, and deduplicated by title so the same failing verify
 		// never opens a second finding.
@@ -2067,8 +2067,8 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 		Light: m.RunsPlanless(), Location: loc,
 		Findings: m.ReviewFindings, ReworkRound: m.ReworkRounds, MaxRounds: m.MaxIterations,
 	}
-	// D-090: only flow=discover_generate ever has discover notes AND
-	// runs planless at the same time (Light is born in PhaseGenerate,
+	// D-090: only flow=discover_build ever has discover notes AND
+	// runs planless at the same time (Light is born in PhaseBuild,
 	// never visits discover); gating on p.Light here is redundant but
 	// harmless, m.DiscoverNotes is simply empty for every other case.
 	if p.Light {

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestDriverEndToEndCodingMission is M2's exit criterion: one mission
-// driven fully through discover -> plan -> generate -> prove -> done
+// driven fully through discover -> plan -> build -> prove -> done
 // against a real Postgres Store and a real git Workspace, with a
 // SCRIPTED FAKE Runner standing in for the model (no live model call,
 // no gateway dependency).
@@ -70,7 +70,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 		t.Fatalf("git commit: %v: %s", err, out)
 	}
 
-	// discover -> plan -> generate -> prove -> done: drive to
+	// discover -> plan -> build -> prove -> done: drive to
 	// completion (bounded, so a design bug can't hang the test suite).
 	for i := 0; i < 10; i++ {
 		cont, err := d.Advance(ctx, id)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -282,7 +282,7 @@ type scriptedRunner struct {
 	// workerPackets records the WorkPacket RunWorker was called with,
 	// one entry per call: lets a test assert the generate phase's
 	// packet actually carried what the driver built (e.g. DiscoverNotes
-	// for flow=discover_generate, D-090).
+	// for flow=discover_build, D-090).
 	workerPackets  []WorkPacket
 	reviewVerdicts []ReviewVerdict
 	reviewIdx      int
@@ -573,7 +573,7 @@ func TestDriverProvisionDetectsEnvironmentFromRepoMarkers(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Goal: "go ahead and fix the login page", Kind: "coding",
 		Sources: []SourceEntry{{Source: SourceKindGitHub, RepoURL: bare, ConnectorID: "conn1"}},
-		Phase:   PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase:   PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
@@ -786,7 +786,7 @@ func TestDriverDecidePlanApprove(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Phase != PhaseGenerate || got.Status != StatusIdle || got.PauseReason != "" {
+	if got.Phase != PhaseBuild || got.Status != StatusIdle || got.PauseReason != "" {
 		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", got.Phase, got.Status, got.PauseReason)
 	}
 }
@@ -797,7 +797,7 @@ func TestDriverDecidePlanApprove(t *testing.T) {
 // PauseApproval, regardless of phase.
 func TestDriverDecidePlanReplanRejectedWhenNotParked(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	d := testDriver(store, &scriptedRunner{})
 
 	err := d.DecidePlan(context.Background(), "m1", InputPlanReplan, "feedback")
@@ -805,7 +805,7 @@ func TestDriverDecidePlanReplanRejectedWhenNotParked(t *testing.T) {
 		t.Fatalf("DecidePlan error = %v, want ErrNotAwaitingApproval", err)
 	}
 	got := store.missions["m1"]
-	if got.Phase != PhaseGenerate || got.Status != StatusWorking {
+	if got.Phase != PhaseBuild || got.Status != StatusWorking {
 		t.Fatalf("mission after rejected decide = %s/%s, want untouched generate/working", got.Phase, got.Status)
 	}
 }
@@ -907,7 +907,7 @@ func TestDriverPlanInfeasibleFailsMission(t *testing.T) {
 // summary.
 func TestDriverExecuteRecordsHandoffOverRawText(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "hit a wall", Handoff: "half the migration is done; finish the token refresh path next"}},
 		workerText:     "raw turn text nobody should see in progress",
@@ -931,7 +931,7 @@ func TestDriverExecuteRecordsHandoffOverRawText(t *testing.T) {
 // handoff: the raw turn text is still what gets recorded.
 func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "hit a wall"}},
 		workerText:     "raw turn text",
@@ -955,7 +955,7 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 // when no handoff was given, not the accumulated stream text.
 func TestDriverExecuteRecordsDelegatedNote(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "tests red", Note: "tests red"}},
 		workerText:     "I'll create the file.Verification passed.",
@@ -1008,7 +1008,7 @@ func TestProgressNoteSelection(t *testing.T) {
 // more Advance call away from done.
 func TestDriverLightDoneSetsFinalOutputAndSkipsToResult(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing", FinalMessage: "here is the complete deliverable"}},
 		workerText:     "draft1 tool-retry-narration here is the complete deliverable",
@@ -1051,7 +1051,7 @@ func TestDriverLightDoneSetsFinalOutputAndSkipsToResult(t *testing.T) {
 // after) still records something rather than an empty FinalOutput.
 func TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}, // FinalMessage left empty
 		workerText:     "the only text the runner produced",
@@ -1068,16 +1068,16 @@ func TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty(t *testing.T) {
 }
 
 // TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult drives
-// a flow=discover_generate mission (D-090, issue #459) end to end and
+// a flow=discover_build mission (D-090, issue #459) end to end and
 // confirms its exact phase/event sequence: discover -> generate ->
 // result -> done, with no plan_created and no review round of any
 // kind. The generate turn takes the same planless short-circuit as
-// light (mission.review_skipped, reason=discover_generate), never
+// light (mission.review_skipped, reason=discover_build), never
 // mission.review_verdict or mission.plan_created.
 func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Flow: FlowDiscoverGenerate, Phase: PhaseDiscover, Status: StatusIdle, MaxIterations: 8,
+		ID: "m1", Kind: "general", Flow: FlowDiscoverBuild, Phase: PhaseDiscover, Status: StatusIdle, MaxIterations: 8,
 	})
 	runner := &scriptedRunner{
 		discoverNotes:  []string{"found three relevant sources"},
@@ -1122,12 +1122,12 @@ func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T)
 	for _, forbidden := range mustNotContain {
 		for _, k := range kinds {
 			if k == forbidden {
-				t.Fatalf("events = %v, discover_generate must never emit %q", kinds, forbidden)
+				t.Fatalf("events = %v, discover_build must never emit %q", kinds, forbidden)
 			}
 		}
 	}
 
-	// The review_skipped event names discover_generate, not light.
+	// The review_skipped event names discover_build, not light.
 	for _, e := range events {
 		if e.Kind != "mission.review_skipped" {
 			continue
@@ -1135,21 +1135,21 @@ func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T)
 		var payload struct {
 			Reason string `json:"reason"`
 		}
-		if err := json.Unmarshal(e.Payload, &payload); err != nil || payload.Reason != "discover_generate" {
-			t.Fatalf("mission.review_skipped payload = %s, want reason=discover_generate", e.Payload)
+		if err := json.Unmarshal(e.Payload, &payload); err != nil || payload.Reason != "discover_build" {
+			t.Fatalf("mission.review_skipped payload = %s, want reason=discover_build", e.Payload)
 		}
 	}
 }
 
 // TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket confirms
 // discover's findings (Mission.DiscoverNotes) reach the generate turn's
-// WorkPacket for flow=discover_generate, the whole point of running
+// WorkPacket for flow=discover_build, the whole point of running
 // discover before a planless pass. Light: true is also asserted, same
 // worker path as a D-069 light mission.
 func TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Flow: FlowDiscoverGenerate, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Flow: FlowDiscoverBuild, Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		DiscoverNotes: "found three relevant sources",
 	})
 	runner := &scriptedRunner{
@@ -1165,7 +1165,7 @@ func TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket(t *testing.T)
 	}
 	p := runner.workerPackets[0]
 	if !p.Light {
-		t.Fatal("discover_generate worker packet Light = false, want true (same planless worker path as light)")
+		t.Fatal("discover_build worker packet Light = false, want true (same planless worker path as light)")
 	}
 	if p.DiscoverNotes != "found three relevant sources" {
 		t.Fatalf("packet DiscoverNotes = %q, want the mission's stored discover notes", p.DiscoverNotes)
@@ -1181,7 +1181,7 @@ func TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket(t *testing.T)
 func TestDriverPacketOmitsDiscoverNotesForNonPlanlessFlow(t *testing.T) {
 	store := newFakeStore()
 	m := Mission{
-		ID: "m1", Kind: "general", Flow: FlowFull, Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Flow: FlowFull, Phase: PhaseBuild, Status: StatusWorking,
 		DiscoverNotes: "found three relevant sources",
 		Plan:          Plan{Units: []PlanUnit{{Title: "write summary.md"}}},
 	}
@@ -1208,7 +1208,7 @@ func TestDriverPacketOmitsDiscoverNotesForNonPlanlessFlow(t *testing.T) {
 func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		Plan: Plan{Units: []PlanUnit{{Title: "write summary.md"}}},
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}}
@@ -1232,11 +1232,11 @@ func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
 // (artifacts + verify_cmd), same as an ordinary flow=full general
 // mission (TestDriverNonLightDoneStillGoesThroughReview). no_prove
 // keeps discover/plan and a real plan's units; it is not a planless
-// flow, unlike discover_generate.
+// flow, unlike discover_build.
 func TestDriverNoProveStillReviewsWithoutArtifacts(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Flow: FlowNoProve, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Flow: FlowNoProve, Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		Plan: Plan{Units: []PlanUnit{{Title: "write summary.md"}}},
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}}
@@ -1260,7 +1260,7 @@ func TestDriverNoProveStillReviewsWithoutArtifacts(t *testing.T) {
 func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Flow: FlowNoProve, Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Flow: FlowNoProve, Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(),
 		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
 	})
@@ -1272,7 +1272,7 @@ func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 	}
 
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || m.Plan.Units[0].Passes {
+	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
 		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if m.Iteration == 0 {
@@ -1282,7 +1282,7 @@ func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 
 func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("gateway unavailable")}
 	d := testDriver(store, runner)
 
@@ -1300,7 +1300,7 @@ func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
 // triggers the backoff brake, unlike a Runner-level failure.
 func TestDriverWorkerRetryDoesNotCountTowardBackoff(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "still working on it"}}}
 	d := testDriver(store, runner)
 
@@ -1350,7 +1350,7 @@ func TestDriverReworkOpensFindingsAndParksWhenExhausted(t *testing.T) {
 			t.Fatalf("review round %d: %v", round, err)
 		}
 		m, _ := store.Get(context.Background(), "m1")
-		if m.Phase != PhaseGenerate || m.Status != StatusIdle {
+		if m.Phase != PhaseBuild || m.Status != StatusIdle {
 			t.Fatalf("after rework %d: phase %q status %q, want generate/idle", round, m.Phase, m.Status)
 		}
 		if m.ReworkRounds != round {
@@ -1476,7 +1476,7 @@ func TestDriverReworkUntouchedEvent(t *testing.T) {
 			gitRun(t, wt, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-q", "--allow-empty", "-m", "base")
 			store := newFakeStore()
 			store.put("m1", Mission{
-				ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ReworkRounds: 1,
+				ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ReworkRounds: 1,
 				Workspace: root, Plan: Plan{Units: []PlanUnit{{Title: "u1"}}}, ReviewFindings: []Finding{finding},
 			})
 			runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
@@ -1525,7 +1525,7 @@ func TestDriverReworkUntouchedEvent(t *testing.T) {
 func TestDriverReplanOnFirstStall(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		Plan: Plan{Units: []PlanUnit{{Title: "u1"}}},
 	})
 	runner := &scriptedRunner{
@@ -1547,7 +1547,7 @@ func TestDriverReplanOnFirstStall(t *testing.T) {
 	if !m.ReplanUsed {
 		t.Fatal("ReplanUsed = false after a replan, want true")
 	}
-	if m.Phase != PhasePlan && m.Phase != PhaseGenerate {
+	if m.Phase != PhasePlan && m.Phase != PhaseBuild {
 		t.Fatalf("mission phase after replan = %q, want plan (or execute once the plan phase ran)", m.Phase)
 	}
 	found := false
@@ -1568,7 +1568,7 @@ func TestDriverReplanOnFirstStall(t *testing.T) {
 func TestDriverBudgetPause(t *testing.T) {
 	store := newFakeStore()
 	budget := 1.0
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 1.5}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -1590,7 +1590,7 @@ func TestDriverBudgetPause(t *testing.T) {
 func TestDriverBudgetPauseMixedCurrency(t *testing.T) {
 	store := newFakeStore()
 	budget := 100.0
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"EUR": 0.01}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -1612,7 +1612,7 @@ func TestDriverBudgetPauseMixedCurrency(t *testing.T) {
 func TestDriverBudgetConvertsOtherCurrencySpendWhenRateAvailable(t *testing.T) {
 	store := newFakeStore()
 	budget := 10.0
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	// 8 USD spend; 1 USD = 0.86 EUR -> 6.88 EUR, under the 10 EUR budget.
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 8}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
@@ -1635,7 +1635,7 @@ func TestDriverBudgetConvertsOtherCurrencySpendWhenRateAvailable(t *testing.T) {
 func TestDriverBudgetPausesWhenConvertedSpendReachesLimit(t *testing.T) {
 	store := newFakeStore()
 	budget := 5.0
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	// 8 USD spend; 1 USD = 0.86 EUR -> 6.88 EUR, over the 5 EUR budget.
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 8}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
@@ -1659,7 +1659,7 @@ func TestDriverBudgetPausesWhenConvertedSpendReachesLimit(t *testing.T) {
 func TestDriverBudgetPauseMixedCurrencyWhenRateMissing(t *testing.T) {
 	store := newFakeStore()
 	budget := 100.0
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 1}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -1795,7 +1795,7 @@ func (r *blockingRunner) DiscoverSession(ctx context.Context, m Mission) (string
 func TestDriverDriveIsSerializedPerMission(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}},
 	})
 	runner := &blockingRunner{
@@ -1850,7 +1850,7 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 		t.Fatalf("Advance: %v", err)
 	}
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate {
+	if m.Phase != PhaseBuild {
 		t.Fatalf("mission phase = %q, want execute (rework path), not stuck on an infra pause", m.Phase)
 	}
 	if m.PauseReason == PauseInfra {
@@ -1869,7 +1869,7 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 
 func TestDriverBlockedParksForInput(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "which env?"}}}
 	d := testDriver(store, runner)
 
@@ -1923,7 +1923,7 @@ func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: true})
+	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: true})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -1945,7 +1945,7 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: false}); err != nil {
+	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: false}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
@@ -1970,7 +1970,7 @@ func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 
 	id, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "general", Route: "route-x", AgentID: "briefing-agent",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: false,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: false,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -2005,7 +2005,7 @@ func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
 
 	if _, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "general", Route: "route-x", AutoApproveTools: false,
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -2026,7 +2026,7 @@ func TestDriverCreateRejectsInvalidMissionWhenValidateDepsWired(t *testing.T) {
 
 	_, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "coding", Route: "route-x", Flow: FlowLight, // light is general-only
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	if err == nil {
 		t.Fatal("Create with light+coding = nil error, want ErrInvalidMission")
@@ -2049,7 +2049,7 @@ func TestDriverCreateSkipsValidationWhenDepsUnset(t *testing.T) {
 
 	if _, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "coding", Flow: FlowLight, // would be rejected if validated
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	}); err != nil {
 		t.Fatalf("Create with no ValidateDeps wired: %v, want nil (validation skipped)", err)
 	}
@@ -2067,7 +2067,7 @@ func TestDriverSignalResumeRegrantsSession(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "test", Kind: "general", AgentID: "briefing-agent",
-		Phase: PhaseGenerate, Status: StatusWaitingForInput, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWaitingForInput, MaxIterations: 8,
 		AutoApproveTools: true, SessionID: "session-1", Workspace: "/workspace/missions/m1",
 	})
 	granter := &fakeGranter{}
@@ -2115,7 +2115,7 @@ func TestDriverSignalResumeGuardsMissingSessionID(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "test", Kind: "general",
-		Phase: PhaseGenerate, Status: StatusWaitingForInput, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWaitingForInput, MaxIterations: 8,
 		AutoApproveTools: true, SessionID: "",
 	})
 	granter := &fakeGranter{}
@@ -2150,7 +2150,7 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 	// SessionID, no Workspace/Worktree.
 	store.put("m1", Mission{
 		ID: "m1", Goal: "scheduled run", Kind: "general",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: true,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, AutoApproveTools: true,
 	})
 	granter := &fakeGranter{}
 	sessions := &fakeSessionCreator{}
@@ -2190,7 +2190,7 @@ func TestDriverProvisionUsesDestinationBranchPatternOverSettings(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
 		Destinations: []DestinationEntry{{DestinationID: "gh-dest-1"}},
-		Phase:        PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase:        PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	wsRoot := t.TempDir()
@@ -2220,7 +2220,7 @@ func TestDriverProvisionFallsBackToSettingsBranchPattern(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	wsRoot := t.TempDir()
@@ -2245,7 +2245,7 @@ func TestDriverProvisionFallsBackToDefaultBranchPattern(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	wsRoot := t.TempDir()
@@ -2269,7 +2269,7 @@ func TestDriverProvisionNamesMissionBeforeBranch(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Absolutely. Below is a handoff-ready fix for the login bug", Kind: "coding",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
@@ -2299,7 +2299,7 @@ func TestDriverProvisionFallsBackToGoalSlugWhenNamingFails(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
@@ -2345,7 +2345,7 @@ func TestDriverProvisionThreadsSigningKeyFromIdentityResolver(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
 		Sources: []SourceEntry{{Source: SourceKindGitHub, RepoURL: bare, ConnectorID: "conn1"}},
-		Phase:   PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase:   PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	wsRoot := t.TempDir()
@@ -2414,7 +2414,7 @@ func TestDriverProvisionsOnceUnderConcurrentAdvance(t *testing.T) {
 		defer close(createDone)
 		id, createErr = d.Create(context.Background(), Mission{
 			Goal: "Fix the login bug", Kind: "general", Route: "route-x",
-			Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+			Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 		})
 	}()
 
@@ -2517,7 +2517,7 @@ func TestDriverEffectiveCommitStylePrecedence(t *testing.T) {
 func TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, SessionID: "already-provisioned-session", Workspace: "/already/provisioned",
 	})
 	granter := &fakeGranter{}
@@ -2547,7 +2547,7 @@ func TestDriverAdvancePausesInsteadOfErroringOnProvisioningFailure(t *testing.T)
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Goal: "test", Kind: "coding",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	// wsRoot is a file, not a directory: Workspace.Provision's
 	// os.MkdirAll(workspace, ...) underneath it fails, giving
@@ -2592,7 +2592,7 @@ func TestDriverSkipsReviewWhenHarnessChecksPass(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}}}},
 	})
@@ -2613,7 +2613,7 @@ func TestDriverSkipsReviewWhenHarnessChecksPass(t *testing.T) {
 func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(),
 		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
 	})
@@ -2625,7 +2625,7 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	}
 
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || m.Plan.Units[0].Passes {
+	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
 		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if m.Iteration == 0 {
@@ -2645,7 +2645,7 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
 	})
@@ -2657,7 +2657,7 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 	}
 
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || m.Plan.Units[0].Passes {
+	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
 		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if u := m.Plan.Units[0]; u.VerifyCheck != "citations" || !strings.Contains(u.VerifyExcerpt, "citation check failed") {
@@ -2677,7 +2677,7 @@ func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Plan: Plan{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
 	})
@@ -2713,7 +2713,7 @@ func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "unit0", Artifacts: []string{"a.md"}},
@@ -2748,7 +2748,7 @@ func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 	}
 
 	m, _ = store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate {
+	if m.Phase != PhaseBuild {
 		t.Fatalf("mission phase = %q, want generate (regression routes back to work, not forward)", m.Phase)
 	}
 	u := m.Plan.Units[0]
@@ -2796,7 +2796,7 @@ func TestDriverBatchVerifyPassesLaterUnitInSameTurn(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "unit0", Artifacts: []string{"a.md"}, VerifyCmd: "grep -q content a.md"},
@@ -2830,7 +2830,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 	root, base := codingWorktree(t)
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Plan: Plan{Units: []PlanUnit{{Title: "add feature", VerifyCmd: "echo tests failed; exit 1"}}},
 	})
@@ -2846,7 +2846,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 		t.Fatalf("Advance: %v", err)
 	}
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || m.Iteration != 1 {
+	if m.Phase != PhaseBuild || m.Iteration != 1 {
 		t.Fatalf("mission = phase %s iteration %d, want another generate turn (worker_retry)", m.Phase, m.Iteration)
 	}
 	if len(runner.reviewCalls) != 0 {
@@ -2867,7 +2867,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 func TestDriverSkipsGenerateWhenAllUnitsHarnessPassed(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8,
+		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8,
 		Plan: Plan{Units: []PlanUnit{{Title: "unit0", HarnessPassed: true}}},
 	})
 	runner := &scriptedRunner{workerErr: errors.New("RunWorker must not be called")}
@@ -2899,7 +2899,7 @@ func TestDriverOpenFindingsStillRunGenerate(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8, Workspace: root,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8, Workspace: root,
 		Plan:           Plan{Units: []PlanUnit{{Title: "unit0", Artifacts: []string{"a.md"}, HarnessPassed: true}}},
 		ReviewFindings: []Finding{{ID: "F1", Title: "wrong tone", File: "a.md", Severity: SeverityBlocking, Status: FindingOpen, RoundOpened: 1}},
 		ReworkRounds:   1,
@@ -2932,7 +2932,7 @@ func TestDriverNoRegressionAdvancesNormally(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true, HarnessPassed: true},
@@ -3105,7 +3105,7 @@ func TestDriverCodingMissionsAlwaysReview(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Plan: Plan{Units: []PlanUnit{{Title: "write code", Artifacts: []string{"main.go"}}}},
 	})
@@ -3166,7 +3166,7 @@ func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
 	// ReplanUsed pre-set true: this test asserts the pause outcome
 	// specifically; the first-stall replan path is covered separately
 	// by TestDriverReplanOnFirstStall.
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 12, ReplanUsed: true})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 12, ReplanUsed: true})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
 		{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt", Forced: true},
 	}}
@@ -3191,7 +3191,7 @@ func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
 // worker_failed rounds toward backoff.
 func TestDriverModelFloorPausesImmediately(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: amazon.nova-lite-v1:0", ErrModelFloor)}
 	d := testDriver(store, runner)
 
@@ -3211,7 +3211,7 @@ func TestDriverModelFloorPausesImmediately(t *testing.T) {
 func TestDriverTurnEventCarriesRouteAndAgent(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Route: "mini", AgentID: "coder-agent",
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "complete"}}}
@@ -3255,7 +3255,7 @@ func TestDriverTurnEventCarriesRouteAndAgent(t *testing.T) {
 func TestDriverTurnEventCarriesServedProviderAndModel(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
 		{Outcome: "complete", Provider: "OpenAI Responses", Model: "gpt-5.3-codex"},
@@ -3289,7 +3289,7 @@ func TestDriverTurnEventCarriesServedProviderAndModel(t *testing.T) {
 // guess provider/model on the mission.turn payload.
 func TestDriverTurnEventOmitsProviderModelWhenNeverServed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("mission runner: provider stream error")}
 	d := testDriver(store, runner)
 
@@ -3444,7 +3444,7 @@ func (f *fakeSandboxRemover) calls() []string {
 func TestDriverAdvanceStopsOnTerminalStatus(t *testing.T) {
 	for _, status := range []Status{StatusDone, StatusError} {
 		store := newFakeStore()
-		store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: status, MaxIterations: 8})
+		store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: status, MaxIterations: 8})
 		runner := &scriptedRunner{}
 		d := testDriver(store, runner)
 
@@ -3466,7 +3466,7 @@ func TestDriverAdvanceStopsOnTerminalStatus(t *testing.T) {
 // recreated a container after cancel's own teardown ran.
 func TestDriverAdvanceDiscardsTurnOnConcurrentTerminal(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	store.applyTransitionErr = ErrTerminal
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	remover := &fakeSandboxRemover{}
@@ -3656,7 +3656,7 @@ func TestDriverReviewPacketScopedDiffAndGate(t *testing.T) {
 		t.Fatalf("criteria name main.go, so its contents must be attached: %v", packet.Artifacts)
 	}
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || len(OpenFindings(m.ReviewFindings)) != 1 || !m.ReviewFindings[0].Blocking() {
+	if m.Phase != PhaseBuild || len(OpenFindings(m.ReviewFindings)) != 1 || !m.ReviewFindings[0].Blocking() {
 		t.Fatalf("mission phase %q findings %+v, want generate with the blocking finding kept", m.Phase, m.ReviewFindings)
 	}
 	for _, ev := range store.events["m1"] {
@@ -3733,7 +3733,7 @@ func TestDriverFindingsOnlyReReview(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	head := strings.TrimSpace(gitRun(t, wt, "rev-parse", "HEAD"))
-	if m.Phase != PhaseGenerate || m.Plan.LastReviewCommit != head || m.Plan.LastReviewAt.IsZero() {
+	if m.Phase != PhaseBuild || m.Plan.LastReviewCommit != head || m.Plan.LastReviewAt.IsZero() {
 		t.Fatalf("after round 1: phase %q last_review_commit %q last_review_at %v, want generate with HEAD %s and a round time", m.Phase, m.Plan.LastReviewCommit, m.Plan.LastReviewAt, head)
 	}
 	full := runner.reviewCalls[0]
@@ -3844,7 +3844,7 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 	wt := filepath.Join(root, "wt")
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
+		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "write a", Artifacts: []string{"a.md"}, Scope: []string{"a.md"}, Criteria: []string{"a.md exists", "no other root files modified"}},
 			{Title: "write b", Artifacts: []string{"b.md"}, Scope: []string{"b.md"}, Criteria: []string{"b.md exists", "no other root files modified"}},
@@ -3862,7 +3862,7 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 		t.Fatalf("worker turn 1: %v", err)
 	}
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate || !m.Plan.Units[0].HarnessPassed || m.Plan.Units[0].Passes || m.Plan.Units[1].HarnessPassed {
+	if m.Phase != PhaseBuild || !m.Plan.Units[0].HarnessPassed || m.Plan.Units[0].Passes || m.Plan.Units[1].HarnessPassed {
 		t.Fatalf("after turn 1: phase %q units %+v, want generate with only unit 0 harness-passed", m.Phase, m.Plan.Units)
 	}
 	if len(runner.reviewCalls) != 0 || countEvents(store, "m1", "mission.generate_continued") != 1 {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -280,7 +280,7 @@ type scriptedRunner struct {
 	// caller that doesn't care about the raw text.
 	workerText string
 	// workerPackets records the WorkPacket RunWorker was called with,
-	// one entry per call: lets a test assert the generate phase's
+	// one entry per call: lets a test assert the build phase's
 	// packet actually carried what the driver built (e.g. DiscoverNotes
 	// for flow=discover_build, D-090).
 	workerPackets  []WorkPacket
@@ -427,7 +427,7 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	}
 	d := testDriver(store, runner)
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseDone || m.Status != StatusDone {
@@ -739,7 +739,7 @@ func TestDriverPlanCreatedEventOmitsEmptyAssumptions(t *testing.T) {
 // TestDriverPlanApprovalGateParks confirms D-087 (issue #456): a plan
 // phase turn on a mission with AutoApprovePlan=false parks on
 // PauseApproval with the plan already stored, instead of advancing to
-// generate; no worker turn runs (scriptedRunner has no workerVerdicts
+// build; no worker turn runs (scriptedRunner has no workerVerdicts
 // scripted, so a stray runExecute call would fail the test via an
 // unscripted-call panic/error).
 func TestDriverPlanApprovalGateParks(t *testing.T) {
@@ -761,10 +761,10 @@ func TestDriverPlanApprovalGateParks(t *testing.T) {
 }
 
 // TestDriverDecidePlanApprove confirms DecidePlan's approve verb
-// unparks a PauseApproval mission straight to generate. Scripts a
+// unparks a PauseApproval mission straight to build. Scripts a
 // workerVerdicts entry (blocked) so the background Drive goroutine
 // DecidePlan kicks off, which continues into the now-unparked
-// generate phase, settles cleanly instead of panicking on an
+// build phase, settles cleanly instead of panicking on an
 // unscripted RunWorker call once it runs past this assertion.
 func TestDriverDecidePlanApprove(t *testing.T) {
 	store := newFakeStore()
@@ -787,7 +787,7 @@ func TestDriverDecidePlanApprove(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 	if got.Phase != PhaseBuild || got.Status != StatusIdle || got.PauseReason != "" {
-		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", got.Phase, got.Status, got.PauseReason)
+		t.Fatalf("mission after approve = %s/%s/%s, want build/idle/<none>", got.Phase, got.Status, got.PauseReason)
 	}
 }
 
@@ -806,7 +806,7 @@ func TestDriverDecidePlanReplanRejectedWhenNotParked(t *testing.T) {
 	}
 	got := store.missions["m1"]
 	if got.Phase != PhaseBuild || got.Status != StatusWorking {
-		t.Fatalf("mission after rejected decide = %s/%s, want untouched generate/working", got.Phase, got.Status)
+		t.Fatalf("mission after rejected decide = %s/%s, want untouched build/working", got.Phase, got.Status)
 	}
 }
 
@@ -1069,9 +1069,9 @@ func TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty(t *testing.T) {
 
 // TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult drives
 // a flow=discover_build mission (D-090, issue #459) end to end and
-// confirms its exact phase/event sequence: discover -> generate ->
+// confirms its exact phase/event sequence: discover -> build ->
 // result -> done, with no plan_created and no review round of any
-// kind. The generate turn takes the same planless short-circuit as
+// kind. The build turn takes the same planless short-circuit as
 // light (mission.review_skipped, reason=discover_build), never
 // mission.review_verdict or mission.plan_created.
 func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T) {
@@ -1085,8 +1085,8 @@ func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T)
 	}
 	d := testDriver(store, runner)
 
-	// discover -> generate (phase_complete routes straight to generate,
-	// never plan) -> generate's own turn (planless short-circuit to
+	// discover -> build (phase_complete routes straight to build,
+	// never plan) -> build's own turn (planless short-circuit to
 	// result) -> result's own deterministic step -> done.
 	driveN(t, d, "m1", 4)
 
@@ -1142,7 +1142,7 @@ func TestDriverDiscoverGenerateVisitsExactlyDiscoverGenerateResult(t *testing.T)
 }
 
 // TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket confirms
-// discover's findings (Mission.DiscoverNotes) reach the generate turn's
+// discover's findings (Mission.DiscoverNotes) reach the build turn's
 // WorkPacket for flow=discover_build, the whole point of running
 // discover before a planless pass. Light: true is also asserted, same
 // worker path as a D-069 light mission.
@@ -1176,7 +1176,7 @@ func TestDriverDiscoverGenerateDiscoverNotesReachThePlanlessPacket(t *testing.T)
 // flow=full mission's packet never carries DiscoverNotes, even when the
 // mission has them stored (every mission that visits discover does):
 // WorkPacket.DiscoverNotes is meant for a planless worker turn only
-// (D-090), and a full-flow generate turn gets its own Plan block
+// (D-090), and a full-flow build turn gets its own Plan block
 // instead.
 func TestDriverPacketOmitsDiscoverNotesForNonPlanlessFlow(t *testing.T) {
 	store := newFakeStore()
@@ -1254,7 +1254,7 @@ func TestDriverNoProveStillReviewsWithoutArtifacts(t *testing.T) {
 // TestDriverNoProveStillChecksArtifacts confirms flow=no_prove skips
 // only the LLM reviewer, never the harness's own CheckArtifacts: a
 // worker claiming done without writing its declared artifact must
-// still be sent back to generate, exactly as TestDriverArtifactCheck-
+// still be sent back to build, exactly as TestDriverArtifactCheck-
 // BlocksTautologicalDone asserts for flow=full. passes flips only on
 // harness evidence, regardless of flow.
 func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
@@ -1273,7 +1273,7 @@ func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
-		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
+		t.Fatalf("mission = phase %s passes %v, want back in build with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if m.Iteration == 0 {
 		t.Fatal("a failed artifact check must cost an iteration under no_prove too")
@@ -1351,7 +1351,7 @@ func TestDriverReworkOpensFindingsAndParksWhenExhausted(t *testing.T) {
 		}
 		m, _ := store.Get(context.Background(), "m1")
 		if m.Phase != PhaseBuild || m.Status != StatusIdle {
-			t.Fatalf("after rework %d: phase %q status %q, want generate/idle", round, m.Phase, m.Status)
+			t.Fatalf("after rework %d: phase %q status %q, want build/idle", round, m.Phase, m.Status)
 		}
 		if m.ReworkRounds != round {
 			t.Fatalf("after rework %d: ReworkRounds = %d", round, m.ReworkRounds)
@@ -2626,7 +2626,7 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
-		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
+		t.Fatalf("mission = phase %s passes %v, want back in build with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if m.Iteration == 0 {
 		t.Fatal("a failed artifact check must cost an iteration")
@@ -2658,7 +2658,7 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || m.Plan.Units[0].Passes {
-		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
+		t.Fatalf("mission = phase %s passes %v, want back in build with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
 	if u := m.Plan.Units[0]; u.VerifyCheck != "citations" || !strings.Contains(u.VerifyExcerpt, "citation check failed") {
 		t.Fatalf("unit = %+v, want the citation failure recorded on it for the next worker packet", u)
@@ -2689,7 +2689,7 @@ func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
 	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
 	d.retryDelayFn = func(int) time.Duration { return 0 }
 
-	driveN(t, d, "m1", 3) // generate -> prove -> result -> done
+	driveN(t, d, "m1", 3) // build -> prove -> result -> done
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseDone || m.Status != StatusDone {
@@ -2703,7 +2703,7 @@ func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
 // batch pass after unit 1's turn must catch this, flip unit 0 back to
 // pending (Passes and HarnessPassed both false, Regressed set, the
 // excerpt attached), append mission.unit_regressed, route back to
-// generate (worker_retry) instead of approving unit 1, and name the
+// build (worker_retry) instead of approving unit 1, and name the
 // regression in the next worker packet's current-unit block.
 func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 	root := t.TempDir()
@@ -2749,7 +2749,7 @@ func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 
 	m, _ = store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild {
-		t.Fatalf("mission phase = %q, want generate (regression routes back to work, not forward)", m.Phase)
+		t.Fatalf("mission phase = %q, want build (regression routes back to work, not forward)", m.Phase)
 	}
 	u := m.Plan.Units[0]
 	if u.Passes || u.HarnessPassed || !u.Regressed || u.VerifyCheck != "artifacts" || !strings.Contains(u.VerifyExcerpt, "a.md: not found") {
@@ -2806,7 +2806,7 @@ func TestDriverBatchVerifyPassesLaterUnitInSameTurn(t *testing.T) {
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote both"}}}
 	d := testDriver(store, runner)
 
-	driveN(t, d, "m1", 3) // generate -> result -> done
+	driveN(t, d, "m1", 3) // build -> result -> done
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseDone {
@@ -2847,7 +2847,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || m.Iteration != 1 {
-		t.Fatalf("mission = phase %s iteration %d, want another generate turn (worker_retry)", m.Phase, m.Iteration)
+		t.Fatalf("mission = phase %s iteration %d, want another build turn (worker_retry)", m.Phase, m.Iteration)
 	}
 	if len(runner.reviewCalls) != 0 {
 		t.Fatal("a review round ran on work the harness had already failed")
@@ -2861,7 +2861,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 }
 
 // TestDriverSkipsGenerateWhenAllUnitsHarnessPassed confirms the D-094
-// short-circuit: a mission entering generate with every unit
+// short-circuit: a mission entering build with every unit
 // harness-verified and no finding open never runs a worker turn; it
 // records mission.generate_skipped and moves to prove.
 func TestDriverSkipsGenerateWhenAllUnitsHarnessPassed(t *testing.T) {
@@ -3615,7 +3615,7 @@ func TestDriverLegacyPlanReviewsAgainstGoal(t *testing.T) {
 // worktree: the packet's diff is restricted to the reviewed unit's
 // scope while the stat covers every changed file, and a blocking
 // finding naming a changed file outside the scope, with evidence,
-// survives the gate and sends the mission back to generate.
+// survives the gate and sends the mission back to build.
 func TestDriverReviewPacketScopedDiffAndGate(t *testing.T) {
 	root, base := codingWorktree(t)
 	wt := filepath.Join(root, "wt")
@@ -3657,7 +3657,7 @@ func TestDriverReviewPacketScopedDiffAndGate(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || len(OpenFindings(m.ReviewFindings)) != 1 || !m.ReviewFindings[0].Blocking() {
-		t.Fatalf("mission phase %q findings %+v, want generate with the blocking finding kept", m.Phase, m.ReviewFindings)
+		t.Fatalf("mission phase %q findings %+v, want build with the blocking finding kept", m.Phase, m.ReviewFindings)
 	}
 	for _, ev := range store.events["m1"] {
 		if ev.Kind == "mission.finding_demoted" {
@@ -3734,7 +3734,7 @@ func TestDriverFindingsOnlyReReview(t *testing.T) {
 	m, _ := store.Get(context.Background(), "m1")
 	head := strings.TrimSpace(gitRun(t, wt, "rev-parse", "HEAD"))
 	if m.Phase != PhaseBuild || m.Plan.LastReviewCommit != head || m.Plan.LastReviewAt.IsZero() {
-		t.Fatalf("after round 1: phase %q last_review_commit %q last_review_at %v, want generate with HEAD %s and a round time", m.Phase, m.Plan.LastReviewCommit, m.Plan.LastReviewAt, head)
+		t.Fatalf("after round 1: phase %q last_review_commit %q last_review_at %v, want build with HEAD %s and a round time", m.Phase, m.Plan.LastReviewCommit, m.Plan.LastReviewAt, head)
 	}
 	full := runner.reviewCalls[0]
 	if full.FindingsOnly || full.Diff == "" || full.DiffStat == "" {
@@ -3863,7 +3863,7 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseBuild || !m.Plan.Units[0].HarnessPassed || m.Plan.Units[0].Passes || m.Plan.Units[1].HarnessPassed {
-		t.Fatalf("after turn 1: phase %q units %+v, want generate with only unit 0 harness-passed", m.Phase, m.Plan.Units)
+		t.Fatalf("after turn 1: phase %q units %+v, want build with only unit 0 harness-passed", m.Phase, m.Plan.Units)
 	}
 	if len(runner.reviewCalls) != 0 || countEvents(store, "m1", "mission.generate_continued") != 1 {
 		t.Fatalf("after turn 1: %d reviews, %d generate_continued events, want 0 and 1", len(runner.reviewCalls), countEvents(store, "m1", "mission.generate_continued"))

--- a/internal/brain/missions/followup_test.go
+++ b/internal/brain/missions/followup_test.go
@@ -19,7 +19,7 @@ func followUpBlockedRunner() *scriptedRunner {
 // mid-flight is refused before any child mission is created.
 func TestCreateFollowUpRejectsNonTerminalParent(t *testing.T) {
 	store := newFakeStore()
-	store.put("parent", Mission{ID: "parent", Goal: "do the thing", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking})
+	store.put("parent", Mission{ID: "parent", Goal: "do the thing", Kind: "general", Phase: PhaseBuild, Status: StatusWorking})
 	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
 
 	_, err := d.CreateFollowUp(context.Background(), "parent", "do more")

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -27,7 +27,7 @@ func TestOutcomeDigest(t *testing.T) {
 				Plan:          Plan{Units: []PlanUnit{{Title: "write widget.go", Passes: true}}},
 			},
 			events: []Event{
-				{Kind: "mission.turn", Payload: json.RawMessage(`{"phase":"generate","duration_ms":500}`)},
+				{Kind: "mission.turn", Payload: json.RawMessage(`{"phase":"build","duration_ms":500}`)},
 				{Kind: "mission.review_verdict", Payload: json.RawMessage(`{"decision":"approved","findings":"looks good"}`)},
 			},
 			terminal: PhaseDone,
@@ -189,7 +189,7 @@ func TestDriverExtractsMemoryOnDone(t *testing.T) {
 
 func TestDriverExtractsMemoryOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, SessionID: "sess-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, SessionID: "sess-1"})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -38,7 +38,7 @@ func TestOutcomeDigest(t *testing.T) {
 				"review verdict: approved", "review findings: looks good",
 				"terminal state: done",
 			},
-			wantExcludes: []string{"duration_ms", "\"phase\":\"generate\""},
+			wantExcludes: []string{"duration_ms", "\"phase\":\"build\""},
 		},
 		{
 			name: "review skipped",
@@ -177,7 +177,7 @@ func TestDriverExtractsMemoryOnDone(t *testing.T) {
 	rec := &recordingExtract{}
 	d.SetMemoryExtract(rec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	waitForCalls(t, rec, 1)
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -1,6 +1,6 @@
 // Package missions implements Phase 1 of the mission engine: an
 // agent-driven, long-running unit of work that walks a fixed phase
-// pipeline (discover -> plan -> generate -> prove -> result ->
+// pipeline (discover -> plan -> build -> prove -> result ->
 // done|failed) under a pure state machine, executed by native
 // (in-process) model turns via loop.Agent. Delegated CLI executors
 // (claude/codex subprocess shelling) are explicitly out of scope for
@@ -114,7 +114,7 @@ type Mission struct {
 	// Flow is the phase set this mission runs (D-090, issue #459),
 	// chosen once at create time, snapshotted here, never model-
 	// mutable. FlowLight (D-069, general kind only) skips discover/plan/
-	// prove entirely: born in phase=generate, one bare worker turn, the
+	// prove entirely: born in phase=build, one bare worker turn, the
 	// final worker message is the deliverable, then result/done. Flow is
 	// the single source of truth (issue #479 dropped the redundant light
 	// column); code that means "light mission" tests Flow == FlowLight.
@@ -173,7 +173,7 @@ type Mission struct {
 	// regardless of any grant, so this cannot weaken that guarantee.
 	AutoApproveTools bool `json:"auto_approve_tools"`
 	// AutoApprovePlan, when true (the default), advances straight from
-	// plan to generate the moment a plan lands, exactly as every
+	// plan to build the moment a plan lands, exactly as every
 	// mission has always worked. false parks the mission on
 	// PauseApproval instead (D-087, issue #456), waiting for an
 	// operator to approve/replan/rediscover. Snapshotted at create

--- a/internal/brain/missions/onterminal_test.go
+++ b/internal/brain/missions/onterminal_test.go
@@ -54,7 +54,7 @@ func TestDriverFiresOnTerminalForWorkflowMission(t *testing.T) {
 	rec := &recordingOnTerminal{}
 	d.SetOnTerminal(rec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	waitForOnTerminalCalls(t, rec, 1)
 	if rec.calls[0] != "m1" {

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -61,7 +61,7 @@ type WorkPacket struct {
 	// resolver is unwired. Native workers only: a delegated CLI has no
 	// load_skill tool, so RenderForDelegated never includes it.
 	SkillsIndex string
-	// Light marks a mission that runs generate planless (D-069's
+	// Light marks a mission that runs build planless (D-069's
 	// original light behavior, plus flow=discover_generate, D-090,
 	// issue #459): Render uses lightSystemPreamble instead of
 	// nativeSystemPreamble, and Plan is always empty so the Plan block
@@ -69,7 +69,7 @@ type WorkPacket struct {
 	Light bool
 	// DiscoverNotes carries the discover phase's findings into a planless
 	// worker turn (D-090): only ever set for flow=discover_generate,
-	// which runs discover before its planless generate pass; a D-069
+	// which runs discover before its planless build pass; a D-069
 	// light mission never visits discover, so this stays empty for it.
 	// Rendered the same "Discovery findings:" way PlanSession's own
 	// prompt renders it (runner.go), kept cache-stable since notes are

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -62,13 +62,13 @@ type WorkPacket struct {
 	// load_skill tool, so RenderForDelegated never includes it.
 	SkillsIndex string
 	// Light marks a mission that runs build planless (D-069's
-	// original light behavior, plus flow=discover_generate, D-090,
+	// original light behavior, plus flow=discover_build, D-090,
 	// issue #459): Render uses lightSystemPreamble instead of
 	// nativeSystemPreamble, and Plan is always empty so the Plan block
 	// never renders.
 	Light bool
 	// DiscoverNotes carries the discover phase's findings into a planless
-	// worker turn (D-090): only ever set for flow=discover_generate,
+	// worker turn (D-090): only ever set for flow=discover_build,
 	// which runs discover before its planless build pass; a D-069
 	// light mission never visits discover, so this stays empty for it.
 	// Rendered the same "Discovery findings:" way PlanSession's own

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -309,7 +309,7 @@ func TestWorkPacketRenderNeutralizesParentContext(t *testing.T) {
 }
 
 // TestWorkPacketRenderIncludesDiscoverNotes confirms discover's
-// findings reach a planless flow=discover_generate worker turn's
+// findings reach a planless flow=discover_build worker turn's
 // prompt (D-090, issue #459), the whole point of running discover
 // before that pass.
 func TestWorkPacketRenderIncludesDiscoverNotes(t *testing.T) {

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -13,36 +13,49 @@ const (
 type Flow string
 
 const (
-	// FlowFull is discover->plan->generate->prove->result, today's
+	// FlowFull is discover->plan->build->prove->result, today's
 	// default and the only flow that existed before #459.
 	FlowFull Flow = "full"
-	// FlowDiscoverGenerate is a true planless flow: discover->generate
+	// FlowDiscoverBuild is a true planless flow: discover->build
 	// ->result, no plan, no review. Discover runs as normal (its
-	// findings land in Mission.DiscoverNotes); generate's own turn then
+	// findings land in Mission.DiscoverNotes); build's own turn then
 	// runs the exact D-069 light worker path (Mission.RunsPlanless):
 	// WorkPacket.Light rendering, no plan units, the worker's final
 	// message (mission_status's final_output) is the deliverable. The
 	// only difference from a plain light mission is that this one runs
 	// discover first, and its discover notes reach the planless prompt
 	// via WorkPacket.DiscoverNotes.
-	FlowDiscoverGenerate Flow = "discover_generate"
-	// FlowNoProve is discover->plan->generate->result: skips only the
+	FlowDiscoverBuild Flow = "discover_build"
+	// FlowNoProve is discover->plan->build->result: skips only the
 	// LLM reviewer round. CheckArtifacts (harness evidence) still runs
-	// on generate's exit for any unit declaring artifacts, same as
+	// on build's exit for any unit declaring artifacts, same as
 	// today's review_skipped path for non-coding missions.
 	FlowNoProve Flow = "no_prove"
-	// FlowLight is generate->result (D-069): existing light behavior.
+	// FlowLight is build->result (D-069): existing light behavior.
 	FlowLight Flow = "light"
 )
 
 // ValidFlow reports whether raw names one of the four defined flows.
 func ValidFlow(raw string) bool {
 	switch Flow(raw) {
-	case FlowFull, FlowDiscoverGenerate, FlowNoProve, FlowLight:
+	case FlowFull, FlowDiscoverBuild, FlowNoProve, FlowLight:
 		return true
 	default:
 		return false
 	}
+}
+
+// parseFlow maps a stored flow string onto a Flow, translating the
+// pre-#611 discover_generate spelling onto FlowDiscoverBuild. Rows a
+// data migration hasn't touched yet still carry the old value; drop
+// this alias once scripts/pending-alters.md has run everywhere and the
+// first stable release ships. An unknown value passes through
+// unchanged, leaving validate.go's ValidFlow check to reject it.
+func parseFlow(raw string) Flow {
+	if raw == "discover_generate" {
+		return FlowDiscoverBuild
+	}
+	return Flow(raw)
 }
 
 // missionPolicy derives every kind/light-dependent behavior once
@@ -53,7 +66,7 @@ type missionPolicy struct {
 	alwaysReview    bool // LLM review round can never be skipped
 	checksCitations bool // CheckCitations on verify
 	canDelegate     bool // harness (delegated CLI executor) allowed
-	skipsPlanning   bool // born in generate; no discover/plan/prove
+	skipsPlanning   bool // born in build; no discover/plan/prove
 	canPush         bool // on_complete push/push_pr allowed
 }
 
@@ -63,7 +76,7 @@ type missionPolicy struct {
 // general-shaped policy, since skipping the LLM reviewer is the whole
 // point of choosing it (CheckArtifacts in verifier.go still runs via
 // routeVerified either way). flow=discover_generate does NOT need this
-// override: it never reaches routeVerified at all, its generate turn
+// override: it never reaches routeVerified at all, its build turn
 // takes the same planless short-circuit as flow=light
 // (Mission.RunsPlanless), which never consults alwaysReview. Coding
 // stays alwaysReview true regardless of flow (ValidateCreate rejects
@@ -118,28 +131,28 @@ func missionPolicyFor(m Mission) missionPolicy {
 	return policyFor(m.Kind, m.Flow)
 }
 
-// RunsPlanless reports whether m's generate phase runs the D-069
+// RunsPlanless reports whether m's build phase runs the D-069
 // light worker path: no plan, no artifact check, the worker's final
 // message (mission_status's final_output) is the deliverable.
-// FlowDiscoverGenerate (D-090, issue #459) shares this exact worker
+// FlowDiscoverBuild (D-090, issue #459) shares this exact worker
 // behavior with FlowLight, the only difference being it runs discover
 // first; unlike FlowLight (missionPolicy.skipsPlanning), it is NOT
 // used by initialPhase: a discover_generate mission is still born in
-// PhaseDiscover, only generate itself runs planless. Exported: read
+// PhaseDiscover, only build itself runs planless. Exported: read
 // outside this package by destinations.renderPayload, which needs the
 // same "final_output IS the result" gate memory.go's digest uses.
 func (m Mission) RunsPlanless() bool {
-	return m.Flow == FlowLight || m.Flow == FlowDiscoverGenerate
+	return m.Flow == FlowLight || m.Flow == FlowDiscoverBuild
 }
 
 // initialPhase is the phase a newly created mission row starts in:
-// PhaseGenerate for a flow=light mission (D-069, skips discover/plan),
+// PhaseBuild for a flow=light mission (D-069, skips discover/plan),
 // PhaseDiscover otherwise. Shared by store.go's Create and
 // scheduler.go's createFromTemplate, which both used to duplicate
 // this check inline.
 func initialPhase(kind string, flow Flow) Phase {
 	if policyFor(kind, flow).skipsPlanning {
-		return PhaseGenerate
+		return PhaseBuild
 	}
 	return PhaseDiscover
 }

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -75,7 +75,7 @@ type missionPolicy struct {
 // skipsPlanning; flow=no_prove forces alwaysReview false on a
 // general-shaped policy, since skipping the LLM reviewer is the whole
 // point of choosing it (CheckArtifacts in verifier.go still runs via
-// routeVerified either way). flow=discover_generate does NOT need this
+// routeVerified either way). flow=discover_build does NOT need this
 // override: it never reaches routeVerified at all, its build turn
 // takes the same planless short-circuit as flow=light
 // (Mission.RunsPlanless), which never consults alwaysReview. Coding
@@ -137,7 +137,7 @@ func missionPolicyFor(m Mission) missionPolicy {
 // FlowDiscoverBuild (D-090, issue #459) shares this exact worker
 // behavior with FlowLight, the only difference being it runs discover
 // first; unlike FlowLight (missionPolicy.skipsPlanning), it is NOT
-// used by initialPhase: a discover_generate mission is still born in
+// used by initialPhase: a discover_build mission is still born in
 // PhaseDiscover, only build itself runs planless. Exported: read
 // outside this package by destinations.renderPayload, which needs the
 // same "final_output IS the result" gate memory.go's digest uses.

--- a/internal/brain/missions/policy_test.go
+++ b/internal/brain/missions/policy_test.go
@@ -50,7 +50,7 @@ func TestPolicyFor(t *testing.T) {
 			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 		{
-			// discover_build never reaches routeVerified (its generate
+			// discover_build never reaches routeVerified (its build
 			// turn takes the planless short-circuit instead), so policyFor
 			// does not special-case it: this is the plain general policy,
 			// same as flow=full; alwaysReview is false here only because
@@ -88,7 +88,7 @@ func TestInitialPhase(t *testing.T) {
 	}{
 		{name: "coding starts at discover", kind: KindCoding, flow: FlowFull, want: PhaseDiscover},
 		{name: "general starts at discover", kind: KindGeneral, flow: FlowFull, want: PhaseDiscover},
-		{name: "light general starts at generate", kind: KindGeneral, flow: FlowLight, want: PhaseBuild},
+		{name: "light general starts at build", kind: KindGeneral, flow: FlowLight, want: PhaseBuild},
 		{name: "unknown kind starts at discover even if light requested", kind: "bogus", flow: FlowLight, want: PhaseDiscover},
 	}
 	for _, tc := range cases {

--- a/internal/brain/missions/policy_test.go
+++ b/internal/brain/missions/policy_test.go
@@ -50,13 +50,13 @@ func TestPolicyFor(t *testing.T) {
 			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 		{
-			// discover_generate never reaches routeVerified (its generate
+			// discover_build never reaches routeVerified (its generate
 			// turn takes the planless short-circuit instead), so policyFor
 			// does not special-case it: this is the plain general policy,
 			// same as flow=full; alwaysReview is false here only because
 			// that is KindGeneral's own baseline, not a flow override.
-			name: "general discover_generate: policyFor has no special case",
-			kind: KindGeneral, flow: FlowDiscoverGenerate,
+			name: "general discover_build: policyFor has no special case",
+			kind: KindGeneral, flow: FlowDiscoverBuild,
 			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 	}
@@ -88,7 +88,7 @@ func TestInitialPhase(t *testing.T) {
 	}{
 		{name: "coding starts at discover", kind: KindCoding, flow: FlowFull, want: PhaseDiscover},
 		{name: "general starts at discover", kind: KindGeneral, flow: FlowFull, want: PhaseDiscover},
-		{name: "light general starts at generate", kind: KindGeneral, flow: FlowLight, want: PhaseGenerate},
+		{name: "light general starts at generate", kind: KindGeneral, flow: FlowLight, want: PhaseBuild},
 		{name: "unknown kind starts at discover even if light requested", kind: "bogus", flow: FlowLight, want: PhaseDiscover},
 	}
 	for _, tc := range cases {

--- a/internal/brain/missions/promote_kb_test.go
+++ b/internal/brain/missions/promote_kb_test.go
@@ -62,7 +62,7 @@ func TestDriverPromotesToKBOnDone(t *testing.T) {
 
 func TestDriverSkipsPromoteKBOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}

--- a/internal/brain/missions/promote_kb_test.go
+++ b/internal/brain/missions/promote_kb_test.go
@@ -50,7 +50,7 @@ func TestDriverPromotesToKBOnDone(t *testing.T) {
 	rec := &recordingPromoteKB{}
 	d.SetPromoteKB(rec.fn())
 
-	driveN(t, d, "m1", 5) // discover -> plan -> generate -> prove -> result -> done
+	driveN(t, d, "m1", 5) // discover -> plan -> build -> prove -> result -> done
 
 	if got := rec.count(); got != 1 {
 		t.Fatalf("promote kb calls = %d, want 1", got)

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -566,7 +566,7 @@ func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 // mission's own directory, routed through the mission's sandbox
 // container: shared by missionTools (worker/reviewer, paired with
 // write_file) and DiscoverSession (shell only, read-only exploration:
-// the generate phase does the actual work, so discover never gets
+// the build phase does the actual work, so discover never gets
 // write_file). Returns nil when the mission has no work root yet
 // (WorkRoot's Workspace/Worktree both empty).
 func (r *nativeRunner) missionShell(m Mission) *tools.Tool {
@@ -1005,14 +1005,14 @@ func reviewRoute(m Mission) string {
 
 // phaseRoute reports the route a mission's just-run phase actually
 // used, mirroring the same helper each phase's request builder calls
-// (discover/plan -> oversightRoute, generate -> workerRoute, prove ->
+// (discover/plan -> oversightRoute, build -> workerRoute, prove ->
 // reviewRoute). Used only for the mission.turn event's telemetry
 // (issue #473); result runs no LLM turn, so it reports "".
 func phaseRoute(m Mission) string {
 	switch m.Phase {
 	case PhaseDiscover, PhasePlan:
 		return oversightRoute(m)
-	case PhaseGenerate:
+	case PhaseBuild:
 		return workerRoute(m)
 	case PhaseProve:
 		return reviewRoute(m)
@@ -1072,7 +1072,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		extra = append(extra, t)
 	}
 	extra = append(extra, r.connectorReadTools(ctx, m)...)
-	if t := r.askUserTool(m, PhaseGenerate); t != nil {
+	if t := r.askUserTool(m, PhaseBuild); t != nil {
 		extra = append(extra, t)
 	}
 	req := loop.Request{
@@ -1094,7 +1094,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		Steering: r.steeringFor(m.ID, packet.Progress),
 	}
 
-	res, err := r.runTurn(ctx, req, missionStatusToolName, PhaseGenerate)
+	res, err := r.runTurn(ctx, req, missionStatusToolName, PhaseBuild)
 	text, seenURLs := res.text, res.seenURLs
 	if err != nil {
 		return WorkerVerdict{}, text, err
@@ -1115,7 +1115,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one mission_status tool call: done, retry, or blocked."},
 	)
-	recoverRes, err := r.runTurn(ctx, recoverReq, missionStatusToolName, PhaseGenerate)
+	recoverRes, err := r.runTurn(ctx, recoverReq, missionStatusToolName, PhaseBuild)
 	recoverText := recoverRes.text
 	seenURLs = append(seenURLs, recoverRes.seenURLs...)
 	if err != nil {
@@ -1198,7 +1198,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // failure. provider/model (issue #507) are who served the turn that
 // produced the returned notes; empty when the turn errored.
 func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, servedProvider, servedModel string, err error) {
-	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the generate phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
+	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the build phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if pc := m.ParentContext(); pc != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(pc)
@@ -1313,7 +1313,7 @@ func (r *nativeRunner) discoverEnvironmentNudge(m Mission) string {
 // than base (issue #495); the driver recreates the sandbox container
 // afterwards. A stack the sandbox has no image for is prefixed onto
 // the findings so the planner budgets a bootstrap unit instead of
-// finding out at generate time.
+// finding out at build time.
 func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, report discoverReport) string {
 	if m.Kind == KindCoding && m.Environment == "" && r.environmentSink != nil {
 		env := strings.ToLower(strings.TrimSpace(report.Environment))
@@ -1600,7 +1600,7 @@ func renderReviewContent(p ReviewPacket) string {
 // criteria, scope, verify_cmd's POSIX-shell/no-substitution/content-
 // check rules, workspace-relative paths, the infeasible escape hatch
 // (D-077), and assumptions. Kept as one shared string so
-// generate/prove's unit parsing (parsePlan) never has to distinguish
+// build/prove's unit parsing (parsePlan) never has to distinguish
 // which mode produced a plan.
 const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. The harness commits each unit's files itself after the worker turn, so criteria and verify_cmd must judge file CONTENT only, never git status, staging, untracked, or uncommitted state. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
 
@@ -1609,7 +1609,7 @@ const planUnitShapeRules = " Every unit must list at least one artifact, the wor
 // true (D-102, issue #496), transcribe mode -- the goal already
 // contains the operator's own plan, so the model converts it into
 // units faithfully instead of redesigning it. Either way the unit
-// shape (planUnitShapeRules) is identical, so generate/prove need no
+// shape (planUnitShapeRules) is identical, so build/prove need no
 // changes: the same D-077 infeasible and D-095 criteria checks apply
 // to a transcribed plan as to a designed one.
 func planSystemPrompt(hasPlan bool) string {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -821,7 +821,7 @@ func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 // goal already carries the plan, must not redesign or add scope)
 // instead of the design-from-scratch opening, while the shared
 // unit-shape rules (artifacts/criteria/verify_cmd/infeasible) still
-// apply either way so generate/prove need no changes.
+// apply either way so build/prove need no changes.
 func TestPlanSessionTranscribeMode(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
@@ -1658,7 +1658,7 @@ func TestPhaseRoute(t *testing.T) {
 	}{
 		{"discover uses oversight route", Mission{Phase: PhaseDiscover, Route: "mini", PlanRoute: "strong"}, "strong"},
 		{"plan uses oversight route", Mission{Phase: PhasePlan, Route: "mini", PlanRoute: "strong"}, "strong"},
-		{"generate uses worker route", Mission{Phase: PhaseBuild, Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
+		{"build uses worker route", Mission{Phase: PhaseBuild, Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
 		{"prove uses review route", Mission{Phase: PhaseProve, Route: "mini", ReviewRoute: "reviewer"}, "reviewer"},
 		{"result runs no LLM turn", Mission{Phase: PhaseResult, Route: "mini"}, ""},
 	}
@@ -2014,7 +2014,7 @@ func TestRunWorkerReportsPermissionDenied(t *testing.T) {
 // TestRunWorkerEmitsToolCallTraceInOrder covers issue #369's acceptance
 // criterion 1: every finished tool call in a worker turn reaches the
 // mission via parkNotifier as a mission.tool_call trace entry, in call
-// order, tagged with the generate phase and the correct outcome
+// order, tagged with the build phase and the correct outcome
 // classification (ok/denied/error).
 func TestRunWorkerEmitsToolCallTraceInOrder(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
@@ -2347,7 +2347,7 @@ func TestDiscoverSessionStreamErrorPropagates(t *testing.T) {
 
 // TestDiscoverSessionGetsShellButNotWriteFile confirms the discover
 // turn's ExtraTools include a mission-scoped shell (for read-only
-// exploration) but never write_file: the generate phase does the
+// exploration) but never write_file: the build phase does the
 // actual work, discover must not create or modify files.
 func TestDiscoverSessionGetsShellButNotWriteFile(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1551,7 +1551,7 @@ func TestRunTurnCarriesServedProviderAndModel(t *testing.T) {
 		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`), doneEventMeta("OpenAI Responses", "gpt-5.3-codex")},
 	}}
 	r := newTestRunner(agent)
-	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild)
 	if err != nil {
 		t.Fatalf("runTurn: %v", err)
 	}
@@ -1568,7 +1568,7 @@ func TestRunTurnOmitsProviderModelWhenNeverServed(t *testing.T) {
 		{{Type: stream.EventError, Err: &stream.StreamError{Message: "boom"}}},
 	}}
 	r := newTestRunner(agent)
-	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild)
 	if err == nil {
 		t.Fatal("runTurn: expected an error")
 	}
@@ -1658,7 +1658,7 @@ func TestPhaseRoute(t *testing.T) {
 	}{
 		{"discover uses oversight route", Mission{Phase: PhaseDiscover, Route: "mini", PlanRoute: "strong"}, "strong"},
 		{"plan uses oversight route", Mission{Phase: PhasePlan, Route: "mini", PlanRoute: "strong"}, "strong"},
-		{"generate uses worker route", Mission{Phase: PhaseGenerate, Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
+		{"generate uses worker route", Mission{Phase: PhaseBuild, Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
 		{"prove uses review route", Mission{Phase: PhaseProve, Route: "mini", ReviewRoute: "reviewer"}, "reviewer"},
 		{"result runs no LLM turn", Mission{Phase: PhaseResult, Route: "mini"}, ""},
 	}
@@ -2029,9 +2029,9 @@ func TestRunWorkerEmitsToolCallTraceInOrder(t *testing.T) {
 		t.Fatalf("RunWorker: %v", err)
 	}
 	want := []toolCallRecord{
-		{"m1", "generate", "search_kb", `{"query":"first"}`, "ok", 12, nil},
-		{"m1", "generate", "shell", `{"command":"rm -rf /"}`, "denied", 3, nil},
-		{"m1", "generate", "write_file", `{"path":"x"}`, "error", 40, nil},
+		{"m1", "build", "search_kb", `{"query":"first"}`, "ok", 12, nil},
+		{"m1", "build", "shell", `{"command":"rm -rf /"}`, "denied", 3, nil},
+		{"m1", "build", "write_file", `{"path":"x"}`, "error", 40, nil},
 	}
 	if len(parker.toolCalls) != len(want) {
 		t.Fatalf("toolCalls = %+v, want %d entries", parker.toolCalls, len(want))
@@ -2417,7 +2417,7 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 		textEvent("partial work"),
 	}}}
 	r := newTestRunner(agent)
-	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild)
 	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
 		t.Fatalf("err = %v, want no-terminal error", err)
 	}
@@ -2435,7 +2435,7 @@ func TestRunTurnIncompleteIsError(t *testing.T) {
 		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
 	}}}
 	r := newTestRunner(agent)
-	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
 		t.Fatalf("err = %v, want incomplete-stream error", err)
 	}
 }
@@ -2448,7 +2448,7 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		{Type: stream.EventError},
 	}}}
 	r := newTestRunner(agent)
-	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild); err == nil || !strings.Contains(err.Error(), "provider stream error") {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
@@ -2483,7 +2483,7 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 	done := make(chan struct{})
 	var err error
 	go func() {
-		_, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+		_, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseBuild)
 		close(done)
 	}()
 	select {

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -15,7 +15,7 @@ type Phase string
 const (
 	PhaseDiscover Phase = "discover"
 	PhasePlan     Phase = "plan"
-	PhaseGenerate Phase = "generate"
+	PhaseBuild    Phase = "build"
 	PhaseProve    Phase = "prove"
 	// PhaseResult runs deterministic delivery/copy/promote/on_complete
 	// work with zero LLM turns (slice 1 of the phase redesign): the last
@@ -31,16 +31,16 @@ const (
 // reaches result via InputPhaseComplete, only via
 // stepReviewApprove/routeVerified once the plan's last unit is
 // verified (reviewSkippedOrProvePassTransition).
-var phaseOrder = []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve}
+var phaseOrder = []Phase{PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve}
 
-// discoverGeneratePhaseOrder is FlowDiscoverGenerate's own pipeline
+// discoverBuildPhaseOrder is FlowDiscoverBuild's own pipeline
 // (D-090, issue #459): discover runs as normal, but its completion
-// routes straight to generate, skipping plan entirely: a true
+// routes straight to build, skipping plan entirely: a true
 // planless flow, not merely a review skip. Generate's own exit takes
 // the same light-style short-circuit runExecute uses for Light
 // missions (straight to InputReviewApprove, never InputPhaseComplete),
-// so this slice never needs a generate successor.
-var discoverGeneratePhaseOrder = []Phase{PhaseDiscover, PhaseGenerate}
+// so this slice never needs a build successor.
+var discoverBuildPhaseOrder = []Phase{PhaseDiscover, PhaseBuild}
 
 // Terminal reports whether phase ends the mission.
 func (p Phase) Terminal() bool {
@@ -50,12 +50,12 @@ func (p Phase) Terminal() bool {
 // nextPhase returns what phase follows p in flow's pipeline, and
 // whether p has a successor (PhaseProve's success case is handled by
 // the caller, since it depends on whether the reviewed unit was last).
-// FlowDiscoverGenerate walks its own shorter pipeline (D-090); every
+// FlowDiscoverBuild walks its own shorter pipeline (D-090); every
 // other flow, including the zero value, walks phaseOrder.
 func nextPhase(flow Flow, p Phase) (Phase, bool) {
 	order := phaseOrder
-	if flow == FlowDiscoverGenerate {
-		order = discoverGeneratePhaseOrder
+	if flow == FlowDiscoverBuild {
+		order = discoverBuildPhaseOrder
 	}
 	for i, cur := range order {
 		if cur == p && i+1 < len(order) {
@@ -72,20 +72,21 @@ func nextPhase(flow Flow, p Phase) (Phase, bool) {
 // strictness, each call site choosing the safe fallback for its own
 // context.
 //
-// Legacy mapping (slice 1 of the phase redesign): explore/execute/
-// review are the pre-rename phase names, still readable from rows a
-// data migration hasn't touched yet or from historical mission_events
-// payloads after a rollback. Drop this branch once the migration in
-// scripts/pending-alters.md has run everywhere and the first stable
-// release ships.
+// Legacy mapping: explore/execute/review are the slice-1 pre-rename
+// names and generate is build's own (issue #611), all still readable
+// from rows a data migration hasn't touched yet or from historical
+// mission_events payloads after a rollback. execute maps straight to
+// build, having been renamed twice. Drop this branch once the
+// migrations in scripts/pending-alters.md have run everywhere and the
+// first stable release ships.
 func parsePhase(raw string) (Phase, bool) {
 	switch Phase(raw) {
-	case PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve, PhaseResult, PhaseDone, PhaseFailed:
+	case PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve, PhaseResult, PhaseDone, PhaseFailed:
 		return Phase(raw), true
 	case "explore":
 		return PhaseDiscover, true
-	case "execute":
-		return PhaseGenerate, true
+	case "execute", "generate":
+		return PhaseBuild, true
 	case "review":
 		return PhaseProve, true
 	default:
@@ -167,7 +168,7 @@ const (
 	InputCancel       Input = "cancel"
 	// InputPlanInfeasible fires when the planner reports the goal cannot
 	// be achieved as stated (D-077); valid only in PhasePlan, fails the
-	// mission instead of letting a rewritten goal reach generate.
+	// mission instead of letting a rewritten goal reach build.
 	InputPlanInfeasible Input = "plan_infeasible"
 	// InputResultComplete/InputResultFailed report the result phase's
 	// own deterministic step outcome (driver-run, zero LLM turns): valid
@@ -178,7 +179,7 @@ const (
 	InputResultFailed   Input = "result_failed"
 	// InputPlanApprove/InputPlanReplan/InputPlanRediscover are the three
 	// operator verbs that resolve a PauseApproval park (D-087): approve
-	// advances straight to generate on the plan as landed; replan
+	// advances straight to build on the plan as landed; replan
 	// re-enters PhasePlan with optional feedback folded into the next
 	// planning prompt; rediscover re-enters PhaseDiscover. Valid only
 	// when the mission is paused for PauseApproval; a no-op transition
@@ -230,7 +231,7 @@ type StepState struct {
 	RateAsOf           string
 	// Units is the plan's unit list (D-094): applyVerification records
 	// each batch verify outcome on it and stepReviewApprove flips
-	// Passes on the harness-passed ones, deciding between generate
+	// Passes on the harness-passed ones, deciding between build
 	// (units left) and result (all passed). Always copied before a
 	// write: it shares its backing array with the Mission row. An empty
 	// plan counts as all passed (planless flows).
@@ -242,19 +243,19 @@ type StepState struct {
 	ReplanUsed bool
 	// Flow is the phase set this mission runs (D-090, issue #459):
 	// nextPhase consults it so discover's completion routes straight to
-	// generate for FlowDiscoverGenerate, skipping plan, the same way
-	// FlowLight skips discover/plan by being born in PhaseGenerate
+	// build for FlowDiscoverBuild, skipping plan, the same way
+	// FlowLight skips discover/plan by being born in PhaseBuild
 	// (D-069), so a stall can never replan into PhasePlan for either.
 	// Empty (a zero-value StepState, every fixture that predates this
 	// field) behaves exactly like FlowFull.
 	Flow Flow
 	// AutoApprovePlan gates the plan phase's success transition
 	// (D-087, issue #456): true (the default) advances straight to
-	// generate, byte-identical to pre-#456 behavior. false parks the
+	// build, byte-identical to pre-#456 behavior. false parks the
 	// mission on PauseApproval instead, waiting for one of the three
 	// operator verbs. FlowLight missions never visit PhasePlan, so this
 	// flag has no effect on them regardless of its value; neither does
-	// FlowDiscoverGenerate, which also never visits PhasePlan.
+	// FlowDiscoverBuild, which also never visits PhasePlan.
 	AutoApprovePlan bool
 	// ReviewFindings is the mission's whole findings ledger (D-092,
 	// issue #512): open ones drive rework, resolved ones stay for the
@@ -281,12 +282,12 @@ type StepState struct {
 }
 
 // neverVisitsPlan reports whether s's mission can never be in
-// PhasePlan: FlowLight (born in PhaseGenerate) and FlowDiscoverGenerate
-// (discover's completion routes straight to generate, D-090) both
+// PhasePlan: FlowLight (born in PhaseBuild) and FlowDiscoverBuild
+// (discover's completion routes straight to build, D-090) both
 // qualify. Used wherever plan-specific state (the stall/replan brake)
 // must be skipped for a mission structurally incapable of reaching it.
 func (s StepState) neverVisitsPlan() bool {
-	return s.Flow == FlowLight || s.Flow == FlowDiscoverGenerate
+	return s.Flow == FlowLight || s.Flow == FlowDiscoverBuild
 }
 
 // StepInput bundles the triggering Input with whatever data it
@@ -315,7 +316,7 @@ type StepInput struct {
 	ReviewAt time.Time
 	// TouchedFiles is every workspace-relative path the worker turn
 	// that just ended changed (git diff --name-only against the
-	// pre-turn HEAD), set on InputPhaseComplete from generate. nil means
+	// pre-turn HEAD), set on InputPhaseComplete from build. nil means
 	// unknown (no worktree), and the untouched counters stay put; an
 	// empty non-nil slice means the turn changed nothing.
 	TouchedFiles []string
@@ -526,33 +527,33 @@ func stepResume(s StepState) Transition {
 }
 
 // stepPhaseComplete advances discover/plan to the next phase in the
-// mission's flow. generate's completion goes through prove (a worker
+// mission's flow. build's completion goes through prove (a worker
 // verdict of DONE requests review, it doesn't itself complete the
 // phase: the driver routes DONE into a review round, whose outcome
 // arrives as InputReviewApprove/InputReviewRework, not
-// InputPhaseComplete), except FlowDiscoverGenerate (D-090, issue
-// #459), whose generate exit takes the same light-style short-circuit
+// InputPhaseComplete), except FlowDiscoverBuild (D-090, issue
+// #459), whose build exit takes the same light-style short-circuit
 // straight to InputReviewApprove that Light missions use, so it never
-// reaches this function from PhaseGenerate either.
+// reaches this function from PhaseBuild either.
 //
 // The plan phase's own completion forks on AutoApprovePlan (D-087,
 // issue #456): true is the byte-identical default, straight through to
 // nextPhase like every other phase. false parks the mission instead:
 // the plan already landed (runPlan's own SetPlan ran before this
 // input arrives), so the park shows the real plan, not a stale one.
-// FlowDiscoverGenerate never visits PhasePlan, so this check never
+// FlowDiscoverBuild never visits PhasePlan, so this check never
 // applies to it: discover's own completion routes straight to
-// generate via nextPhase's flow-aware pipeline.
+// build via nextPhase's flow-aware pipeline.
 //
-// A generate completion with open findings (a rework turn, D-092) also
+// A build completion with open findings (a rework turn, D-092) also
 // scores the turn against them: every open finding whose file the
 // worker never touched counts one more untouched round (the id-based
 // stall input stepReviewRework reads), and the blocking ones are named
 // in mission.rework_untouched. ReworkRounds is deliberately NOT reset
 // here: the review cycle is still running.
 //
-// A generate completion with units still lacking harness evidence and
-// no finding open stays in generate for the next unit (D-096, issue
+// A build completion with units still lacking harness evidence and
+// no finding open stays in build for the next unit (D-096, issue
 // #524): prove runs one round over the whole change set once every unit
 // is harness-passed, instead of one round per unit. Open findings send
 // the turn to prove regardless: a rework must be re-reviewed.
@@ -568,7 +569,7 @@ func stepPhaseComplete(s StepState, in StepInput) Transition {
 		return Transition{Next: s}
 	}
 	var events []EventDraft
-	if s.Phase == PhaseGenerate && in.TouchedFiles != nil {
+	if s.Phase == PhaseBuild && in.TouchedFiles != nil {
 		var untouched []Finding
 		s.ReviewFindings, untouched = markUntouched(s.ReviewFindings, in.TouchedFiles)
 		if len(untouched) > 0 {
@@ -577,7 +578,7 @@ func stepPhaseComplete(s StepState, in StepInput) Transition {
 			}})
 		}
 	}
-	if s.Phase == PhaseGenerate && len(OpenFindings(s.ReviewFindings)) == 0 {
+	if s.Phase == PhaseBuild && len(OpenFindings(s.ReviewFindings)) == 0 {
 		if pending := unverifiedUnits(s.Units); len(pending) > 0 {
 			s.Status = StatusIdle
 			s.Iteration = 0
@@ -597,7 +598,7 @@ func stepPhaseComplete(s StepState, in StepInput) Transition {
 }
 
 // stepPlanApprove is the approve verb (D-087): valid only while parked
-// on PauseApproval, advances straight to generate on the plan as it
+// on PauseApproval, advances straight to build on the plan as it
 // landed: the same nextPhase(PhasePlan) step stepPhaseComplete would
 // have taken had AutoApprovePlan been true. Any other state is a no-op
 // (the API layer rejects the request with 409 before Step ever sees
@@ -608,7 +609,7 @@ func stepPlanApprove(s StepState) Transition {
 	}
 	s.Status = StatusIdle
 	s.PauseReason = ""
-	s.Phase = PhaseGenerate
+	s.Phase = PhaseBuild
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.plan_approved", Payload: map[string]any{}}}}
@@ -757,7 +758,7 @@ func replanTransition(s StepState, in StepInput) Transition {
 // stepReviewApprove clears the stall counter (progress was made),
 // flips Passes on every harness-passed unit (D-094: approval, whether a
 // reviewer's or the review-skip fast path's, only ever lands on harness
-// evidence), and either moves on to generate (units left) or advances
+// evidence), and either moves on to build (units left) or advances
 // to the result phase (all passed).
 func stepReviewApprove(s StepState) Transition {
 	s.StallCount = 0
@@ -770,7 +771,7 @@ func stepReviewApprove(s StepState) Transition {
 	if allPassed(s.Units) {
 		return reviewSkippedOrProvePassTransition(s)
 	}
-	s.Phase = PhaseGenerate
+	s.Phase = PhaseBuild
 	s.Status = StatusIdle
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
@@ -887,8 +888,8 @@ func reviewSkippedOrProvePassTransition(s StepState) Transition {
 }
 
 // stepReviewRework merges the round's findings into the ledger (D-092)
-// and sends the mission back to generate for another attempt, unless
-// one of two brakes fires first. Both park IN generate, so a resume
+// and sends the mission back to build for another attempt, unless
+// one of two brakes fires first. Both park IN build, so a resume
 // buys exactly one more worker turn against the open findings rather
 // than an immediate re-review of unchanged work:
 //  1. stall: an open blocking finding whose file the worker left
@@ -913,7 +914,7 @@ func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 		s.LastReviewAt = in.ReviewAt
 	}
 	open := OpenFindings(s.ReviewFindings)
-	s.Phase = PhaseGenerate
+	s.Phase = PhaseBuild
 	s.Status = StatusIdle
 	if stalled := stalledFindings(open, cfg.StallRounds); len(stalled) > 0 {
 		return Transition{
@@ -1115,7 +1116,7 @@ func stepResultComplete(s StepState) Transition {
 	// flow=discover_generate, D-090), both of which reach done with zero
 	// harness verification (no plan units, no CheckArtifacts/RunVerify);
 	// distinguishes that in the event log from a harness-verified done.
-	verified := s.Flow != FlowLight && s.Flow != FlowDiscoverGenerate
+	verified := s.Flow != FlowLight && s.Flow != FlowDiscoverBuild
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.done", Payload: map[string]any{"verified": verified}}}}
 }
 

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -36,7 +36,7 @@ var phaseOrder = []Phase{PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve}
 // discoverBuildPhaseOrder is FlowDiscoverBuild's own pipeline
 // (D-090, issue #459): discover runs as normal, but its completion
 // routes straight to build, skipping plan entirely: a true
-// planless flow, not merely a review skip. Generate's own exit takes
+// planless flow, not merely a review skip. Build's own exit takes
 // the same light-style short-circuit runExecute uses for Light
 // missions (straight to InputReviewApprove, never InputPhaseComplete),
 // so this slice never needs a build successor.
@@ -713,7 +713,7 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 		}
 		s.LastGapFingerprint = in.GapFingerprint
 		// D-069/D-090: a mission that never visits PhasePlan (light, or
-		// flow=discover_generate) skips the replan/no-progress-pause
+		// flow=discover_build) skips the replan/no-progress-pause
 		// brake entirely and falls straight through to the plain
 		// retry/max_iterations path below, same as stepWorkerFailed's
 		// backoff ceiling.
@@ -1113,7 +1113,7 @@ func stepResultComplete(s StepState) Transition {
 	s.Phase = PhaseDone
 	s.Status = StatusDone
 	// verified: false for a planless mission (flow=light, or
-	// flow=discover_generate, D-090), both of which reach done with zero
+	// flow=discover_build, D-090), both of which reach done with zero
 	// harness verification (no plan units, no CheckArtifacts/RunVerify);
 	// distinguishes that in the event log from a harness-verified done.
 	verified := s.Flow != FlowLight && s.Flow != FlowDiscoverBuild

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -19,21 +19,21 @@ func TestStep(t *testing.T) {
 	}{
 		{
 			name:  "cancel from working fails the mission",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputCancel},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseFailed, Status: StatusError},
 		},
 		{
 			name:  "cancel from waiting_for_input fails the mission",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWaitingForInput},
+			state: StepState{Phase: PhaseBuild, Status: StatusWaitingForInput},
 			input: StepInput{Input: InputCancel},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseFailed, Status: StatusError},
 		},
 		{
 			name:  "cancel from paused fails the mission and clears the stale pause reason",
-			state: StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseBackoff},
+			state: StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff},
 			input: StepInput{Input: InputCancel},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseFailed, Status: StatusError},
@@ -68,10 +68,10 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "nil budget never pauses on spend",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Spent: 1_000_000},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Spent: 1_000_000},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: ""},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Spent: 1_000_000, Iteration: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Spent: 1_000_000, Iteration: 1},
 		},
 		{
 			name:  "budget check does not apply to a terminal mission",
@@ -82,10 +82,10 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "mixed-currency spend pauses even when same-currency spend is well under budget",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Spent: 0, Budget: budget(100), MixedCurrencySpend: true},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Spent: 0, Budget: budget(100), MixedCurrencySpend: true},
 			input: StepInput{Input: InputWorkerRetry},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseMixedCurrency, Spent: 0, Budget: budget(100), MixedCurrencySpend: true},
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseMixedCurrency, Spent: 0, Budget: budget(100), MixedCurrencySpend: true},
 		},
 		{
 			name:  "phase_complete advances discover to plan",
@@ -95,20 +95,20 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle},
 		},
 		{
-			// D-090, issue #459: flow=discover_generate routes discover's
+			// D-090, issue #459: flow=discover_build routes discover's
 			// completion straight to generate, never plan.
-			name:  "flow=discover_generate: phase_complete advances discover straight to generate, skipping plan",
-			state: StepState{Phase: PhaseDiscover, Status: StatusWorking, Flow: FlowDiscoverGenerate, Iteration: 2, ConsecutiveFailures: 1},
+			name:  "flow=discover_build: phase_complete advances discover straight to generate, skipping plan",
+			state: StepState{Phase: PhaseDiscover, Status: StatusWorking, Flow: FlowDiscoverBuild, Iteration: 2, ConsecutiveFailures: 1},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, Flow: FlowDiscoverGenerate},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, Flow: FlowDiscoverBuild},
 		},
 		{
 			name:  "phase_complete advances plan to generate when auto_approve_plan is true",
 			state: StepState{Phase: PhasePlan, Status: StatusWorking, AutoApprovePlan: true},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, AutoApprovePlan: true},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, AutoApprovePlan: true},
 		},
 		{
 			name:  "phase_complete parks on approval when auto_approve_plan is false",
@@ -119,7 +119,7 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "phase_complete advances generate to prove",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseProve, Status: StatusIdle},
@@ -133,28 +133,28 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "worker_blocked parks the mission waiting for input",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputWorkerBlocked, Message: "which endpoint?"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWaitingForInput},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWaitingForInput},
 		},
 		{
 			name:  "worker_failed below backoff threshold just retries",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 1},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 1},
 			input: StepInput{Input: InputWorkerFailed},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
 		},
 		{
 			name:  "worker_failed 3rd consecutive time pauses with backoff",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2},
 			input: StepInput{Input: InputWorkerFailed},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseBackoff, MaxIterations: 8, ConsecutiveFailures: 3, Iteration: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff, MaxIterations: 8, ConsecutiveFailures: 3, Iteration: 1},
 		},
 		{
 			name:  "worker_failed hitting max_iterations hard-fails instead of pausing",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, ConsecutiveFailures: 0},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, ConsecutiveFailures: 0},
 			input: StepInput{Input: InputWorkerFailed},
 			cfg:   Config{BackoffFailures: 10, StallRounds: 10},
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 1, ConsecutiveFailures: 1, Iteration: 1},
@@ -164,59 +164,59 @@ func TestStep(t *testing.T) {
 			// MaxIterations and BackoffFailures on the same failure must
 			// fail terminally, never pause for backoff.
 			name:  "worker_failed hitting both ceiling and backoff threshold hard-fails, not pauses",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 3, Iteration: 2, ConsecutiveFailures: 2},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 3, Iteration: 2, ConsecutiveFailures: 2},
 			input: StepInput{Input: InputWorkerFailed},
 			cfg:   Config{BackoffFailures: 3, StallRounds: 10},
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 3, Iteration: 3, ConsecutiveFailures: 3},
 		},
 		{
 			name:  "worker_retry costs an iteration and resets consecutive failures",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
 			input: StepInput{Input: InputWorkerRetry},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 0, Iteration: 2},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 0, Iteration: 2},
 		},
 		{
 			name:  "worker_retry hitting max_iterations hard-fails",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, Iteration: 0},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Iteration: 0},
 			input: StepInput{Input: InputWorkerRetry},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 1, Iteration: 1, ConsecutiveFailures: 0},
 		},
 		{
 			name:  "worker_retry with no fingerprint never accumulates stall",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc"},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc"},
 			input: StepInput{Input: InputWorkerRetry},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc"},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc"},
 		},
 		{
 			name:  "worker_retry with a new fingerprint returns to generate, stall count resets to 1",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 0, LastGapFingerprint: ""},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 0, LastGapFingerprint: ""},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
 		},
 		{
 			name:  "worker_retry with the SAME fingerprint twice pauses no_progress once replan is already used",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
 		},
 		{
 			name:  "worker_retry with a DIFFERENT fingerprint does not accumulate stall",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_1"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_1"},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_1"},
 		},
 		{
 			name:  "review_approve on a non-last unit returns to generate",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, StallCount: 1, LastGapFingerprint: "x", Units: []PlanUnit{{}}},
 			input: StepInput{Input: InputReviewApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, Units: []PlanUnit{{}}},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, Units: []PlanUnit{{}}},
 		},
 		{
 			name:  "review_approve on the last unit advances to result, not done",
@@ -230,25 +230,25 @@ func TestStep(t *testing.T) {
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8},
 			input: StepInput{Input: InputReviewRework},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8, Iteration: 1, ReworkRounds: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8, Iteration: 1, ReworkRounds: 1},
 		},
 		{
 			name:  "review_rework leaves the worker-retry stall fingerprint alone",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc"},
 			input: StepInput{Input: InputReviewRework},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc", ReworkRounds: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc", ReworkRounds: 1},
 		},
 		{
 			name:  "review_rework reaching max_iterations parks review_exhausted in generate instead of failing",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 1},
 			input: StepInput{Input: InputReviewRework},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseReviewExhausted, MaxIterations: 1, ReworkRounds: 1},
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseReviewExhausted, MaxIterations: 1, ReworkRounds: 1},
 		},
 		{
 			name:  "worker_retry stall with replan unused replans instead of pausing",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Reason: "same failure again"},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
@@ -261,7 +261,7 @@ func TestStep(t *testing.T) {
 			// arrives at planning one failure from a backoff pause despite
 			// having made no failed attempt yet in the new phase.
 			name:  "worker_retry stall replan clears ConsecutiveFailures",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ConsecutiveFailures: 2},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ConsecutiveFailures: 2},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Reason: "same failure again"},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
@@ -282,17 +282,17 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "resume from paused clears the pause reason and goes idle",
-			state: StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseBackoff, Iteration: 3, ConsecutiveFailures: 2},
+			state: StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff, Iteration: 3, ConsecutiveFailures: 2},
 			input: StepInput{Input: InputResume},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, Iteration: 3, ConsecutiveFailures: 2},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, Iteration: 3, ConsecutiveFailures: 2},
 		},
 		{
 			name:  "resume from waiting_for_input clears and goes idle",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWaitingForInput},
+			state: StepState{Phase: PhaseBuild, Status: StatusWaitingForInput},
 			input: StepInput{Input: InputResume},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle},
 		},
 		{
 			name:  "resume on a terminal mission is a no-op",
@@ -322,10 +322,10 @@ func TestStep(t *testing.T) {
 			// any other phase is a no-op, same convention as the default
 			// unrecognized-input case.
 			name:  "plan_infeasible outside plan phase is a no-op",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputPlanInfeasible, Reason: "goal forbids the only possible action"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking},
 		},
 		{
 			name:  "result_complete advances result to done",
@@ -346,7 +346,7 @@ func TestStep(t *testing.T) {
 			state: StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
 			input: StepInput{Input: InputPlanApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle},
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle},
 		},
 		{
 			// Operator iterations are free: replan must NOT set ReplanUsed
@@ -366,10 +366,10 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "plan_approve outside an approval park is a no-op",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputPlanApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking},
 		},
 		{
 			name:  "plan_replan outside an approval park is a no-op",
@@ -445,7 +445,7 @@ func TestStepPlanInfeasibleEmitsGoalInfeasibleEvent(t *testing.T) {
 func TestStepMixedCurrencyPauseDetail(t *testing.T) {
 	budget := 100.0
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Budget: &budget, MixedCurrencySpend: true},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Budget: &budget, MixedCurrencySpend: true},
 		StepInput{Input: InputWorkerRetry},
 		DefaultConfig,
 	)
@@ -464,7 +464,7 @@ func TestStepMixedCurrencyPauseDetail(t *testing.T) {
 // no_progress exactly as before this feature existed.
 func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 	first := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)
@@ -479,7 +479,7 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 	}
 
 	second := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp", ReplanUsed: true},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp", ReplanUsed: true},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp"},
 		DefaultConfig,
 	)
@@ -489,13 +489,13 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 }
 
 // TestStepLightApproveGoesResult confirms a light mission (born in
-// PhaseGenerate, empty plan so every unit counts as passed) advances to
+// PhaseBuild, empty plan so every unit counts as passed) advances to
 // the result phase on review_approve exactly like a coding/general
 // mission's last unit: not straight to done, since D-086's result
 // phase now sits between the last unit's approval and done.
 func TestStepLightApproveGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Flow: FlowLight},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -504,18 +504,18 @@ func TestStepLightApproveGoesResult(t *testing.T) {
 	}
 }
 
-// TestStepDiscoverGenerateApproveGoesResult confirms a discover_generate
+// TestStepDiscoverGenerateApproveGoesResult confirms a discover_build
 // mission (generate turn takes the same planless short-circuit as
 // light, empty plan so every unit counts as passed) advances to the
 // result phase on review_approve exactly like light, D-090.
 func TestStepDiscoverGenerateApproveGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowDiscoverGenerate},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Flow: FlowDiscoverBuild},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
 	if got.Next.Phase != PhaseResult || got.Next.Status != StatusIdle {
-		t.Fatalf("Step(discover_generate approve) = %+v, want phase=result status=idle", got.Next)
+		t.Fatalf("Step(discover_build approve) = %+v, want phase=result status=idle", got.Next)
 	}
 }
 
@@ -548,15 +548,15 @@ func TestStepResultCompleteEmitsVerifiedFlag(t *testing.T) {
 		t.Fatalf("non-light mission.done payload = %+v, want verified=true", nonLight.Events[0].Payload)
 	}
 
-	// D-090, issue #459: flow=discover_generate reaches done with zero
+	// D-090, issue #459: flow=discover_build reaches done with zero
 	// harness verification too (no spec units, planless), same as light.
 	discoverGenerate := Step(
-		StepState{Phase: PhaseResult, Status: StatusWorking, Flow: FlowDiscoverGenerate},
+		StepState{Phase: PhaseResult, Status: StatusWorking, Flow: FlowDiscoverBuild},
 		StepInput{Input: InputResultComplete},
 		DefaultConfig,
 	)
 	if verified, ok := discoverGenerate.Events[0].Payload["verified"].(bool); !ok || verified {
-		t.Fatalf("discover_generate mission.done payload = %+v, want verified=false", discoverGenerate.Events[0].Payload)
+		t.Fatalf("discover_build mission.done payload = %+v, want verified=false", discoverGenerate.Events[0].Payload)
 	}
 }
 
@@ -600,21 +600,21 @@ func TestStepAppliesVerification(t *testing.T) {
 	}{
 		{
 			name:  "worker_retry records the failing excerpt without flipping anything",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "a"}}},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "a"}}},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: long}}},
 			wantUnits: []PlanUnit{{Title: "a", VerifyCheck: "verify_cmd", VerifyExcerpt: long[:verifyExcerptCap] + "…"}},
-			wantPhase: PhaseGenerate, wantEvents: []string{"mission.retry"},
+			wantPhase: PhaseBuild, wantEvents: []string{"mission.retry"},
 		},
 		{
 			name:  "phase_complete marks a passing unit harness-passed and stays in generate while a unit is pending (D-096)",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
 			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
-			wantPhase: PhaseGenerate, wantEvents: []string{"mission.generate_continued"},
+			wantPhase: PhaseBuild, wantEvents: []string{"mission.generate_continued"},
 		},
 		{
 			name:  "phase_complete enters prove once every unit is harness-passed, Passes waits for approval",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
 			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 1, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
 			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
@@ -633,11 +633,11 @@ func TestStepAppliesVerification(t *testing.T) {
 			state:     StepState{Phase: PhaseProve, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
 			input:     StepInput{Input: InputReviewApprove},
 			wantUnits: []PlanUnit{{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b"}},
-			wantPhase: PhaseGenerate, wantEvents: []string{"mission.unit_verified"},
+			wantPhase: PhaseBuild, wantEvents: []string{"mission.unit_verified"},
 		},
 		{
 			name: "a passed unit failing again regresses to pending with the excerpt and an event",
-			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{
 				{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b"},
 			}},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "regression:unit_0", Verified: []UnitVerification{
@@ -647,21 +647,21 @@ func TestStepAppliesVerification(t *testing.T) {
 				{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "a.md: not found"},
 				{Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd"},
 			},
-			wantPhase: PhaseGenerate, wantEvents: []string{"mission.unit_regressed", "mission.retry"},
+			wantPhase: PhaseBuild, wantEvents: []string{"mission.unit_regressed", "mission.retry"},
 		},
 		{
 			name:      "a regressed unit passing again clears the regression marker",
-			state:     StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "gone"}}},
+			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "gone"}}},
 			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
 			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
 		},
 		{
 			name:      "an out-of-range unit index is ignored",
-			state:     StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}}},
+			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}}},
 			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 4, Passed: true}}},
 			wantUnits: []PlanUnit{{Title: "a"}},
-			wantPhase: PhaseGenerate, wantEvents: []string{"mission.generate_continued"},
+			wantPhase: PhaseBuild, wantEvents: []string{"mission.generate_continued"},
 		},
 	}
 	for _, tc := range cases {
@@ -689,7 +689,7 @@ func TestStepAppliesVerification(t *testing.T) {
 // excerpt, so the timeline names what broke without the full output.
 func TestStepRegressionEventPayload(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "write a.md", Passes: true, HarnessPassed: true}}},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "write a.md", Passes: true, HarnessPassed: true}}},
 		StepInput{Input: InputWorkerRetry, Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: strings.Repeat("y", 600)}}},
 		DefaultConfig,
 	)
@@ -710,7 +710,7 @@ func TestStepRegressionEventPayload(t *testing.T) {
 // separate as documentation of that fast path's contract.
 func TestStepReviewSkippedGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking},
+		StepState{Phase: PhaseBuild, Status: StatusWorking},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -729,7 +729,7 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 	// mission (StallCount already at the threshold, ReplanUsed false)
 	// must instead fall through to the plain retry path for a light one.
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Flow: FlowLight, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)
@@ -746,7 +746,7 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 	// Repeated identical-fingerprint stalls still respect the hard
 	// max_iterations ceiling, exactly like worker_failed.
 	final := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, MaxIterations: 1, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Flow: FlowLight, MaxIterations: 1, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)
@@ -756,25 +756,25 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 }
 
 // TestStepDiscoverGenerateStallNeverReplans mirrors
-// TestStepLightStallNeverReplans for flow=discover_generate (D-090,
+// TestStepLightStallNeverReplans for flow=discover_build (D-090,
 // issue #459): its generate turn never visits PhasePlan either, so the
 // same replan-skip must apply.
 func TestStepDiscoverGenerateStallNeverReplans(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowDiscoverGenerate, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Flow: FlowDiscoverBuild, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)
 	if got.Next.Phase == PhasePlan {
-		t.Fatalf("Step(discover_generate stall) = %+v, must never route to PhasePlan", got.Next)
+		t.Fatalf("Step(discover_build stall) = %+v, must never route to PhasePlan", got.Next)
 	}
 	if got.Next.Status == StatusPaused {
-		t.Fatalf("Step(discover_generate stall) = %+v, must not pause no_progress either", got.Next)
+		t.Fatalf("Step(discover_build stall) = %+v, must not pause no_progress either", got.Next)
 	}
 }
 
 func TestParsePhase(t *testing.T) {
-	valid := []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve, PhaseResult, PhaseDone, PhaseFailed}
+	valid := []Phase{PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve, PhaseResult, PhaseDone, PhaseFailed}
 	for _, p := range valid {
 		if got, ok := parsePhase(string(p)); !ok || got != p {
 			t.Fatalf("parsePhase(%q) = %q, %v; want %q, true", p, got, ok, p)
@@ -788,19 +788,21 @@ func TestParsePhase(t *testing.T) {
 	}
 }
 
-// TestParsePhaseLegacyMapping is the table test for slice 1's legacy
-// phase name tolerance: a row (or historical mission_events payload)
-// still carrying the pre-rename explore/execute/review value must
-// parse to its new-name equivalent, so a new binary reads old rows
-// correctly before the data migration in scripts/pending-alters.md
-// runs, and old event history keeps displaying after a rollback.
+// TestParsePhaseLegacyMapping is the table test for legacy phase name
+// tolerance: a row (or historical mission_events payload) still
+// carrying a pre-rename value (slice 1's explore/execute/review, or
+// #611's generate) must parse to its current equivalent, so a new
+// binary reads old rows correctly before the data migration in
+// scripts/pending-alters.md runs, and old event history keeps
+// displaying after a rollback.
 func TestParsePhaseLegacyMapping(t *testing.T) {
 	cases := []struct {
 		legacy string
 		want   Phase
 	}{
 		{"explore", PhaseDiscover},
-		{"execute", PhaseGenerate},
+		{"execute", PhaseBuild},
+		{"generate", PhaseBuild},
 		{"review", PhaseProve},
 	}
 	for _, tc := range cases {
@@ -833,7 +835,7 @@ func TestPhaseTerminal(t *testing.T) {
 			t.Fatalf("%q.Terminal() = false, want true", p)
 		}
 	}
-	nonTerminal := []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve, PhaseResult}
+	nonTerminal := []Phase{PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve, PhaseResult}
 	for _, p := range nonTerminal {
 		if p.Terminal() {
 			t.Fatalf("%q.Terminal() = true, want false", p)
@@ -920,14 +922,14 @@ func TestStepPlanRediscoverEmitsEvent(t *testing.T) {
 // division of labor as pending_permission's own park.
 func TestStepAskUserParksWithoutEvent(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking},
+		StepState{Phase: PhaseBuild, Status: StatusWorking},
 		StepInput{Input: InputAskUser},
 		DefaultConfig,
 	)
 	if got.Next.Status != StatusWaitingForInput {
 		t.Fatalf("Status = %s, want waiting_for_input", got.Next.Status)
 	}
-	if got.Next.Phase != PhaseGenerate {
+	if got.Next.Phase != PhaseBuild {
 		t.Fatalf("Phase = %s, want generate (unchanged)", got.Next.Phase)
 	}
 	if len(got.Events) != 0 {
@@ -938,7 +940,7 @@ func TestStepAskUserParksWithoutEvent(t *testing.T) {
 // TestStepAskUserParksInEveryLLMPhase confirms the park applies
 // uniformly regardless of which of the four LLM phases asked.
 func TestStepAskUserParksInEveryLLMPhase(t *testing.T) {
-	for _, phase := range []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve} {
+	for _, phase := range []Phase{PhaseDiscover, PhasePlan, PhaseBuild, PhaseProve} {
 		got := Step(StepState{Phase: phase, Status: StatusWorking}, StepInput{Input: InputAskUser}, DefaultConfig)
 		if got.Next.Status != StatusWaitingForInput || got.Next.Phase != phase {
 			t.Fatalf("phase %s: Next = %+v, want same phase with status waiting_for_input", phase, got.Next)
@@ -976,7 +978,7 @@ func TestStepReworkAssignsFindingIDsInOrder(t *testing.T) {
 	if !reflect.DeepEqual(got.Next.ReviewFindings, want) {
 		t.Fatalf("ReviewFindings = %+v, want %+v", got.Next.ReviewFindings, want)
 	}
-	if got.Next.ReworkRounds != 1 || got.Next.Phase != PhaseGenerate || got.Next.Status != StatusIdle {
+	if got.Next.ReworkRounds != 1 || got.Next.Phase != PhaseBuild || got.Next.Status != StatusIdle {
 		t.Fatalf("Next = %+v, want rework round 1 back in generate/idle", got.Next)
 	}
 	ev := eventOfKind(got.Events, "mission.review_verdict")
@@ -1071,7 +1073,7 @@ func TestStepApproveResolvesAllAndResetsRounds(t *testing.T) {
 // never reached the ceiling. ReworkRounds must survive it.
 func TestStepPhaseCompleteKeepsReworkRounds(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 3, Iteration: 2, ReworkRounds: 2},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 3, Iteration: 2, ReworkRounds: 2},
 		StepInput{Input: InputPhaseComplete},
 		DefaultConfig,
 	)
@@ -1092,12 +1094,12 @@ func TestStepPhaseCompleteKeepsReworkRounds(t *testing.T) {
 // Legacy Passes-only rows count as verified.
 func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
 	pending := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Iteration: 2, ConsecutiveFailures: 1, Units: []PlanUnit{
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 2, ConsecutiveFailures: 1, Units: []PlanUnit{
 			{Title: "a", HarnessPassed: true}, {Title: "b"}, {Title: "c"},
 		}},
 		StepInput{Input: InputPhaseComplete}, DefaultConfig,
 	)
-	if pending.Next.Phase != PhaseGenerate || pending.Next.Status != StatusIdle || pending.Next.Iteration != 0 || pending.Next.ConsecutiveFailures != 0 {
+	if pending.Next.Phase != PhaseBuild || pending.Next.Status != StatusIdle || pending.Next.Iteration != 0 || pending.Next.ConsecutiveFailures != 0 {
 		t.Fatalf("Next = %+v, want generate/idle with counters reset", pending.Next)
 	}
 	ev := eventOfKind(pending.Events, "mission.generate_continued")
@@ -1109,7 +1111,7 @@ func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
 	}
 
 	allPassed := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", Passes: true}}},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", Passes: true}}},
 		StepInput{Input: InputPhaseComplete}, DefaultConfig,
 	)
 	if allPassed.Next.Phase != PhaseProve || eventOfKind(allPassed.Events, "mission.phase_started") == nil {
@@ -1117,7 +1119,7 @@ func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
 	}
 
 	openFinding := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}},
 			ReviewFindings: []Finding{{ID: "F1", Title: "gap", Status: FindingOpen}}},
 		StepInput{Input: InputPhaseComplete}, DefaultConfig,
 	)
@@ -1164,7 +1166,7 @@ func TestStepPhaseCompleteScoresUntouchedFindings(t *testing.T) {
 		{ID: "F3", Title: "c", Severity: SeverityBlocking, Status: FindingOpen},
 		{ID: "F4", Title: "d", File: "src/x.go", Severity: SeverityBlocking, Status: FindingResolved},
 	}
-	state := StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, ReviewFindings: ledger}
+	state := StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ReviewFindings: ledger}
 
 	untouched := Step(state, StepInput{Input: InputPhaseComplete, TouchedFiles: []string{"README.md"}}, DefaultConfig)
 	fs := untouched.Next.ReviewFindings
@@ -1207,7 +1209,7 @@ func TestStepReworkParksExhaustedWithIDsInDetail(t *testing.T) {
 		StepInput{Input: InputReviewRework, Findings: []Finding{{Title: "no header toggle", File: "t.tsx"}}},
 		DefaultConfig,
 	)
-	if got.Next.Phase != PhaseGenerate || got.Next.Status != StatusPaused || got.Next.PauseReason != PauseReviewExhausted {
+	if got.Next.Phase != PhaseBuild || got.Next.Status != StatusPaused || got.Next.PauseReason != PauseReviewExhausted {
 		t.Fatalf("Next = %+v, want paused review_exhausted in generate", got.Next)
 	}
 	if got.Next.ReworkRounds != 3 {
@@ -1238,7 +1240,7 @@ func TestStepReworkStallsOnUntouchedFile(t *testing.T) {
 		StepInput{Input: InputReviewRework},
 		DefaultConfig,
 	)
-	if stalled.Next.Phase != PhaseGenerate || stalled.Next.PauseReason != PauseNoProgress {
+	if stalled.Next.Phase != PhaseBuild || stalled.Next.PauseReason != PauseNoProgress {
 		t.Fatalf("Next = %+v, want paused no_progress in generate", stalled.Next)
 	}
 	ev := eventOfKind(stalled.Events, "mission.paused")

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -96,15 +96,15 @@ func TestStep(t *testing.T) {
 		},
 		{
 			// D-090, issue #459: flow=discover_build routes discover's
-			// completion straight to generate, never plan.
-			name:  "flow=discover_build: phase_complete advances discover straight to generate, skipping plan",
+			// completion straight to build, never plan.
+			name:  "flow=discover_build: phase_complete advances discover straight to build, skipping plan",
 			state: StepState{Phase: PhaseDiscover, Status: StatusWorking, Flow: FlowDiscoverBuild, Iteration: 2, ConsecutiveFailures: 1},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, Flow: FlowDiscoverBuild},
 		},
 		{
-			name:  "phase_complete advances plan to generate when auto_approve_plan is true",
+			name:  "phase_complete advances plan to build when auto_approve_plan is true",
 			state: StepState{Phase: PhasePlan, Status: StatusWorking, AutoApprovePlan: true},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
@@ -118,7 +118,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
 		},
 		{
-			name:  "phase_complete advances generate to prove",
+			name:  "phase_complete advances build to prove",
 			state: StepState{Phase: PhaseBuild, Status: StatusWorking},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
@@ -191,7 +191,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc"},
 		},
 		{
-			name:  "worker_retry with a new fingerprint returns to generate, stall count resets to 1",
+			name:  "worker_retry with a new fingerprint returns to build, stall count resets to 1",
 			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 0, LastGapFingerprint: ""},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0"},
 			cfg:   DefaultConfig,
@@ -212,7 +212,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_1"},
 		},
 		{
-			name:  "review_approve on a non-last unit returns to generate",
+			name:  "review_approve on a non-last unit returns to build",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, StallCount: 1, LastGapFingerprint: "x", Units: []PlanUnit{{}}},
 			input: StepInput{Input: InputReviewApprove},
 			cfg:   DefaultConfig,
@@ -226,7 +226,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseResult, Status: StatusIdle},
 		},
 		{
-			name:  "review_rework with no findings returns to generate and counts the round",
+			name:  "review_rework with no findings returns to build and counts the round",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8},
 			input: StepInput{Input: InputReviewRework},
 			cfg:   DefaultConfig,
@@ -240,7 +240,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc", ReworkRounds: 1},
 		},
 		{
-			name:  "review_rework reaching max_iterations parks review_exhausted in generate instead of failing",
+			name:  "review_rework reaching max_iterations parks review_exhausted in build instead of failing",
 			state: StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 1},
 			input: StepInput{Input: InputReviewRework},
 			cfg:   DefaultConfig,
@@ -342,7 +342,7 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseResult, Status: StatusPaused, PauseReason: PauseInfra},
 		},
 		{
-			name:  "plan_approve from an approval park advances to generate",
+			name:  "plan_approve from an approval park advances to build",
 			state: StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
 			input: StepInput{Input: InputPlanApprove},
 			cfg:   DefaultConfig,
@@ -505,7 +505,7 @@ func TestStepLightApproveGoesResult(t *testing.T) {
 }
 
 // TestStepDiscoverGenerateApproveGoesResult confirms a discover_build
-// mission (generate turn takes the same planless short-circuit as
+// mission (build turn takes the same planless short-circuit as
 // light, empty plan so every unit counts as passed) advances to the
 // result phase on review_approve exactly like light, D-090.
 func TestStepDiscoverGenerateApproveGoesResult(t *testing.T) {
@@ -606,7 +606,7 @@ func TestStepAppliesVerification(t *testing.T) {
 			wantPhase: PhaseBuild, wantEvents: []string{"mission.retry"},
 		},
 		{
-			name:  "phase_complete marks a passing unit harness-passed and stays in generate while a unit is pending (D-096)",
+			name:  "phase_complete marks a passing unit harness-passed and stays in build while a unit is pending (D-096)",
 			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
 			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
@@ -757,7 +757,7 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 
 // TestStepDiscoverGenerateStallNeverReplans mirrors
 // TestStepLightStallNeverReplans for flow=discover_build (D-090,
-// issue #459): its generate turn never visits PhasePlan either, so the
+// issue #459): its build turn never visits PhasePlan either, so the
 // same replan-skip must apply.
 func TestStepDiscoverGenerateStallNeverReplans(t *testing.T) {
 	got := Step(
@@ -791,7 +791,7 @@ func TestParsePhase(t *testing.T) {
 // TestParsePhaseLegacyMapping is the table test for legacy phase name
 // tolerance: a row (or historical mission_events payload) still
 // carrying a pre-rename value (slice 1's explore/execute/review, or
-// #611's generate) must parse to its current equivalent, so a new
+// #611's build) must parse to its current equivalent, so a new
 // binary reads old rows correctly before the data migration in
 // scripts/pending-alters.md runs, and old event history keeps
 // displaying after a rollback.
@@ -930,7 +930,7 @@ func TestStepAskUserParksWithoutEvent(t *testing.T) {
 		t.Fatalf("Status = %s, want waiting_for_input", got.Next.Status)
 	}
 	if got.Next.Phase != PhaseBuild {
-		t.Fatalf("Phase = %s, want generate (unchanged)", got.Next.Phase)
+		t.Fatalf("Phase = %s, want build (unchanged)", got.Next.Phase)
 	}
 	if len(got.Events) != 0 {
 		t.Fatalf("Events = %+v, want none: the store already recorded mission.input_requested", got.Events)
@@ -979,7 +979,7 @@ func TestStepReworkAssignsFindingIDsInOrder(t *testing.T) {
 		t.Fatalf("ReviewFindings = %+v, want %+v", got.Next.ReviewFindings, want)
 	}
 	if got.Next.ReworkRounds != 1 || got.Next.Phase != PhaseBuild || got.Next.Status != StatusIdle {
-		t.Fatalf("Next = %+v, want rework round 1 back in generate/idle", got.Next)
+		t.Fatalf("Next = %+v, want rework round 1 back in build/idle", got.Next)
 	}
 	ev := eventOfKind(got.Events, "mission.review_verdict")
 	if ev == nil || !reflect.DeepEqual(ev.Payload["open"], []string{"F1", "F2"}) || ev.Payload["round"] != 1 {
@@ -1087,7 +1087,7 @@ func TestStepPhaseCompleteKeepsReworkRounds(t *testing.T) {
 }
 
 // TestStepPhaseCompleteRoutesOnPendingUnits pins the D-096 routing: a
-// generate completion stays in generate (counters reset, next unit
+// build completion stays in build (counters reset, next unit
 // named) while any unit lacks harness evidence and nothing is open,
 // enters prove once every unit is harness-passed, and enters prove
 // regardless when a finding is open (a rework must be re-reviewed).
@@ -1100,14 +1100,14 @@ func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
 		StepInput{Input: InputPhaseComplete}, DefaultConfig,
 	)
 	if pending.Next.Phase != PhaseBuild || pending.Next.Status != StatusIdle || pending.Next.Iteration != 0 || pending.Next.ConsecutiveFailures != 0 {
-		t.Fatalf("Next = %+v, want generate/idle with counters reset", pending.Next)
+		t.Fatalf("Next = %+v, want build/idle with counters reset", pending.Next)
 	}
 	ev := eventOfKind(pending.Events, "mission.generate_continued")
 	if ev == nil || ev.Payload["next_unit"] != 1 || ev.Payload["pending_units"] != 2 {
 		t.Fatalf("events = %+v, want generate_continued naming unit 1 with 2 pending", pending.Events)
 	}
 	if eventOfKind(pending.Events, "mission.phase_started") != nil {
-		t.Fatal("staying in generate must not emit phase_started")
+		t.Fatal("staying in build must not emit phase_started")
 	}
 
 	allPassed := Step(
@@ -1199,7 +1199,7 @@ func TestStepPhaseCompleteScoresUntouchedFindings(t *testing.T) {
 }
 
 // TestStepReworkParksExhaustedWithIDsInDetail: the third rework at the
-// default ceiling parks (never fails), in generate, naming every open
+// default ceiling parks (never fails), in build, naming every open
 // finding by id and title.
 func TestStepReworkParksExhaustedWithIDsInDetail(t *testing.T) {
 	got := Step(
@@ -1210,7 +1210,7 @@ func TestStepReworkParksExhaustedWithIDsInDetail(t *testing.T) {
 		DefaultConfig,
 	)
 	if got.Next.Phase != PhaseBuild || got.Next.Status != StatusPaused || got.Next.PauseReason != PauseReviewExhausted {
-		t.Fatalf("Next = %+v, want paused review_exhausted in generate", got.Next)
+		t.Fatalf("Next = %+v, want paused review_exhausted in build", got.Next)
 	}
 	if got.Next.ReworkRounds != 3 {
 		t.Fatalf("ReworkRounds = %d, want 3", got.Next.ReworkRounds)
@@ -1241,7 +1241,7 @@ func TestStepReworkStallsOnUntouchedFile(t *testing.T) {
 		DefaultConfig,
 	)
 	if stalled.Next.Phase != PhaseBuild || stalled.Next.PauseReason != PauseNoProgress {
-		t.Fatalf("Next = %+v, want paused no_progress in generate", stalled.Next)
+		t.Fatalf("Next = %+v, want paused no_progress in build", stalled.Next)
 	}
 	ev := eventOfKind(stalled.Events, "mission.paused")
 	if ev == nil || !reflect.DeepEqual(ev.Payload["findings"], []string{"F1"}) {

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -142,7 +142,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
-	m.Flow = Flow(flow)
+	m.Flow = parseFlow(flow)
 	scanReviewFindings(&m, reviewFindingsRaw)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	_ = json.Unmarshal(destinationsRaw, &m.Destinations)
@@ -228,7 +228,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan); err != nil {
 		return Mission{}, err
 	}
-	m.Flow = Flow(flow)
+	m.Flow = parseFlow(flow)
 	scanReviewFindings(&m, reviewFindingsRaw)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	_ = json.Unmarshal(destinationsRaw, &m.Destinations)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -517,7 +517,7 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 	if m.Flow != FlowLight {
 		t.Fatalf("Flow = %q, want %q", m.Flow, FlowLight)
 	}
-	if m.Phase != PhaseGenerate {
+	if m.Phase != PhaseBuild {
 		t.Fatalf("Phase = %q, want execute for a light mission at create", m.Phase)
 	}
 	if m.FinalOutput != "" {
@@ -801,7 +801,7 @@ func TestReviewFindingsRoundTrip(t *testing.T) {
 		{ID: "F2", Unit: 0, Title: "typo", Severity: SeverityMinor, Status: FindingResolved, RoundOpened: 1},
 	}
 	if err := s.ApplyTransition(ctx, id, Transition{
-		Next: StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 3, ReviewFindings: findings, ReworkRounds: 2},
+		Next: StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 3, ReviewFindings: findings, ReworkRounds: 2},
 	}); err != nil {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
@@ -839,7 +839,7 @@ func TestApplyTransitionPersistsLastReviewCommit(t *testing.T) {
 	units := []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, HarnessPassed: true}}
 	reviewAt := time.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC)
 	if err := s.ApplyTransition(ctx, id, Transition{
-		Next: StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 3, Units: units, LastReviewCommit: "abc123", LastReviewAt: reviewAt, ReworkRounds: 1},
+		Next: StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 3, Units: units, LastReviewCommit: "abc123", LastReviewAt: reviewAt, ReworkRounds: 1},
 	}); err != nil {
 		t.Fatalf("ApplyTransition with review commit: %v", err)
 	}
@@ -902,7 +902,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 
 	// Turn 1: unit 0 passes on harness evidence.
 	passed := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: plan.Units},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: plan.Units},
 		StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 		DefaultConfig,
 	)
@@ -922,7 +922,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 
 	// Turn 2: unit 0 regresses while unit 1 passes.
 	regressed := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: m.Plan.Units},
+		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: m.Plan.Units},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "regression:unit_0", Verified: []UnitVerification{
 			{Unit: 0, Check: "artifacts", Excerpt: "a.md: not found"}, {Unit: 1, Passed: true, Check: "artifacts"},
 		}},
@@ -999,7 +999,7 @@ func TestPlanApprovalParkRoundTrip(t *testing.T) {
 	}
 
 	if err := s.ApplyTransition(ctx, id, Transition{
-		Next:   StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8},
+		Next:   StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8},
 		Events: []EventDraft{{Kind: "mission.plan_approved", Payload: map[string]any{}}},
 	}); err != nil {
 		t.Fatalf("ApplyTransition (approve): %v", err)
@@ -1008,7 +1008,7 @@ func TestPlanApprovalParkRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get after approve: %v", err)
 	}
-	if approved.Phase != PhaseGenerate || approved.Status != StatusIdle || approved.PauseReason != "" {
+	if approved.Phase != PhaseBuild || approved.Status != StatusIdle || approved.PauseReason != "" {
 		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", approved.Phase, approved.Status, approved.PauseReason)
 	}
 }
@@ -1031,7 +1031,7 @@ func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
 	}
 
 	// Non-terminal transition must NOT clear it: only a terminal one.
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8}}); err != nil {
 		t.Fatalf("ApplyTransition (non-terminal): %v", err)
 	}
 	m, err := s.Get(ctx, id)
@@ -1081,8 +1081,8 @@ func TestApplyTransitionRejectsWriteOnTerminalMission(t *testing.T) {
 	// A stale in-flight turn's transition arrives after cancel already
 	// landed: must be rejected, not written over the terminal row.
 	err = s.ApplyTransition(ctx, id, Transition{
-		Next:   StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8},
-		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "generate"}}},
+		Next:   StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "build"}}},
 	})
 	if !errors.Is(err, ErrTerminal) {
 		t.Fatalf("ApplyTransition (stale turn) err = %v, want ErrTerminal", err)
@@ -1129,8 +1129,8 @@ func TestApplyTransitionRejectsWriteOnUnrecognizedPhase(t *testing.T) {
 	}
 
 	err = s.ApplyTransition(ctx, id, Transition{
-		Next:   StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8},
-		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "generate"}}},
+		Next:   StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "build"}}},
 	})
 	if !errors.Is(err, ErrTerminal) {
 		t.Fatalf("ApplyTransition (unrecognized phase) err = %v, want ErrTerminal", err)
@@ -1422,7 +1422,7 @@ func TestRecoverWorking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create working: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, workingID, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, workingID, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition working: %v", err)
 	}
 
@@ -1450,7 +1450,7 @@ func TestRecoverStaleWorking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create fresh: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, freshID, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, freshID, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition fresh: %v", err)
 	}
 
@@ -1458,7 +1458,7 @@ func TestRecoverStaleWorking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create stale: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, staleID, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, staleID, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition stale: %v", err)
 	}
 	db, err := s.db.Get()
@@ -1517,7 +1517,7 @@ func workingBackdated(t *testing.T, s *Store, goal string) string {
 	if err != nil {
 		t.Fatalf("Create %s: %v", goal, err)
 	}
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition %s: %v", goal, err)
 	}
 	db, err := s.db.Get()
@@ -1540,7 +1540,7 @@ func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {
 	}
 	pauseBackoff := func() {
 		if err := s.ApplyTransition(ctx, backoffID, Transition{
-			Next:   StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseBackoff},
+			Next:   StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff},
 			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff)}}},
 		}); err != nil {
 			t.Fatalf("ApplyTransition pause backoff: %v", err)
@@ -1553,7 +1553,7 @@ func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {
 		t.Fatalf("Create infra: %v", err)
 	}
 	if err := s.ApplyTransition(ctx, infraID, Transition{
-		Next:   StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseInfra},
+		Next:   StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseInfra},
 		Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra)}}},
 	}); err != nil {
 		t.Fatalf("ApplyTransition pause infra: %v", err)
@@ -1583,7 +1583,7 @@ func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {
 	}
 
 	// Resume, then pause for backoff again: count must accumulate.
-	if err := s.ApplyTransition(ctx, backoffID, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusIdle}}); err != nil {
+	if err := s.ApplyTransition(ctx, backoffID, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusIdle}}); err != nil {
 		t.Fatalf("ApplyTransition resume: %v", err)
 	}
 	pauseBackoff()
@@ -1702,7 +1702,7 @@ func TestPendingPermissionsAndResolveTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition working: %v", err)
 	}
 	if err := s.SetPendingPermission(ctx, id, "perm-timeout-1", "shell", `{"command":"rm -rf x"}`, "destructive", "deletes files"); err != nil {
@@ -1788,18 +1788,18 @@ func TestAskUserParkAnswerRoundTripCarriesQAIntoNextTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition working: %v", err)
 	}
 
 	input := PendingInput{
 		Question: "which runtime should this target?", Kind: "mcq",
-		Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseGenerate,
+		Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseBuild,
 	}
 	if err := s.SetPendingInput(ctx, id, input); err != nil {
 		t.Fatalf("SetPendingInput: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWaitingForInput}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWaitingForInput}}); err != nil {
 		t.Fatalf("ApplyTransition waiting_for_input: %v", err)
 	}
 
@@ -1903,7 +1903,7 @@ func TestSweepPermissionTimeoutsAutoDeniesAndResumes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseBuild, Status: StatusWorking}}); err != nil {
 		t.Fatalf("ApplyTransition working: %v", err)
 	}
 	if err := s.SetPendingPermission(ctx, id, "perm-sweep-1", "shell", `{"command":"rm -rf x"}`, "destructive", "deletes files"); err != nil {

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -964,7 +964,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 // state, not in-memory only: a mission created with auto_approve_plan
 // false, parked on PauseApproval via ApplyTransition, survives a fresh
 // Get exactly as parked (same as a process restart would see), then
-// the approve verb's own transition unparks it to generate.
+// the approve verb's own transition unparks it to build.
 func TestPlanApprovalParkRoundTrip(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
@@ -1009,7 +1009,7 @@ func TestPlanApprovalParkRoundTrip(t *testing.T) {
 		t.Fatalf("Get after approve: %v", err)
 	}
 	if approved.Phase != PhaseBuild || approved.Status != StatusIdle || approved.PauseReason != "" {
-		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", approved.Phase, approved.Status, approved.PauseReason)
+		t.Fatalf("mission after approve = %s/%s/%s, want build/idle/<none>", approved.Phase, approved.Status, approved.PauseReason)
 	}
 }
 

--- a/internal/brain/missions/store_test.go
+++ b/internal/brain/missions/store_test.go
@@ -13,8 +13,8 @@ func TestScanPendingInput(t *testing.T) {
 		{name: "nil leaves PendingInput nil", raw: nil, want: nil},
 		{
 			name: "populated unmarshals",
-			raw:  []byte(`{"question":"which runtime?","kind":"mcq","options":["node","python"],"proposed_default":"node","phase":"generate"}`),
-			want: &PendingInput{Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseGenerate},
+			raw:  []byte(`{"question":"which runtime?","kind":"mcq","options":["node","python"],"proposed_default":"node","phase":"build"}`),
+			want: &PendingInput{Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseBuild},
 		},
 		{name: "invalid json leaves PendingInput nil", raw: []byte(`not json`), want: nil},
 	}

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -217,16 +217,16 @@ func TestValidateCreate(t *testing.T) {
 			m.Flow = FlowNoProve
 			return m
 		}, ValidateDeps{}, false},
-		{"discover_generate on general accepted", func(m Mission) Mission {
-			m.Flow = FlowDiscoverGenerate
+		{"discover_build on general accepted", func(m Mission) Mission {
+			m.Flow = FlowDiscoverBuild
 			return m
 		}, ValidateDeps{}, false},
 		{"no_prove on coding rejected", func(m Mission) Mission {
 			m.Kind, m.Flow = "coding", FlowNoProve
 			return m
 		}, ValidateDeps{}, true},
-		{"discover_generate on coding rejected", func(m Mission) Mission {
-			m.Kind, m.Flow = "coding", FlowDiscoverGenerate
+		{"discover_build on coding rejected", func(m Mission) Mission {
+			m.Kind, m.Flow = "coding", FlowDiscoverBuild
 			return m
 		}, ValidateDeps{}, true},
 	}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -540,7 +540,7 @@ CREATE TABLE IF NOT EXISTS workflow_run_events (
 -- Missions are long-running, agent-driven units of work distinct from
 -- chat sessions: a mission survives across many model turns, tracks a
 -- plan and progress log, and drives itself through a fixed phase
--- pipeline (discover -> plan -> generate -> prove -> result ->
+-- pipeline (discover -> plan -> build -> prove -> result ->
 -- done|failed) under a state machine (internal/brain/missions).
 --
 -- phase and status are deliberately NOT CHECK-constrained. A future
@@ -594,14 +594,14 @@ CREATE TABLE IF NOT EXISTS missions (
     budget_amount         numeric(12,2),
     -- Currency budget_amount is denominated in.
     budget_currency       char(3) NOT NULL DEFAULT 'USD',
-    -- Model route worker/generate turns run on.
+    -- Model route worker/build turns run on.
     route                 text NOT NULL DEFAULT '',
     -- Model route the prove phase's reviewer runs on; '' falls back
     -- through plan_route to route (runner.go's reviewRoute).
     review_route          text NOT NULL DEFAULT '',
     -- PlanRoute, when set, is the route oversight phases (discover, plan,
-    -- replan) run on instead of route -- "GLM plans, local generates":
-    -- worker/generate turns keep running on route while oversight runs on
+    -- replan) run on instead of route -- "GLM plans, local builds":
+    -- worker/build turns keep running on route while oversight runs on
     -- a stronger model. '' (the default) means route covers everything,
     -- exact prior behavior. review_route still overrides for prove
     -- specifically: precedence there is review_route > plan_route >
@@ -612,7 +612,7 @@ CREATE TABLE IF NOT EXISTS missions (
     -- otherwise resolve, as "provider name/model" (router.go's
     -- splitProviderModelHint) -- '' means today's first-usable walk.
     -- Precedence mirrors the route helpers exactly: route_model backs
-    -- generate (workerRoute), plan_route_model backs discover/plan
+    -- build (workerRoute), plan_route_model backs discover/plan
     -- (oversightRoute), review_route_model falls back review_route_model
     -- > plan_route_model > route_model (runner.go's reviewRouteModel).
     -- Escalation is never pinned: it is a failure-path fallback and a
@@ -703,7 +703,7 @@ CREATE TABLE IF NOT EXISTS missions (
     -- classified commands still always ask, unaffected by this column
     -- or any grant.
     auto_approve_tools    boolean NOT NULL DEFAULT true,
-    -- D-087 (issue #456): true (default) advances plan -> generate the
+    -- D-087 (issue #456): true (default) advances plan -> build the
     -- moment a plan lands, byte-identical to every mission before this
     -- column existed. false parks the mission on pause_reason='approval'
     -- instead, waiting for an operator approve/replan/rediscover verb --
@@ -715,7 +715,7 @@ CREATE TABLE IF NOT EXISTS missions (
     -- mission never touches tracked files -- its diff is
     -- always empty, so the reviewer previously had zero evidence to
     -- judge and rejected every round. This carries the worker's own
-    -- mission_status evidence text forward from generate to prove,
+    -- mission_status evidence text forward from build to prove,
     -- alongside (not instead of) the diff for coding missions.
     last_evidence         text NOT NULL DEFAULT '',
     -- The discover phase's findings, carried into the plan phase's
@@ -796,17 +796,17 @@ CREATE TABLE IF NOT EXISTS missions (
     asks_used              integer NOT NULL DEFAULT 0,
     -- D-090 (issue #459): the phase set this mission runs, chosen once
     -- at create time and never model-mutable. 'full' is
-    -- discover->plan->generate->prove->result (the pre-#459 default);
-    -- 'discover_generate' skips plan (generate runs planless, same as
+    -- discover->plan->build->prove->result (the pre-#459 default);
+    -- 'discover_build' skips plan (build runs planless, same as
     -- light) and prove; 'no_prove' keeps plan but skips the LLM
-    -- reviewer round (harness CheckArtifacts still runs on generate's
+    -- reviewer round (harness CheckArtifacts still runs on build's
     -- exit); 'light' is the existing D-069 behavior (general kind only:
-    -- born in phase=generate, one bare worker turn, the final worker
+    -- born in phase=build, one bare worker turn, the final worker
     -- message is the deliverable). flow is the single source of truth
     -- for D-069 code paths (issue #479 dropped the redundant light
     -- column).
     flow                  text NOT NULL DEFAULT 'full'
-        CHECK (flow IN ('full', 'discover_generate', 'no_prove', 'light')),
+        CHECK (flow IN ('full', 'discover_build', 'no_prove', 'light')),
     -- has_plan (D-102, issue #496): the goal already carries the
     -- operator's own plan, so the plan turn transcribes it into units
     -- instead of designing one from scratch. false (default) is

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -4,4 +4,33 @@ Additive schema changes not yet applied to any live database. Safe to
 run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
-(none)
+## Generate -> Build phase rename (issue #611)
+
+The worker phase is now `build`. Code reads both spellings
+(`parsePhase`, `parseFlow`), so this is safe to run before or after the
+deploy; it exists so stored rows match the new vocabulary rather than
+relying on the read-time alias forever.
+
+Order matters: `missions.flow`'s CHECK constraint is dropped first, the
+rows are rewritten, and only then is the new constraint added. Adding
+it earlier fails, since Postgres validates a new CHECK against every
+existing row immediately and the old `discover_generate` values are not
+in the new list.
+
+```sql
+BEGIN;
+
+ALTER TABLE missions DROP CONSTRAINT missions_flow_check;
+
+UPDATE missions SET phase = 'build' WHERE phase = 'generate';
+UPDATE missions SET flow = 'discover_build' WHERE flow = 'discover_generate';
+
+ALTER TABLE missions ADD CONSTRAINT missions_flow_check
+    CHECK (flow IN ('full', 'discover_build', 'no_prove', 'light'));
+
+COMMIT;
+```
+
+`mission_events` is append-only and is deliberately left alone: its
+historical rows keep whatever phase string they were written with, and
+`parsePhase` translates them on read.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1275,11 +1275,11 @@ export interface CreateMissionInput {
   // flow selects the phase set this mission runs (D-090): omit (or "")
   // maps to "light" when light is true, else "full", the pre-#459
   // default. "no_prove" keeps discover/plan but skips only the LLM
-  // reviewer. "discover_generate" is a true planless flow: discover
+  // reviewer. "discover_build" is a true planless flow: discover
   // runs, then a single planless generate pass (no plan, no review),
   // same worker behavior as light. Only "full" is valid when
   // kind === 'coding'.
-  flow?: 'full' | 'discover_generate' | 'no_prove' | 'light'
+  flow?: 'full' | 'discover_build' | 'no_prove' | 'light'
   // has_plan (D-102, issue #496) marks a goal that already carries the
   // operator's own plan: the plan turn transcribes it into units
   // instead of designing one from scratch. Omit (or false) for the

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1224,7 +1224,7 @@ export interface CreateMissionInput {
   budget_currency?: string
   auto_approve_tools?: boolean
   // auto_approve_plan: omit (or true) advances straight from plan to
-  // generate; false parks the mission awaiting operator approval once
+  // build; false parks the mission awaiting operator approval once
   // the plan phase produces a plan.
   auto_approve_plan?: boolean
   // harness names the delegated coding-CLI executor a coding mission
@@ -1276,7 +1276,7 @@ export interface CreateMissionInput {
   // maps to "light" when light is true, else "full", the pre-#459
   // default. "no_prove" keeps discover/plan but skips only the LLM
   // reviewer. "discover_build" is a true planless flow: discover
-  // runs, then a single planless generate pass (no plan, no review),
+  // runs, then a single planless build pass (no plan, no review),
   // same worker behavior as light. Only "full" is valid when
   // kind === 'coding'.
   flow?: 'full' | 'discover_build' | 'no_prove' | 'light'
@@ -1311,7 +1311,7 @@ export async function getMissionExecutorOptions(route?: string): Promise<Executo
 }
 
 // getMissionExecutionPlan resolves all five mission phases (discover,
-// plan, generate, prove, escalate) server-side for the given create
+// plan, build, prove, escalate) server-side for the given create
 // inputs, so the frontend never mirrors route/harness precedence
 // itself. Params match the create form's own fields; all optional.
 export async function getMissionExecutionPlan(params: {
@@ -1440,7 +1440,7 @@ export async function answerMissionPermission(
 }
 
 // approveMissionPlan approves a mission parked on plan approval
-// (pause_reason: "approval"): the mission moves to phase=generate.
+// (pause_reason: "approval"): the mission moves to phase=build.
 export async function approveMissionPlan(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/approve-plan`, { method: 'POST' })
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -738,7 +738,7 @@ export interface Mission {
   // generate -> prove -> result -> done|failed. explore/execute/review
   // are the pre-rename names, still possible on a mission whose row
   // predates the data migration in scripts/pending-alters.md.
-  phase: 'discover' | 'plan' | 'generate' | 'prove' | 'result' | 'done' | 'failed' | 'explore' | 'execute' | 'review'
+  phase: 'discover' | 'plan' | 'build' | 'prove' | 'result' | 'done' | 'failed' | 'explore' | 'execute' | 'review' | 'generate'
   status: 'idle' | 'working' | 'waiting_for_input' | 'paused' | 'done' | 'error'
   // failure_reason is derived server-side (Store.List/Get) from this
   // mission's latest mission.failed event's payload.reason:
@@ -862,7 +862,7 @@ export interface Mission {
   // final_output is that worker's verbatim final message: the
   // deliverable itself, absent/empty until the mission reaches done.
   // Invariant: final_output is only ever populated when light is true
-  // OR flow is "discover_generate" (D-090, issue #459: also planless);
+  // OR flow is "discover_build" (D-090, issue #459: also planless);
   // any other mission's Result comes from last_evidence instead (see
   // MissionDetail.tsx's runsPlanless helper picking the Result field).
   light?: boolean
@@ -870,11 +870,11 @@ export interface Mission {
   // once at create time and never model-mutable: "full" is discover ->
   // plan -> generate -> prove -> result (the pre-#459 default);
   // "no_prove" keeps discover/plan but skips only the LLM reviewer;
-  // "discover_generate" is a true planless flow, discover -> generate
+  // "discover_build" is a true planless flow, discover -> build
   // -> result (no plan, no review, the worker's final message is the
   // deliverable, same worker behavior as light); "light" is the
   // existing D-069 behavior, always paired with light: true.
-  flow?: 'full' | 'discover_generate' | 'no_prove' | 'light'
+  flow?: 'full' | 'discover_build' | 'no_prove' | 'light'
   // has_plan (D-102, issue #496) marks a mission whose goal already
   // carried the operator's own plan: the plan turn ran in transcribe
   // mode instead of designing units from scratch.
@@ -981,7 +981,7 @@ export interface ExecutorSpawnedPayload {
   model: string
   auth_mode: string
   run_id: string
-  // phase (issue #582) is 'generate' for a worker run and 'prove' for
+  // phase (issue #582) is 'build' for a worker run and 'prove' for
   // a delegated review run; absent on events recorded before it existed
   // (always worker runs).
   phase?: string

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -722,7 +722,7 @@ export interface ReviewFinding {
 }
 
 // Mission is one long-running, agent-driven unit of work
-// (internal/brain/missions): discover -> plan -> generate -> prove ->
+// (internal/brain/missions): discover -> plan -> build -> prove ->
 // result under a state machine.
 export interface Mission {
   id: string
@@ -735,7 +735,7 @@ export interface Mission {
   kind: 'coding' | 'general'
   agent_id?: string
   // Mission phase pipeline (D-086, issue #455): discover -> plan ->
-  // generate -> prove -> result -> done|failed. explore/execute/review
+  // build -> prove -> result -> done|failed. explore/execute/review/generate
   // are the pre-rename names, still possible on a mission whose row
   // predates the data migration in scripts/pending-alters.md.
   phase: 'discover' | 'plan' | 'build' | 'prove' | 'result' | 'done' | 'failed' | 'explore' | 'execute' | 'review' | 'generate'
@@ -792,7 +792,7 @@ export interface Mission {
   // route_model/plan_route_model/review_route_model pin one phase axis
   // to one exact chain entry ("provider name/model") in the route it
   // would otherwise resolve: "" or absent keeps the first-usable walk.
-  // Precedence mirrors the route fields: route_model backs generate,
+  // Precedence mirrors the route fields: route_model backs build,
   // plan_route_model backs discover/plan, review_route_model falls back
   // review_route_model > plan_route_model > route_model.
   route_model?: string
@@ -825,7 +825,7 @@ export interface Mission {
   last_evidence?: string
   auto_approve_tools: boolean
   // auto_approve_plan: true (default) advances straight from plan to
-  // generate; false parks the mission (status: "paused", pause_reason:
+  // build; false parks the mission (status: "paused", pause_reason:
   // "approval") once the plan phase produces a plan, until an operator
   // approves, replans, or sends it back to discover.
   auto_approve_plan: boolean
@@ -858,7 +858,7 @@ export interface Mission {
   // never sent over the wire (see api/missions.go's sanitizeMission).
   attachments?: { id: string; mime: string; name?: string }[]
   // light marks a mission that skips discover/plan/prove (D-069):
-  // kind=general only, born in phase=generate, one bare worker turn.
+  // kind=general only, born in phase=build, one bare worker turn.
   // final_output is that worker's verbatim final message: the
   // deliverable itself, absent/empty until the mission reaches done.
   // Invariant: final_output is only ever populated when light is true

--- a/web/src/components/missions/MissionCard.test.tsx
+++ b/web/src/components/missions/MissionCard.test.tsx
@@ -10,7 +10,7 @@ const baseMission: Mission = {
   id: 'm1',
   goal: 'Fix the login bug on the staging server before Friday',
   kind: 'general',
-  phase: 'generate',
+  phase: 'build',
   status: 'working',
   plan: { units: [] },
   progress: [],
@@ -56,7 +56,7 @@ describe('MissionCard name fallback', () => {
 
 describe('MissionCard status pill', () => {
   it('shows the raw status for a non-terminal mission', () => {
-    renderCard({ ...baseMission, status: 'working', phase: 'generate' })
+    renderCard({ ...baseMission, status: 'working', phase: 'build' })
     expect(screen.getByText('working')).toBeInTheDocument()
   })
 
@@ -139,7 +139,7 @@ describe('MissionCard needs-answer badge', () => {
         kind: 'open',
         proposed_default: 'staging',
         asked_at: '2026-01-01T00:00:00Z',
-        phase: 'generate',
+        phase: 'build',
       },
     })
     expect(screen.getByText('needs answer')).toBeInTheDocument()
@@ -153,8 +153,8 @@ describe('MissionCard needs-answer badge', () => {
 
 describe('MissionCard phase step text', () => {
   it('shows the phase step for a non-terminal mission', () => {
-    renderCard({ ...baseMission, phase: 'generate' })
-    expect(screen.getByText('Generate · 3 of 5')).toBeInTheDocument()
+    renderCard({ ...baseMission, phase: 'build' })
+    expect(screen.getByText('Build · 3 of 5')).toBeInTheDocument()
   })
 
   it('drops the phase text once the mission is terminal, leaving the badge to say so', () => {
@@ -222,12 +222,12 @@ describe('MissionCard removed fields', () => {
   it('never renders retries, unit progress, or the raw phase text', () => {
     renderCard({
       ...baseMission,
-      phase: 'generate',
+      phase: 'build',
       iteration: 3,
       plan: { units: [{ title: 'a', verify_cmd: '', passes: true }, { title: 'b', verify_cmd: '', passes: false }] },
     })
     expect(screen.queryByText(/Retries/)).not.toBeInTheDocument()
     expect(screen.queryByText(/\d+\/\d+ units/)).not.toBeInTheDocument()
-    expect(screen.queryByText('generate')).not.toBeInTheDocument()
+    expect(screen.queryByText('build')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/missions/MissionExecutionPlan.tsx
+++ b/web/src/components/missions/MissionExecutionPlan.tsx
@@ -19,12 +19,12 @@ function pinValue(entry: ExecutionPlanEntry): string {
 const phaseLabels: Record<string, string> = {
   discover: 'Discover',
   plan: 'Plan',
-  generate: 'Generate',
+  build: 'Build',
   prove: 'Prove',
   escalate: 'Escalate',
 }
 
-const phaseOrder = ['discover', 'plan', 'generate', 'prove', 'escalate']
+const phaseOrder = ['discover', 'plan', 'build', 'prove', 'escalate']
 
 // routeSourceLabels renders each provenance value human-readable, in
 // parentheses next to the route name. 'off'/'none' render nothing —
@@ -35,7 +35,7 @@ const routeSourceLabels: Record<string, string> = {
   'named-coding': 'coding route',
   'default-role': 'default route',
   'inherited-from-plan': 'same as plan route',
-  'inherited-from-generate': 'same as generate route',
+  'inherited-from-build': 'same as build route',
 }
 
 function routeLabel(phase: ExecutionPlanPhase): string | null {
@@ -64,7 +64,7 @@ function priceLabel(phase: ExecutionPlanPhase): string | null {
 }
 
 // modelPinFor/onModelPinChangeFor map a phase key to the pin state that
-// backs it: generate uses route_model, discover/plan use plan_route_model
+// backs it: build uses route_model, discover/plan use plan_route_model
 // (they share oversightRoute), prove uses review_route_model. Escalate
 // is never pinned — it's a failure-path fallback (runner.go's
 // workerModel clears route_model once escalated), so it gets no select.
@@ -73,7 +73,7 @@ function modelPinFor(phaseKey: string, props: MissionExecutionPlanProps): string
     case 'discover':
     case 'plan':
       return props.planRouteModel ?? ''
-    case 'generate':
+    case 'build':
       return props.routeModel ?? ''
     case 'prove':
       return props.reviewRouteModel ?? ''
@@ -90,7 +90,7 @@ function onModelPinChangeFor(
     case 'discover':
     case 'plan':
       return props.onPlanRouteModelChange ?? null
-    case 'generate':
+    case 'build':
       return props.onRouteModelChange ?? null
     case 'prove':
       return props.onReviewRouteModelChange ?? null

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1501,7 +1501,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
 })
 
 describe('MissionForm: plan route', () => {
-  it('renders the Plan route select in Advanced, defaulted to "Same as generate route"', async () => {
+  it('renders the Plan route select in Advanced, defaulted to "Same as build route"', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
@@ -1509,7 +1509,7 @@ describe('MissionForm: plan route', () => {
     await screen.findByLabelText('Review route')
 
     expect(screen.getByLabelText('Plan route')).toBeInTheDocument()
-    expect(screen.getByLabelText('Plan route')).toHaveTextContent('Same as generate route')
+    expect(screen.getByLabelText('Plan route')).toHaveTextContent('Same as build route')
   })
 
   it('submits plan_route when a route other than the default is picked', async () => {
@@ -1724,7 +1724,7 @@ const fivePhases: ExecutionPlanPhase[] = [
   }),
   makePhase({ phase: 'plan' }),
   makePhase({
-    phase: 'generate',
+    phase: 'build',
     axis: 'harness',
     harness: 'claude-cli',
     harness_source: 'settings',
@@ -1757,11 +1757,11 @@ describe('MissionForm: execution plan', () => {
     // No pin set on either phase: the select shows "Auto" naming the
     // entry the server marked selected.
     expect(screen.getByLabelText('Discover model')).toHaveTextContent('Autoglm-5.3')
-    expect(screen.getByLabelText('Generate model')).toHaveTextContent('Autosonnet-5')
+    expect(screen.getByLabelText('Build model')).toHaveTextContent('Autosonnet-5')
     fireEvent.click(screen.getByLabelText('Discover model'))
     expect(await screen.findByRole('option', { name: 'glm-5.3' })).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText('Discover model'))
-    fireEvent.click(screen.getByLabelText('Generate model'))
+    fireEvent.click(screen.getByLabelText('Build model'))
     expect(await screen.findByRole('option', { name: 'sonnet-5' })).toBeInTheDocument()
     expect(screen.getByText('$0.60/$2.20 per Mtok')).toBeInTheDocument()
     expect(screen.getByText('Naming and memory extraction use the summarize route.')).toBeInTheDocument()
@@ -1825,17 +1825,17 @@ describe('MissionForm: execution plan', () => {
     expect(screen.queryByText(/per Mtok/)).not.toBeInTheDocument()
   })
 
-  it('picking an entry in the generate model select submits route_model, and Auto omits it', async () => {
+  it('picking an entry in the build model select submits route_model, and Auto omits it', async () => {
     vi.mocked(getMissionExecutionPlan).mockResolvedValue(fivePhases)
     vi.mocked(createMission).mockResolvedValue({ id: 'm-pin' } as Mission)
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
-    await screen.findByLabelText('Generate model')
+    await screen.findByLabelText('Build model')
 
-    fireEvent.click(screen.getByLabelText('Generate model'))
+    fireEvent.click(screen.getByLabelText('Build model'))
     fireEvent.click(await screen.findByRole('option', { name: 'sonnet-5' }))
-    expect(screen.getByLabelText('Generate model')).toHaveTextContent('sonnet-5')
+    expect(screen.getByLabelText('Build model')).toHaveTextContent('sonnet-5')
 
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
     await waitFor(() =>
@@ -1851,7 +1851,7 @@ describe('MissionForm: execution plan', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
-    await screen.findByLabelText('Generate model')
+    await screen.findByLabelText('Build model')
 
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
     await waitFor(() =>
@@ -1864,20 +1864,20 @@ describe('MissionForm: execution plan', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
-    await screen.findByLabelText('Generate model')
+    await screen.findByLabelText('Build model')
 
-    fireEvent.click(screen.getByLabelText('Generate model'))
+    fireEvent.click(screen.getByLabelText('Build model'))
     fireEvent.click(await screen.findByRole('option', { name: 'sonnet-5' }))
-    expect(screen.getByLabelText('Generate model')).toHaveTextContent('sonnet-5')
+    expect(screen.getByLabelText('Build model')).toHaveTextContent('sonnet-5')
 
-    fireEvent.click(screen.getByLabelText('Generate model'))
+    fireEvent.click(screen.getByLabelText('Build model'))
     fireEvent.click(await screen.findByRole('option', { name: 'Autosonnet-5' }))
-    expect(screen.getByLabelText('Generate model')).toHaveTextContent('Autosonnet-5')
+    expect(screen.getByLabelText('Build model')).toHaveTextContent('Autosonnet-5')
   })
 
   it('shows live default labels for plan, prove, and escalation route selects', async () => {
     const plan = fivePhases.map((p) => {
-      if (p.phase === 'plan') return { ...p, route: 'coding', route_source: 'inherited-from-generate' }
+      if (p.phase === 'plan') return { ...p, route: 'coding', route_source: 'inherited-from-build' }
       if (p.phase === 'prove') return { ...p, route: 'coding', route_source: 'inherited-from-plan' }
       return p
     })
@@ -1889,7 +1889,7 @@ describe('MissionForm: execution plan', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
     await screen.findByLabelText('Review route')
 
-    expect(screen.getByLabelText('Plan route')).toHaveTextContent('Same as generate route (coding)')
+    expect(screen.getByLabelText('Plan route')).toHaveTextContent('Same as build route (coding)')
     expect(screen.getByLabelText('Review route')).toHaveTextContent('Same as plan route (coding)')
     expect(screen.getByLabelText('Escalation route')).toHaveTextContent(
       'Off (no escalation on failure)',

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -58,18 +58,18 @@ type Kind = 'coding' | 'general'
 // Flow selects the phase set a mission runs (D-090, issue #459); only
 // meaningful on kind=general (coding always stays 'full', enforced
 // server-side).
-type Flow = 'full' | 'discover_generate' | 'no_prove' | 'light'
+type Flow = 'full' | 'discover_build' | 'no_prove' | 'light'
 
 const flowChoices: { value: Flow; label: string; description: string }[] = [
-  { value: 'full', label: 'Full', description: 'Discover, plan, generate, review.' },
+  { value: 'full', label: 'Full', description: 'Discover, plan, build, review.' },
   {
     value: 'no_prove',
     label: 'No review',
     description: 'Discover and plan run, but the LLM reviewer is skipped.',
   },
   {
-    value: 'discover_generate',
-    label: 'Discover + generate',
+    value: 'discover_build',
+    label: 'Discover + build',
     description: 'Discovers first, then a single planless pass; the final message is the result.',
   },
   { value: 'light', label: 'Light', description: "Single pass; the worker's final message is the result." },
@@ -204,17 +204,17 @@ function defaultHarnessLabel(defaultHarnessName: string): string {
 // string before the plan has loaded.
 function defaultPlanRouteLabel(plan: ExecutionPlanPhase[] | null): string {
   const phase = plan?.find((p) => p.phase === 'plan')
-  if (!phase?.route) return 'Same as generate route'
-  return `Same as generate route (${phase.route})`
+  if (!phase?.route) return 'Same as build route'
+  return `Same as build route (${phase.route})`
 }
 
 // defaultReviewRouteLabel names what leaving Review route on
-// "Default" resolves to: either the plan or the generate route,
+// "Default" resolves to: either the plan or the build route,
 // whichever the prove phase actually inherited from.
 function defaultReviewRouteLabel(plan: ExecutionPlanPhase[] | null): string {
   const phase = plan?.find((p) => p.phase === 'prove')
-  if (!phase?.route) return 'Default (same as plan/generate route)'
-  const from = phase.route_source === 'inherited-from-generate' ? 'generate' : 'plan'
+  if (!phase?.route) return 'Default (same as plan/build route)'
+  const from = phase.route_source === 'inherited-from-build' ? 'build' : 'plan'
   return `Same as ${from} route (${phase.route})`
 }
 
@@ -1686,7 +1686,7 @@ export function MissionForm({
                     id="mission-plan-route"
                     value={planRoute}
                     onChange={(e) => setPlanRoute(e.target.value)}
-                    placeholder="Same as generate route"
+                    placeholder="Same as build route"
                   />
                 ) : (
                   <Select
@@ -1707,8 +1707,8 @@ export function MissionForm({
                   </Select>
                 )}
                 <p className="text-xs text-muted-foreground">
-                  Discover, plan, and prove run on this route instead of the generate route above,
-                  e.g. a strong model plans while a cheap/local route generates.
+                  Discover, plan, and prove run on this route instead of the build route above,
+                  e.g. a strong model plans while a cheap/local route builds.
                 </p>
               </div>
               {mode === 'create' && !repeat && (

--- a/web/src/components/missions/PhaseStepper.test.tsx
+++ b/web/src/components/missions/PhaseStepper.test.tsx
@@ -4,13 +4,19 @@ import { failedPhaseFromEvents, PhaseStepper, normalizePhase, phaseIndex, phaseS
 
 describe('normalizePhase', () => {
   it('passes current phase names through', () => {
-    expect(normalizePhase('generate')).toBe('generate')
+    expect(normalizePhase('build')).toBe('build')
   })
 
   it('maps legacy phase names', () => {
-    expect(normalizePhase('execute')).toBe('generate')
+    expect(normalizePhase('execute')).toBe('build')
     expect(normalizePhase('explore')).toBe('discover')
     expect(normalizePhase('review')).toBe('prove')
+  })
+
+  // Missions created before #611 stored 'generate'; those rows are
+  // append-only, so the mapping has to survive.
+  it('maps the pre-#611 generate name onto build', () => {
+    expect(normalizePhase('generate')).toBe('build')
   })
 
   it('passes terminal phases through', () => {
@@ -27,7 +33,7 @@ describe('phaseIndex', () => {
   it('indexes the five pipeline phases', () => {
     expect(phaseIndex('discover')).toBe(0)
     expect(phaseIndex('plan')).toBe(1)
-    expect(phaseIndex('generate')).toBe(2)
+    expect(phaseIndex('build')).toBe(2)
     expect(phaseIndex('prove')).toBe(3)
     expect(phaseIndex('result')).toBe(4)
   })
@@ -48,8 +54,8 @@ describe('phaseStepText', () => {
     expect(phaseStepText({ phase: 'prove' })).toBe('Prove · 4 of 5')
   })
 
-  it('renders light missions as "Generate · light"', () => {
-    expect(phaseStepText({ phase: 'generate', light: true })).toBe('Generate · light')
+  it('renders light missions as "Build · light"', () => {
+    expect(phaseStepText({ phase: 'build', light: true })).toBe('Build · light')
   })
 
   it('renders terminal phases as Done/Failed', () => {
@@ -64,8 +70,8 @@ describe('phaseStepText', () => {
 
 describe('PhaseStepper', () => {
   it('renders all five steps with the current one marked', () => {
-    render(<PhaseStepper phase="generate" />)
-    const current = screen.getByText('Generate').closest('span[aria-current="step"]')
+    render(<PhaseStepper phase="build" />)
+    const current = screen.getByText('Build').closest('span[aria-current="step"]')
     expect(current).not.toBeNull()
     expect(screen.getByText('Discover')).toBeInTheDocument()
     expect(screen.getByText('Result')).toBeInTheDocument()
@@ -73,7 +79,7 @@ describe('PhaseStepper', () => {
 
   it('marks completed steps with a check icon', () => {
     const { container } = render(<PhaseStepper phase="prove" />)
-    // discover, plan, generate are completed (3 checks); prove is current (no check)
+    // discover, plan, build are completed (3 checks); prove is current (no check)
     const checks = container.querySelectorAll('svg.lucide-check')
     expect(checks).toHaveLength(3)
     checks.forEach((c) => expect(c).toHaveClass('text-good'))
@@ -83,13 +89,13 @@ describe('PhaseStepper', () => {
     const { container } = render(<PhaseStepper phase="done" />)
     expect(screen.queryByText('Done')).not.toBeInTheDocument()
     expect(container.querySelectorAll('svg.lucide-check')).toHaveLength(5)
-    expect(screen.getAllByText(/Discover|Plan|Generate|Prove|Result/)).toHaveLength(5)
+    expect(screen.getAllByText(/Discover|Plan|Build|Prove|Result/)).toHaveLength(5)
   })
 
   it('marks the failed step with an X and checks the ones before it', () => {
-    const { container } = render(<PhaseStepper phase="failed" failedAt="generate" />)
+    const { container } = render(<PhaseStepper phase="failed" failedAt="build" />)
     expect(container.querySelectorAll('svg.lucide-check')).toHaveLength(2)
-    const failedStep = screen.getByText('Generate').closest('span')
+    const failedStep = screen.getByText('Build').closest('span')
     expect(failedStep).toHaveClass('text-destructive')
     expect(failedStep?.querySelector('svg.lucide-circle-x')).not.toBeNull()
     expect(screen.getByText('Prove').closest('span')).toHaveClass('text-muted-foreground')
@@ -105,26 +111,26 @@ describe('PhaseStepper', () => {
       created_at: '2026-01-01T00:00:00Z',
     })
     expect(failedPhaseFromEvents([])).toBe('discover')
-    expect(failedPhaseFromEvents([], true)).toBe('generate')
+    expect(failedPhaseFromEvents([], true)).toBe('build')
     expect(
       failedPhaseFromEvents([
         ev(1, 'mission.phase_started', { phase: 'plan' }),
         ev(2, 'mission.phase_started', { phase: 'execute' }),
         ev(3, 'mission.failed', { reason: 'cancelled' }),
       ]),
-    ).toBe('generate')
+    ).toBe('build')
   })
 
   it('renders failed phase with no completed steps', () => {
     const { container } = render(<PhaseStepper phase="failed" />)
     expect(screen.queryByText('Failed')).not.toBeInTheDocument()
     expect(container.querySelectorAll('svg.lucide-check')).toHaveLength(0)
-    expect(screen.getAllByText(/Discover|Plan|Generate|Prove|Result/)).toHaveLength(5)
+    expect(screen.getAllByText(/Discover|Plan|Build|Prove|Result/)).toHaveLength(5)
   })
 
-  it('renders a single Generate step with a light badge for light missions', () => {
-    render(<PhaseStepper phase="generate" light />)
-    expect(screen.getByText('Generate')).toBeInTheDocument()
+  it('renders a single Build step with a light badge for light missions', () => {
+    render(<PhaseStepper phase="build" light />)
+    expect(screen.getByText('Build')).toBeInTheDocument()
     expect(screen.getByText('light')).toBeInTheDocument()
     expect(screen.queryByText('Discover')).not.toBeInTheDocument()
   })
@@ -141,10 +147,10 @@ describe('PhaseStepper', () => {
 
     const failed = render(<PhaseStepper phase="failed" light />)
     expect(failed.container.querySelector('svg.lucide-circle-x')).not.toBeNull()
-    expect(screen.getByText('Generate').closest('span')).toHaveClass('text-destructive')
+    expect(screen.getByText('Build').closest('span')).toHaveClass('text-destructive')
     failed.unmount()
 
-    const running = render(<PhaseStepper phase="generate" light />)
+    const running = render(<PhaseStepper phase="build" light />)
     expect(running.container.querySelector('svg.lucide-check')).toBeNull()
     expect(running.container.querySelector('svg.lucide-circle-x')).toBeNull()
   })

--- a/web/src/components/missions/PhaseStepper.tsx
+++ b/web/src/components/missions/PhaseStepper.tsx
@@ -8,7 +8,7 @@ import { phaseLabel } from '@/lib/phaseColors'
 // Mission phase pipeline (D-086, issue #455), current names only:
 // normalizePhase maps the pre-rename ones (explore/execute/review)
 // onto these via phaseLabel before indexing.
-const missionPhases = ['discover', 'plan', 'generate', 'prove', 'result'] as const
+const missionPhases = ['discover', 'plan', 'build', 'prove', 'result'] as const
 export type MissionPhase = (typeof missionPhases)[number]
 
 // normalizePhase maps a raw mission phase string (current or legacy)
@@ -43,7 +43,7 @@ export function failedPhaseFromEvents(events: MissionEvent[], light?: boolean): 
       if (n !== 'done' && n !== 'failed') return n
     }
   }
-  return light ? 'generate' : 'discover'
+  return light ? 'build' : 'discover'
 }
 
 // phaseStepText renders the compact "Phase · n of 5" line used on
@@ -51,7 +51,7 @@ export function failedPhaseFromEvents(events: MissionEvent[], light?: boolean): 
 export function phaseStepText(mission: { phase: string; light?: boolean; flow?: string }): string {
   if (mission.phase === 'done') return 'Done'
   if (mission.phase === 'failed') return 'Failed'
-  if (mission.light) return 'Generate · light'
+  if (mission.light) return 'Build · light'
   const label = phaseLabel(mission.phase)
   const i = missionPhases.indexOf(label as MissionPhase)
   if (i < 0) return label
@@ -65,7 +65,7 @@ export function phaseStepText(mission: { phase: string; light?: boolean; flow?: 
 // the step it died in with an X (failedAt) so the reader sees how far
 // it got. The mission status itself lives in the page header badge. No hue per phase;
 // understandable without colour via icon, weight and aria-current.
-// Light missions collapse to a single "Generate" step.
+// Light missions collapse to a single "Build" step.
 export function PhaseStepper({
   phase,
   light,
@@ -87,7 +87,7 @@ export function PhaseStepper({
           <span className={cn('flex items-center gap-1.5 font-medium', lightFailed ? 'text-destructive' : 'text-foreground')}>
             {lightDone && <Check aria-hidden className="size-3.5 text-good" />}
             {lightFailed && <CircleX aria-hidden className="size-3.5" />}
-            Generate
+            Build
           </span>
           <Badge variant="secondary" size="sm">
             light

--- a/web/src/components/missions/PlanApprovalGate.tsx
+++ b/web/src/components/missions/PlanApprovalGate.tsx
@@ -10,7 +10,7 @@ import { PlanSection } from './PlanSection'
 // actually acted on the decision, so the card must not look
 // unanswered for that span.
 const answeredCopy: Record<'approve' | 'replan' | 'rediscover', string> = {
-  approve: 'Approved, moving to generate…',
+  approve: 'Approved, moving to build…',
   replan: 'Replan requested…',
   rediscover: 'Sending back to discover…',
 }

--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -109,7 +109,7 @@ const toolCallTraceEvents: MissionEvent[] = [
     mission_id: 'm1',
     seq: 1,
     kind: 'mission.tool_call',
-    payload: { phase: 'generate', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
+    payload: { phase: 'build', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
     provenance: 'harness',
     created_at: '2026-01-01T00:00:00Z',
   },
@@ -117,7 +117,7 @@ const toolCallTraceEvents: MissionEvent[] = [
     mission_id: 'm1',
     seq: 2,
     kind: 'mission.tool_call',
-    payload: { phase: 'generate', tool: 'shell', args_digest: '{"command":"ls"}', status: 'denied', duration_ms: 3 },
+    payload: { phase: 'build', tool: 'shell', args_digest: '{"command":"ls"}', status: 'denied', duration_ms: 3 },
     provenance: 'harness',
     created_at: '2026-01-01T00:00:01Z',
   },
@@ -125,7 +125,7 @@ const toolCallTraceEvents: MissionEvent[] = [
     mission_id: 'm1',
     seq: 3,
     kind: 'mission.tool_call',
-    payload: { phase: 'generate', tool: 'write_file', args_digest: '{"path":"x"}', status: 'error', duration_ms: 40 },
+    payload: { phase: 'build', tool: 'write_file', args_digest: '{"path":"x"}', status: 'error', duration_ms: 40 },
     provenance: 'harness',
     created_at: '2026-01-01T00:00:02Z',
   },
@@ -133,7 +133,7 @@ const toolCallTraceEvents: MissionEvent[] = [
     mission_id: 'm1',
     seq: 4,
     kind: 'mission.turn',
-    payload: { phase: 'generate', duration_ms: 500, ok: true, input: 'worker_done' },
+    payload: { phase: 'build', duration_ms: 500, ok: true, input: 'worker_done' },
     provenance: 'harness',
     created_at: '2026-01-01T00:00:03Z',
   },
@@ -160,7 +160,7 @@ describe('TimelineSection tool call trace', () => {
     // the humanized tool call rows directly, no extra grouping click.
     expect(screen.getByText(/3 tool calls/)).toBeTruthy()
     expect(screen.queryByText('Search kb')).toBeNull()
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     expect(screen.getByText('Search kb')).toBeTruthy()
     expect(screen.getByText('Shell')).toBeTruthy()
     expect(screen.getByText('Write file')).toBeTruthy()
@@ -168,7 +168,7 @@ describe('TimelineSection tool call trace', () => {
 
   it('shows the raw tool name and arguments when a tool call row is expanded', () => {
     render(<TimelineSection events={toolCallTraceEvents} />)
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     fireEvent.click(screen.getByText('Search kb'))
 
     expect(screen.getByText('search_kb')).toBeTruthy()
@@ -177,7 +177,7 @@ describe('TimelineSection tool call trace', () => {
 
   it('collapses a tool call row again on a second click', () => {
     render(<TimelineSection events={toolCallTraceEvents} />)
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     const toggle = screen.getByText('Search kb')
     fireEvent.click(toggle)
     expect(screen.getByText('search_kb')).toBeTruthy()
@@ -192,7 +192,7 @@ describe('TimelineSection tool call trace', () => {
         seq: 1,
         kind: 'mission.tool_call',
         payload: {
-          phase: 'generate',
+          phase: 'build',
           tool: 'search_kb',
           args_digest: '{"query":"deploy"}',
           status: 'ok',
@@ -206,13 +206,13 @@ describe('TimelineSection tool call trace', () => {
         mission_id: 'm1',
         seq: 2,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 500, ok: true, input: 'worker_done' },
+        payload: { phase: 'build', duration_ms: 500, ok: true, input: 'worker_done' },
         provenance: 'harness',
         created_at: '2026-01-01T00:00:01Z',
       },
     ]
     render(<TimelineSection events={withHits} />)
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     fireEvent.click(screen.getByText('Search kb'))
     expect(screen.getByText('Runbook · score 0.8123')).toBeTruthy()
   })
@@ -224,7 +224,7 @@ describe('TimelineSection tool call trace', () => {
         seq: 1,
         kind: 'mission.tool_call',
         payload: {
-          phase: 'generate',
+          phase: 'build',
           tool: 'search_kb',
           args_digest: '{"query":"nothing"}',
           status: 'ok',
@@ -238,20 +238,20 @@ describe('TimelineSection tool call trace', () => {
         mission_id: 'm1',
         seq: 2,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 200, ok: true, input: 'worker_done' },
+        payload: { phase: 'build', duration_ms: 200, ok: true, input: 'worker_done' },
         provenance: 'harness',
         created_at: '2026-01-01T00:00:01Z',
       },
     ]
     render(<TimelineSection events={noHits} />)
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     fireEvent.click(screen.getByText('Search kb'))
     expect(screen.getByText('no hits')).toBeTruthy()
   })
 
   it('shows no hit list for a non-search_kb tool call', () => {
     render(<TimelineSection events={toolCallTraceEvents} />)
-    openRow(/Turn \(generate\)/)
+    openRow(/Turn \(build\)/)
     fireEvent.click(screen.getByText('Shell'))
     expect(screen.queryByText('no hits')).toBeNull()
     expect(screen.queryByText(/score/)).toBeNull()
@@ -263,7 +263,7 @@ describe('TimelineSection tool call trace', () => {
         mission_id: 'm1',
         seq: 1,
         kind: 'mission.tool_call',
-        payload: { phase: 'generate', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
+        payload: { phase: 'build', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
         provenance: 'harness',
         created_at: '2026-01-01T00:00:00Z',
       },
@@ -271,7 +271,7 @@ describe('TimelineSection tool call trace', () => {
         mission_id: 'm1',
         seq: 2,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 500, ok: true, input: 'worker_done' },
+        payload: { phase: 'build', duration_ms: 500, ok: true, input: 'worker_done' },
         provenance: 'harness',
         created_at: '2026-01-01T00:00:01Z',
       },
@@ -339,8 +339,8 @@ describe('TimelineSection phase labels', () => {
 
   it('labels rows from their own payload phase without any phase_started', () => {
     render(<TimelineSection events={toolCallTraceEvents} />)
-    expect(screen.getAllByText('generate').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('generate')[0]).toHaveClass('text-blue-700')
+    expect(screen.getAllByText('build').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('build')[0]).toHaveClass('text-blue-700')
   })
 
   it('labels initial-phase rows before the first transition with their own phase', () => {
@@ -385,7 +385,7 @@ describe('TimelineSection phase labels', () => {
         mission_id: 'm1',
         seq: 1,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 10, ok: true, input: 'worker_done' },
+        payload: { phase: 'build', duration_ms: 10, ok: true, input: 'worker_done' },
         provenance: 'harness',
         created_at: '2026-01-01T00:00:00Z',
       },
@@ -399,7 +399,7 @@ describe('TimelineSection phase labels', () => {
       },
     ]
     render(<TimelineSection events={withNull} />)
-    expect(screen.getAllByText('generate').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('build').length).toBeGreaterThan(0)
   })
 
   it('renders no phase label when no event carries a phase at all', () => {

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -361,9 +361,9 @@ describe('executor lifecycle event rendering', () => {
 describe('mission.turn rendering', () => {
   it('renders phase, ok, and duration for a successful turn', () => {
     render(
-      <div>{renderEvent(event({ phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
+      <div>{renderEvent(event({ phase: 'build', duration_ms: 1500, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
     )
-    expect(screen.getByText('Turn (generate): ok · 1.5s')).toBeInTheDocument()
+    expect(screen.getByText('Turn (build): ok · 1.5s')).toBeInTheDocument()
   })
 
   it('renders a failed turn in red with the reason', () => {
@@ -386,34 +386,41 @@ describe('mission.turn rendering', () => {
     expect(screen.getByText('Turn (execute): ok · 800ms')).toBeInTheDocument()
   })
 
+  it('renders a pre-#611 generate turn unchanged, same as any other legacy name', () => {
+    render(
+      <div>{renderEvent(event({ phase: 'generate', duration_ms: 800, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
+    )
+    expect(screen.getByText('Turn (generate): ok · 800ms')).toBeInTheDocument()
+  })
+
   it('renders route and agent as muted context when the payload carries them', () => {
     render(
       <div>
         {renderEvent(
           event(
-            { phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
+            { phase: 'build', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
             'mission.turn',
           ),
         )}
       </div>,
     )
-    const row = screen.getByText(/Turn \(generate\): ok/)
+    const row = screen.getByText(/Turn \(build\): ok/)
     expect(row).toHaveTextContent('Coder · coding')
   })
 
   it('renders a failed turn in red even without a reason (no colon suffix)', () => {
     render(
-      <div>{renderEvent(event({ phase: 'generate', duration_ms: 300, ok: false, input: 'worker_retry' }, 'mission.turn'))}</div>,
+      <div>{renderEvent(event({ phase: 'build', duration_ms: 300, ok: false, input: 'worker_retry' }, 'mission.turn'))}</div>,
     )
-    const row = screen.getByText('Turn (generate): failed · 300ms')
+    const row = screen.getByText('Turn (build): failed · 300ms')
     expect(row).toHaveClass('text-destructive')
   })
 
   it('renders exactly as before when route/agent are absent (legacy event)', () => {
     render(
-      <div>{renderEvent(event({ phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
+      <div>{renderEvent(event({ phase: 'build', duration_ms: 1500, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
     )
-    const row = screen.getByText('Turn (generate): ok · 1.5s')
+    const row = screen.getByText('Turn (build): ok · 1.5s')
     expect(row).toBeInTheDocument()
     expect(row).not.toHaveTextContent('undefined')
   })
@@ -444,7 +451,7 @@ describe('mission.turn rendering', () => {
       <div>
         {renderEvent(
           event(
-            { phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
+            { phase: 'build', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
             'mission.turn',
           ),
         )}
@@ -587,7 +594,7 @@ describe('mission.route_changed rendering', () => {
 describe('toolRunFromEvent', () => {
   it('maps a mission.tool_call event to a ToolRun', () => {
     const e = event(
-      { phase: 'generate', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
+      { phase: 'build', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
       'mission.tool_call',
       3,
     )
@@ -601,7 +608,7 @@ describe('toolRunFromEvent', () => {
   })
 
   it('maps an unrecognized status to error', () => {
-    const e = event({ phase: 'generate', tool: 'shell', status: 'blocked', duration_ms: 3 }, 'mission.tool_call')
+    const e = event({ phase: 'build', tool: 'shell', status: 'blocked', duration_ms: 3 }, 'mission.tool_call')
     expect(toolRunFromEvent(e).status).toBe('error')
   })
 })

--- a/web/src/components/timothy/status.test.tsx
+++ b/web/src/components/timothy/status.test.tsx
@@ -7,7 +7,7 @@ describe('missionStatus', () => {
   })
 
   it('maps running phases to working', () => {
-    for (const phase of ['discover', 'plan', 'generate', 'prove']) {
+    for (const phase of ['discover', 'plan', 'build', 'prove']) {
       expect(missionStatus({ phase, status: 'working' })).toBe('working')
     }
   })
@@ -33,11 +33,11 @@ describe('missionStatus', () => {
   })
 
   it('maps a non-terminal error status to error', () => {
-    expect(missionStatus({ phase: 'generate', status: 'error' })).toBe('error')
+    expect(missionStatus({ phase: 'build', status: 'error' })).toBe('error')
   })
 
   it('maps a non-terminal done status to success', () => {
-    expect(missionStatus({ phase: 'generate', status: 'done' })).toBe('success')
+    expect(missionStatus({ phase: 'build', status: 'done' })).toBe('success')
   })
 })
 

--- a/web/src/lib/phaseColors.ts
+++ b/web/src/lib/phaseColors.ts
@@ -4,18 +4,20 @@
 export const phaseTextColors: Record<string, string> = {
   discover: 'text-sky-700 dark:text-sky-400',
   plan: 'text-violet-700 dark:text-violet-400',
-  generate: 'text-blue-700 dark:text-blue-400',
+  build: 'text-blue-700 dark:text-blue-400',
   prove: 'text-amber-700 dark:text-amber-400',
   result: 'text-green-700 dark:text-green-400',
 }
 
 // phaseLabel normalizes a phase string for display: the pre-D-086
-// names (explore/execute/review) a historical mission's events may
-// still carry map to their current equivalents, same mapping
-// statemachine.go's parsePhase applies on read.
+// names (explore/execute/review) and the pre-#611 name (generate) a
+// historical mission's events may still carry map to their current
+// equivalents, same mapping statemachine.go's parsePhase applies on
+// read. execute maps straight to build, having been renamed twice.
 const legacyPhaseNames: Record<string, string> = {
   explore: 'discover',
-  execute: 'generate',
+  execute: 'build',
+  generate: 'build',
   review: 'prove',
 }
 

--- a/web/src/pages/MissionDetail.a11y.test.tsx
+++ b/web/src/pages/MissionDetail.a11y.test.tsx
@@ -44,7 +44,7 @@ const baseMission: Mission = {
   id: 'm1',
   goal: 'Fix the login bug',
   kind: 'coding',
-  phase: 'generate',
+  phase: 'build',
   status: 'working',
   plan: { units: [] },
   progress: [],

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -79,7 +79,7 @@ const baseMission: Mission = {
   id: 'm1',
   goal: 'Fix the login bug',
   kind: 'coding',
-  phase: 'generate',
+  phase: 'build',
   status: 'working',
   branch: 'mission/fix-login',
   base_commit: 'abc123def456',
@@ -425,7 +425,7 @@ describe('MissionDetail retries/turns/processing/elapsed', () => {
         mission_id: 'm1',
         seq: 5,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 30_000, ok: true },
+        payload: { phase: 'build', duration_ms: 30_000, ok: true },
         provenance: 'live',
         created_at: '2026-01-01T00:04:00Z',
       },
@@ -433,7 +433,7 @@ describe('MissionDetail retries/turns/processing/elapsed', () => {
         mission_id: 'm1',
         seq: 6,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 17_500, ok: true },
+        payload: { phase: 'build', duration_ms: 17_500, ok: true },
         provenance: 'live',
         created_at: '2026-01-01T00:05:00Z',
       },
@@ -450,7 +450,7 @@ describe('MissionDetail retries/turns/processing/elapsed', () => {
         mission_id: 'm1',
         seq: 5,
         kind: 'mission.turn',
-        payload: { phase: 'generate', duration_ms: 1000, ok: true },
+        payload: { phase: 'build', duration_ms: 1000, ok: true },
         provenance: 'live',
         created_at: '2026-01-01T00:04:00Z',
       },
@@ -1005,7 +1005,7 @@ describe('MissionDetail', () => {
     renderPage()
     await screen.findByRole('heading', { name: 'Fix the login bug' })
     fireEvent.click(screen.getByRole('button', { name: 'Intervene' }))
-    await screen.findByText((_, el) => el?.textContent === 'Currently in generate · working')
+    await screen.findByText((_, el) => el?.textContent === 'Currently in build · working')
   })
 
   it('disables the Intervene button once the mission is terminal', async () => {
@@ -1468,7 +1468,7 @@ describe('MissionDetail plan approval gate', () => {
     const approveButton = await screen.findByRole('button', { name: 'Approve' })
     fireEvent.click(approveButton)
     await waitFor(() => expect(approveMissionPlan).toHaveBeenCalledWith('m1'))
-    expect(await screen.findByText('Approved, moving to generate…')).toBeTruthy()
+    expect(await screen.findByText('Approved, moving to build…')).toBeTruthy()
   })
 
   it('requests a replan with feedback', async () => {
@@ -1510,7 +1510,7 @@ describe('MissionDetail pending input gate', () => {
         kind: 'open',
         proposed_default: 'staging',
         asked_at: '2026-01-01T00:00:00Z',
-        phase: 'generate',
+        phase: 'build',
       },
     })
     renderPage()

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -175,11 +175,11 @@ const pauseReasonLabels: Record<string, string> = {
 }
 
 // runsPlanless mirrors missions.Mission.RunsPlanless (D-090, issue
-// #459): light and flow=discover_generate both run generate with no
+// #459): light and flow=discover_build both run build with no
 // plan, no review; the worker's final message is the deliverable
 // (final_output), not last_evidence.
 function runsPlanless(mission: Mission): boolean {
-  return !!mission.light || mission.flow === 'discover_generate'
+  return !!mission.light || mission.flow === 'discover_build'
 }
 
 // latestPROpened finds the most recent mission.pr_opened event so the

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -34,7 +34,7 @@ const mission: Mission = {
   id: 'm1',
   goal: 'Fix the login bug',
   kind: 'general',
-  phase: 'generate',
+  phase: 'build',
   status: 'working',
   plan: { units: [] },
   progress: [],

--- a/web/src/pages/design/AgentSurfaces.tsx
+++ b/web/src/pages/design/AgentSurfaces.tsx
@@ -214,7 +214,7 @@ function EventLogComponentSample() {
   )
 }
 
-const phaseSteps = ['Discover', 'Plan', 'Generate', 'Prove', 'Result']
+const phaseSteps = ['Discover', 'Plan', 'Build', 'Prove', 'Result']
 
 function PhaseStepper({ current }: { current: string }) {
   const currentIndex = phaseSteps.indexOf(current)
@@ -263,7 +263,7 @@ function MissionHeaderSample() {
         <h2 className="text-title font-semibold text-foreground">Weekly GitHub digest</h2>
         <StatusBadge status="working" />
       </div>
-      <PhaseStepper current="Generate" />
+      <PhaseStepper current="Build" />
       <div className="max-w-xs space-y-3">
         <CostSample value="$0.0421 of $1.00" spent={4} tone="brand" />
         <CostSample value="$0.86 of $1.00" spent={86} tone="warning" />

--- a/web/src/pages/design/Compositions.tsx
+++ b/web/src/pages/design/Compositions.tsx
@@ -30,7 +30,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { missionGoal, toolCallArgs } from './fixtures'
 
 const missionCards = [
-  { status: 'working' as const, harness: 'Native', title: 'Weekly GitHub digest', phase: 'Generate · 3 of 5', model: 'claude-sonnet-5', time: '2 min ago', cost: '$0.0421' },
+  { status: 'working' as const, harness: 'Native', title: 'Weekly GitHub digest', phase: 'Build · 3 of 5', model: 'claude-sonnet-5', time: '2 min ago', cost: '$0.0421' },
   { status: 'waiting' as const, harness: 'Claude Code', title: 'Migrate provider settings to credential_ref', phase: 'Plan · 1 of 4', model: 'gpt-5.2-mini', time: '18 min ago', cost: '$0.0087' },
   { status: 'success' as const, harness: 'Codex', title: 'Summarize unread email from the last 24 hours', phase: 'Result · 5 of 5', model: 'qwen3:4b', time: '1 hour ago', cost: '$0.0000' },
 ]


### PR DESCRIPTION
Closes #611.

Generate reads correctly for a mission that writes a summary, and poorly for a coding mission where the phase clones a repo, edits files, runs a test suite and opens a PR. None of that is generation in the sense the word suggests. Build is a verb, covers prose and code without privileging either, and keeps the pipeline reading as discover -> plan -> build -> prove -> result.

## What changed

- `PhaseGenerate` -> `PhaseBuild` (`"generate"` -> `"build"`)
- `FlowDiscoverGenerate` -> `FlowDiscoverBuild` (`discover_generate` -> `discover_build`)
- `inherited-from-generate` -> `inherited-from-build`
- Every user-facing label: phase stepper, execution plan table, flow picker, plan approval text, design system page

## Back-compat

`parsePhase` gains `generate` alongside the existing `explore`/`execute`/`review` aliases. `execute` now maps two hops forward, having been renamed twice. Flow had no parse chokepoint, so `parseFlow` is new and wired into both scan sites in `store.go`.

`mission_events` is append-only, so historical rows keep whatever phase string they were written with. The timeline renders them verbatim, unchanged from how the previous rename left it (#460 made that call deliberately: the record shows what actually ran).

Event type names keep their old spelling (`mission.generate_skipped`, `mission.generate_continued`), the same way `mission.review_*` survived review -> prove. They are stable identifiers, not display text. Noted in `missions/CLAUDE.md` so the next reader does not "fix" it.

## Migration

`scripts/pending-alters.md` carries the data migration. Order matters: drop the flow CHECK constraint, rewrite the rows, then add the new constraint. Adding it first fails, since Postgres validates a new CHECK against every existing row immediately and the old `discover_generate` values are not in the new list. I found that by running it, not by reading it.

## Verification

- `make test vet lint`: pass, 0 lint issues
- 1844/1844 web tests
- migrations apply clean to a fresh pgvector database
- `make test-integration`: pass
- **`make canary`: PASS**, with the run logging `discover -> plan -> build -> done` on a real mission
- pending alter applied to the local database (1 row moved to `discover_build`), brain healthy against the migrated schema afterwards

## Note for deploy

The homelab database needs the `scripts/pending-alters.md` block. It is safe to run before or after the deploy: the code reads both spellings either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791499637&installation_model_id=431401&pr_number=616&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F616&signature=05746c38b23a57570e8208d691bfdd431aa6d85d7eb32f93548a0585926e1365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->