### PR TITLE
feat(agents): plain-text renameable names, uuid the only key

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -503,7 +503,8 @@ func main() {
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
-		flags.Location, agentReg.Resolve, app.Log)
+		flags.Location, agentReg.ResolveByID, app.Log)
+	svc.SetAgentResolverByName(agentReg.Resolve)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
 	// TURN_TIMEOUT raises the detached-turn ceiling above the compiled

--- a/internal/brain/agents/agents.go
+++ b/internal/brain/agents/agents.go
@@ -11,11 +11,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/SumonMSelim/timothy/internal/brain/missions/executor"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -59,20 +62,29 @@ type Agent struct {
 	Knowledge []string `json:"knowledge"`
 }
 
-// namePattern mirrors connectors: a lowercase slug that survives in
-// URLs, ledger rows, and event payloads.
-var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
+// validateName trims a.Name and checks it against the plain-text rule
+// (issue #615): 1..64 runes, any printable character, no control
+// characters. Returns the trimmed name.
+func validateName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	if utf8.RuneCountInString(name) > 64 {
+		return "", fmt.Errorf("name must be at most 64 characters")
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("name must not contain control characters")
+		}
+	}
+	return name, nil
+}
 
-func validate(a Agent) error {
-	if !namePattern.MatchString(a.Name) {
-		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _)")
-	}
-	if len(a.Name) > 64 {
-		return fmt.Errorf("name must be at most 64 characters")
-	}
-	if a.Harness != "" {
-		if _, ok := executor.Lookup(a.Harness); !ok {
-			return fmt.Errorf("harness: unknown harness %q", a.Harness)
+func validateHarness(harness string) error {
+	if harness != "" {
+		if _, ok := executor.Lookup(harness); !ok {
+			return fmt.Errorf("harness: unknown harness %q", harness)
 		}
 	}
 	return nil
@@ -80,8 +92,9 @@ func validate(a Agent) error {
 
 // Sentinel errors the HTTP layer maps onto status codes.
 var (
-	ErrNotFound = errors.New("not found")
-	ErrInUse    = errors.New("in use")
+	ErrNotFound     = errors.New("not found")
+	ErrInUse        = errors.New("in use")
+	ErrNameConflict = errors.New("an agent with this name already exists")
 )
 
 const cacheTTL = 10 * time.Second
@@ -175,6 +188,11 @@ func (s *Store) Enabled(ctx context.Context) []Agent {
 // a vanished agent) resolves to the default. The bool reports whether
 // the requested name actually resolved — false only when a non-empty
 // name matched nothing.
+//
+// Callers should prefer ResolveByID: this is now the read-time
+// compatibility path for session_events/cost_ledger rows written
+// before agents were addressed by id (issue #615), same idea as
+// missions' parsePhase.
 func (s *Store) Resolve(ctx context.Context, name string) (Agent, bool) {
 	byName, def := s.load(ctx)
 	if name == "" {
@@ -252,9 +270,16 @@ func (s *Store) invalidate() {
 	s.mu.Unlock()
 }
 
-// Create inserts an agent and audits.
+// Create inserts an agent and audits. name is trimmed; a case-
+// insensitive duplicate (agents_name_ci) reports ErrNameConflict
+// rather than a raw pg error.
 func (s *Store) Create(ctx context.Context, a Agent) (string, error) {
-	if err := validate(a); err != nil {
+	name, err := validateName(a.Name)
+	if err != nil {
+		return "", err
+	}
+	a.Name = name
+	if err := validateHarness(a.Harness); err != nil {
 		return "", err
 	}
 	db, err := s.db.Get()
@@ -270,6 +295,9 @@ func (s *Store) Create(ctx context.Context, a Agent) (string, error) {
 		a.Name, a.Description, a.PromptOverlay, a.Route, skills, tools, a.Memory, a.Enabled,
 		a.ReviewRoute, appr, knowledge, a.Harness).Scan(&id)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return "", ErrNameConflict
+		}
 		return "", fmt.Errorf("agents create: %w", err)
 	}
 	s.audit(ctx, "create", id, nil, a)
@@ -277,9 +305,15 @@ func (s *Store) Create(ctx context.Context, a Agent) (string, error) {
 	return id, nil
 }
 
-// Patch applies a partial update. Name is immutable (it lives in
-// ledger rows and event payloads); is_default moves via SetDefault.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// Patch applies a partial update. is_default moves via SetDefault. A
+// non-nil Name renames the agent (audited with before/after).
 type Patch struct {
+	Name              *string   `json:"name"`
 	Description       *string   `json:"description"`
 	PromptOverlay     *string   `json:"prompt_overlay"`
 	Route             *string   `json:"route"`
@@ -294,9 +328,16 @@ type Patch struct {
 }
 
 func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
-	if p.Harness != nil && *p.Harness != "" {
-		if _, ok := executor.Lookup(*p.Harness); !ok {
-			return fmt.Errorf("harness: unknown harness %q", *p.Harness)
+	if p.Name != nil {
+		name, err := validateName(*p.Name)
+		if err != nil {
+			return err
+		}
+		p.Name = &name
+	}
+	if p.Harness != nil {
+		if err := validateHarness(*p.Harness); err != nil {
+			return err
 		}
 	}
 	db, err := s.db.Get()
@@ -315,6 +356,9 @@ func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
 		return fmt.Errorf("agent %s: %w", id, ErrNotFound)
 	}
 	after := before
+	if p.Name != nil {
+		after.Name = *p.Name
+	}
 	if p.Description != nil {
 		after.Description = *p.Description
 	}
@@ -351,15 +395,18 @@ func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
 	if p.Harness != nil {
 		after.Harness = *p.Harness
 	}
-	if _, err := tx.Exec(ctx, `UPDATE agents SET description = $2, prompt_overlay = $3,
-			route = $4, skills = $5, tools = $6, memory = $7, enabled = $8,
-			review_route = $9, approval_allowlist = $10, knowledge = $11,
-			harness = $12, updated_at = now()
+	if _, err := tx.Exec(ctx, `UPDATE agents SET name = $2, description = $3, prompt_overlay = $4,
+			route = $5, skills = $6, tools = $7, memory = $8, enabled = $9,
+			review_route = $10, approval_allowlist = $11, knowledge = $12,
+			harness = $13, updated_at = now()
 		WHERE id = $1`,
-		id, after.Description, after.PromptOverlay, after.Route,
+		id, after.Name, after.Description, after.PromptOverlay, after.Route,
 		jsonArr(after.Skills), jsonArr(after.Tools), after.Memory, after.Enabled,
 		after.ReviewRoute, jsonArr(after.ApprovalAllowlist), jsonArr(after.Knowledge),
 		after.Harness); err != nil {
+		if isUniqueViolation(err) {
+			return ErrNameConflict
+		}
 		return fmt.Errorf("agents patch: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/brain/agents/agents_integration_test.go
+++ b/internal/brain/agents/agents_integration_test.go
@@ -4,9 +4,11 @@ package agents
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -71,8 +73,20 @@ func TestAgentCRUDAndResolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if _, err := s.Create(ctx, Agent{Name: "Bad Name!"}); err == nil {
-		t.Fatal("invalid name accepted")
+	// Plain text is accepted now: spaces, capitals, punctuation (issue
+	// #615). Only empty and over-length names are rejected.
+	if _, err := s.Create(ctx, Agent{Name: marker + "Research Bot!"}); err != nil {
+		t.Fatalf("Create with spaces/capitals/punctuation rejected: %v", err)
+	}
+	if _, err := s.Create(ctx, Agent{Name: "  "}); err == nil {
+		t.Fatal("blank name accepted")
+	}
+	if _, err := s.Create(ctx, Agent{Name: strings.Repeat("a", 65)}); err == nil {
+		t.Fatal("65-rune name accepted")
+	}
+	// A case-insensitive duplicate (after trim) is rejected.
+	if _, err := s.Create(ctx, Agent{Name: "  " + strings.ToUpper(name) + "  "}); !errors.Is(err, ErrNameConflict) {
+		t.Fatalf("Create duplicate name = %v, want ErrNameConflict", err)
 	}
 
 	a, ok := s.Resolve(ctx, name)
@@ -129,6 +143,33 @@ func TestAgentCRUDAndResolve(t *testing.T) {
 	}
 	if a, _ := s.Resolve(ctx, name); a.Route != "default" {
 		t.Fatalf("patched route = %q (cache must invalidate)", a.Route)
+	}
+
+	// Patch renames the agent and audits before/after (issue #615).
+	renamed := marker + "Renamed Researcher"
+	if err := s.Patch(ctx, id, Patch{Name: &renamed}); err != nil {
+		t.Fatalf("Patch rename: %v", err)
+	}
+	if byID, ok := s.ResolveByID(ctx, id); !ok || byID.Name != renamed {
+		t.Fatalf("ResolveByID after rename = %+v ok=%v, want %s", byID, ok, renamed)
+	}
+	db, _ := s.db.Get()
+	var before, after []byte
+	if err := db.QueryRow(ctx, `SELECT before, after FROM admin_audit
+		WHERE entity = 'agent' AND entity_id = $1 AND action = 'update'
+		ORDER BY ts DESC LIMIT 1`, id).Scan(&before, &after); err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	if !strings.Contains(string(before), name) || !strings.Contains(string(after), renamed) {
+		t.Fatalf("rename audit before=%s after=%s, want before to mention %s and after %s", before, after, name, renamed)
+	}
+	name = renamed
+
+	// Patch rejects a case-insensitive duplicate rename onto the seeded
+	// default's name.
+	dup := "  " + strings.ToUpper("general") + " "
+	if err := s.Patch(ctx, id, Patch{Name: &dup}); !errors.Is(err, ErrNameConflict) {
+		t.Fatalf("Patch duplicate name = %v, want ErrNameConflict", err)
 	}
 
 	// The seeded default is protected; moving the flag frees it.

--- a/internal/brain/agents/agents_test.go
+++ b/internal/brain/agents/agents_test.go
@@ -1,0 +1,39 @@
+package agents
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateName covers the plain-text name rule (issue #615):
+// trimmed, 1..64 runes, no control characters. Spaces and capitals are
+// accepted; the old lowercase-slug pattern is gone.
+func TestValidateName(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"plain lowercase", "researcher", "researcher", false},
+		{"spaces and capitals", "Research Bot", "Research Bot", false},
+		{"punctuation", "Bot! (v2)", "Bot! (v2)", false},
+		{"trims surrounding whitespace", "  Research Bot  ", "Research Bot", false},
+		{"empty rejected", "", "", true},
+		{"blank rejected", "   ", "", true},
+		{"exactly 64 runes accepted", strings.Repeat("a", 64), strings.Repeat("a", 64), false},
+		{"65 runes rejected", strings.Repeat("a", 65), "", true},
+		{"control character rejected", "bad\tname", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := validateName(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("validateName(%q) err = %v, wantErr %v", c.in, err, c.wantErr)
+			}
+			if err == nil && got != c.want {
+				t.Fatalf("validateName(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/brain/agents/dispatch.go
+++ b/internal/brain/agents/dispatch.go
@@ -14,32 +14,32 @@ import (
 type Classify func(ctx context.Context, prompt string) (string, error)
 
 // Dispatch picks the agent whose profile best fits message, among
-// candidates (only enabled agents should be passed in). A single
-// candidate is returned without calling classify — there's nothing to
-// choose between. Any classifier failure or an out-of-range/unparsable
-// answer falls back to fallbackName (typically the default agent):
-// dispatch is an ergonomics layer, never a hard gate on serving a
-// session.
-func Dispatch(ctx context.Context, classify Classify, message string, candidates []Agent, fallbackName string) string {
+// candidates (only enabled agents should be passed in), and returns
+// its id. A single candidate is returned without calling classify:
+// there's nothing to choose between. Any classifier failure or an
+// out-of-range/unparsable answer falls back to fallbackID (typically
+// the default agent's id): dispatch is an ergonomics layer, never a
+// hard gate on serving a session.
+func Dispatch(ctx context.Context, classify Classify, message string, candidates []Agent, fallbackID string) string {
 	if len(candidates) == 0 {
-		return fallbackName
+		return fallbackID
 	}
 	if len(candidates) == 1 {
-		return candidates[0].Name
+		return candidates[0].ID
 	}
 	if classify == nil {
-		return fallbackName
+		return fallbackID
 	}
 
 	reply, err := classify(ctx, dispatchPrompt(message, candidates))
 	if err != nil {
-		return fallbackName
+		return fallbackID
 	}
 	idx, ok := parseChoice(reply, len(candidates))
 	if !ok {
-		return fallbackName
+		return fallbackID
 	}
-	return candidates[idx].Name
+	return candidates[idx].ID
 }
 
 // dispatchPrompt lists each candidate as "N. name: description" (or

--- a/internal/brain/agents/dispatch_test.go
+++ b/internal/brain/agents/dispatch_test.go
@@ -20,9 +20,9 @@ func TestDispatchSingleCandidateSkipsClassifier(t *testing.T) {
 		called = true
 		return "1", nil
 	}
-	got := Dispatch(context.Background(), classify, "hello", []Agent{{Name: "solo"}}, "general")
-	if got != "solo" {
-		t.Fatalf("got %q, want solo", got)
+	got := Dispatch(context.Background(), classify, "hello", []Agent{{ID: "solo-id", Name: "solo"}}, "general-id")
+	if got != "solo-id" {
+		t.Fatalf("got %q, want solo-id", got)
 	}
 	if called {
 		t.Fatal("classify called for a single candidate; want short-circuit")
@@ -30,18 +30,18 @@ func TestDispatchSingleCandidateSkipsClassifier(t *testing.T) {
 }
 
 func TestDispatchNilClassifierReturnsFallback(t *testing.T) {
-	agents := []Agent{{Name: "a"}, {Name: "b"}}
-	got := Dispatch(context.Background(), nil, "hello", agents, "general")
-	if got != "general" {
-		t.Fatalf("got %q, want fallback general", got)
+	agents := []Agent{{ID: "a-id", Name: "a"}, {ID: "b-id", Name: "b"}}
+	got := Dispatch(context.Background(), nil, "hello", agents, "general-id")
+	if got != "general-id" {
+		t.Fatalf("got %q, want fallback general-id", got)
 	}
 }
 
 func TestDispatchPicksClassifiedAgent(t *testing.T) {
 	agents := []Agent{
-		{Name: "general", Description: "everyday tasks"},
-		{Name: "researcher", Description: "consults tools before answering"},
-		{Name: "summarizer", Description: "condenses long content"},
+		{ID: "general-id", Name: "general", Description: "everyday tasks"},
+		{ID: "researcher-id", Name: "researcher", Description: "consults tools before answering"},
+		{ID: "summarizer-id", Name: "summarizer", Description: "condenses long content"},
 	}
 	classify := func(_ context.Context, prompt string) (string, error) {
 		if len(prompt) == 0 {
@@ -49,30 +49,30 @@ func TestDispatchPicksClassifiedAgent(t *testing.T) {
 		}
 		return "2", nil // researcher
 	}
-	got := Dispatch(context.Background(), classify, "what does the latest RFC say?", agents, "general")
-	if got != "researcher" {
-		t.Fatalf("got %q, want researcher", got)
+	got := Dispatch(context.Background(), classify, "what does the latest RFC say?", agents, "general-id")
+	if got != "researcher-id" {
+		t.Fatalf("got %q, want researcher-id", got)
 	}
 }
 
 func TestDispatchFallsBackOnClassifierError(t *testing.T) {
-	agents := []Agent{{Name: "a"}, {Name: "b"}}
+	agents := []Agent{{ID: "a-id", Name: "a"}, {ID: "b-id", Name: "b"}}
 	classify := func(context.Context, string) (string, error) {
 		return "", errors.New("route unavailable")
 	}
-	got := Dispatch(context.Background(), classify, "hello", agents, "general")
-	if got != "general" {
-		t.Fatalf("got %q, want fallback general on classifier error", got)
+	got := Dispatch(context.Background(), classify, "hello", agents, "general-id")
+	if got != "general-id" {
+		t.Fatalf("got %q, want fallback general-id on classifier error", got)
 	}
 }
 
 func TestDispatchFallsBackOnUnparsableReply(t *testing.T) {
-	agents := []Agent{{Name: "a"}, {Name: "b"}}
+	agents := []Agent{{ID: "a-id", Name: "a"}, {ID: "b-id", Name: "b"}}
 	for _, reply := range []string{"", "researcher", "the second one", "0", "3", "-1"} {
 		classify := func(context.Context, string) (string, error) { return reply, nil }
-		got := Dispatch(context.Background(), classify, "hello", agents, "general")
-		if got != "general" {
-			t.Errorf("reply %q: got %q, want fallback general", reply, got)
+		got := Dispatch(context.Background(), classify, "hello", agents, "general-id")
+		if got != "general-id" {
+			t.Errorf("reply %q: got %q, want fallback general-id", reply, got)
 		}
 	}
 }
@@ -92,10 +92,10 @@ func TestDispatchPromptListsAllCandidatesAndMessage(t *testing.T) {
 
 func TestParseChoice(t *testing.T) {
 	cases := []struct {
-		reply    string
-		n        int
-		wantIdx  int
-		wantOk   bool
+		reply   string
+		n       int
+		wantIdx int
+		wantOk  bool
 	}{
 		{"1", 3, 0, true},
 		{"2", 3, 1, true},

--- a/internal/brain/api/agents.go
+++ b/internal/brain/api/agents.go
@@ -33,6 +33,8 @@ func failAgent(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusNotFound, "not_found", err.Error())
 	case errors.Is(err, agents.ErrInUse):
 		jsonError(w, http.StatusConflict, "in_use", err.Error())
+	case errors.Is(err, agents.ErrNameConflict):
+		jsonError(w, http.StatusConflict, "name_conflict", err.Error())
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -139,6 +139,7 @@ type Service struct {
 	memory         MemoryExtract   // nil: long-term memory off
 	recall         MemoryRetrieve  // nil: no memory injection
 	agents         AgentResolver   // nil: zero-value agent (no skills/tools but retrieve_output, default route, memory on)
+	agentsByName   AgentResolver   // nil: Retry can't fall back to a pre-#615 name-keyed session event
 	candidates     AgentCandidates // nil: auto-dispatch falls back to default
 	classify       agents.Classify // nil: auto-dispatch falls back to default
 	budget         func(context.Context) int
@@ -319,6 +320,15 @@ func (s *Service) SetAutoDispatch(candidates AgentCandidates, classify agents.Cl
 	s.candidates, s.classify = candidates, classify
 }
 
+// SetAgentResolverByName wires the read-time compatibility path Retry
+// uses when a session's last user_message carries an agent name from
+// before agents were addressed by id (issue #615): resolved only when
+// the id lookup misses. Optional: nil means such old rows fail Retry
+// with unknown agent, same as any other genuinely-unknown value.
+func (s *Service) SetAgentResolverByName(resolver AgentResolver) {
+	s.agentsByName = resolver
+}
+
 // SetApprovalGrants wires the standing-grant seeder: once wired, a
 // turn served by an agent with a non-empty ApprovalAllowlist gets
 // those tools granted for its session before the turn runs, extending
@@ -375,9 +385,9 @@ func (s *Service) seedApprovalGrants(ctx context.Context, sessionID string, prof
 // gates packs per turn, nil allows all. The assembled system prompt
 // only changes when a setting does, so provider prompt caches (D-018)
 // stay warm in the steady state.
-// AgentResolver returns the profile serving a named agent; empty name
-// resolves the default. False = unknown (non-empty) name.
-type AgentResolver func(ctx context.Context, name string) (agents.Agent, bool)
+// AgentResolver returns the profile serving an agent id; empty id
+// resolves the default. False = unknown (non-empty) id.
+type AgentResolver func(ctx context.Context, id string) (agents.Agent, bool)
 
 // AgentCandidates lists the enabled agents auto-dispatch (D-034
 // follow-up) chooses among; nil or empty means dispatch always falls
@@ -416,7 +426,7 @@ func (s *Service) SetTurnTimeout(d time.Duration) error {
 	return nil
 }
 
-// dispatchAgent resolves the "auto" sentinel to a real agent name via
+// dispatchAgent resolves the "auto" sentinel to a real agent id via
 // agents.Dispatch. classify is built here (not injected verbatim as
 // Classify) so it always drains through this service's own Gateway:
 // a fresh call, not a lingering handle from setup time.
@@ -855,7 +865,10 @@ type AttachmentRef struct {
 type Request struct {
 	SessionID string `json:"session_id,omitempty"`
 	Message   string `json:"message"`
-	// Agent names who serves this turn; empty = the default agent.
+	// Agent is the id of who serves this turn, the autoAgentName
+	// sentinel, or empty for the default agent. A name is not accepted
+	// (issue #615): an agent's name is a renameable display label now,
+	// not a stable reference.
 	Agent     string `json:"agent,omitempty"`
 	Route     string `json:"route,omitempty"`
 	ModelHint string `json:"model_hint,omitempty"`
@@ -900,16 +913,16 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		return "", nil, err
 	}
 	documents = append(documents, referenceDocs...)
-	agentName := req.Agent
-	if agentName == autoAgentName {
-		agentName = s.dispatchAgent(ctx, req.Message)
+	agentID := req.Agent
+	if agentID == autoAgentName {
+		agentID = s.dispatchAgent(ctx, req.Message)
 	}
 	profile := agents.Agent{Memory: true}
 	if s.agents != nil {
 		var known bool
-		profile, known = s.agents(ctx, agentName)
+		profile, known = s.agents(ctx, agentID)
 		if !known {
-			return "", nil, fmt.Errorf("chat: %w: unknown agent %q", ErrBadRequest, agentName)
+			return "", nil, fmt.Errorf("chat: %w: unknown agent %q", ErrBadRequest, agentID)
 		}
 	}
 	var skillBody string
@@ -996,7 +1009,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	bc.setCancel(cancel)
 
 	if _, err := s.log.Append(turnCtx, sessionID, session.KindUserMessage, session.UserMessage{
-		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images, Documents: documents,
+		Text: req.Message, Route: route, Agent: profile.ID, ModelHint: modelHint, Images: images, Documents: documents,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
@@ -1212,6 +1225,13 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	if s.agents != nil {
 		var known bool
 		profile, known = s.agents(ctx, last.Agent)
+		// last.Agent is an id for every turn persisted since issue #615;
+		// a miss falls back to a name lookup for session events written
+		// before that (read-time compatibility, same idea as missions'
+		// parsePhase).
+		if !known && s.agentsByName != nil {
+			profile, known = s.agentsByName(ctx, last.Agent)
+		}
 		if !known {
 			return sessionID, nil, fmt.Errorf("chat: %w: unknown agent %q", ErrBadRequest, last.Agent)
 		}
@@ -1359,7 +1379,7 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	}
 	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
 		Route:      route,
-		Agent:      profile.Name,
+		Agent:      profile.ID,
 		ToolAllow:  resolveToolAllow(profile),
 		ExtraTools: extraTools,
 		Purpose:    "chat",

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1733,20 +1733,20 @@ func TestChatAutoDispatchesAgent(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
-		switch name {
-		case "", "general":
-			return agents.Agent{Name: "general", Route: "default"}, true
-		case "researcher":
-			return agents.Agent{Name: "researcher", Route: "research"}, true
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
+		switch id {
+		case "", "general-id":
+			return agents.Agent{ID: "general-id", Name: "general", Route: "default"}, true
+		case "researcher-id":
+			return agents.Agent{ID: "researcher-id", Name: "researcher", Route: "research"}, true
 		default:
 			return agents.Agent{}, false
 		}
 	}
 	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	candidates := []agents.Agent{
-		{Name: "general", Description: "everyday tasks"},
-		{Name: "researcher", Description: "consults sources"},
+		{ID: "general-id", Name: "general", Description: "everyday tasks"},
+		{ID: "researcher-id", Name: "researcher", Description: "consults sources"},
 	}
 	svc.SetAutoDispatch(
 		func(context.Context) []agents.Agent { return candidates },
@@ -1760,8 +1760,8 @@ func TestChatAutoDispatchesAgent(t *testing.T) {
 	drain(t, ch)
 
 	sent := chatRequest(t, gw)
-	if sent.Agent != "researcher" || sent.Route != "research" {
-		t.Fatalf("agent/route = %s/%s, want researcher/research (auto-dispatched)", sent.Agent, sent.Route)
+	if sent.Agent != "researcher-id" || sent.Route != "research" {
+		t.Fatalf("agent/route = %s/%s, want researcher-id/research (auto-dispatched)", sent.Agent, sent.Route)
 	}
 
 	events, err := log.Events(t.Context(), "s1")
@@ -1774,8 +1774,8 @@ func TestChatAutoDispatchesAgent(t *testing.T) {
 			_ = json.Unmarshal(ev.Payload, &msg)
 		}
 	}
-	if msg.Agent != "researcher" {
-		t.Fatalf("persisted user message agent = %q, want researcher (never the raw auto sentinel)", msg.Agent)
+	if msg.Agent != "researcher-id" {
+		t.Fatalf("persisted user message agent = %q, want researcher-id (never the raw auto sentinel)", msg.Agent)
 	}
 }
 
@@ -1787,9 +1787,9 @@ func TestChatAutoWithoutDispatchWiredFallsBackToDefault(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
-		if name == "" {
-			return agents.Agent{Name: "general", Route: "default"}, true
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
+		if id == "" {
+			return agents.Agent{ID: "general-id", Name: "general", Route: "default"}, true
 		}
 		return agents.Agent{}, false
 	}
@@ -1802,8 +1802,8 @@ func TestChatAutoWithoutDispatchWiredFallsBackToDefault(t *testing.T) {
 	drain(t, ch)
 
 	sent := chatRequest(t, gw)
-	if sent.Agent != "general" {
-		t.Fatalf("agent = %q, want general (fallback default)", sent.Agent)
+	if sent.Agent != "general-id" {
+		t.Fatalf("agent = %q, want general-id (fallback default)", sent.Agent)
 	}
 }
 
@@ -1815,11 +1815,11 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
-		switch name {
-		case "", "researcher":
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
+		switch id {
+		case "", "researcher-id":
 			return agents.Agent{
-				Name: "researcher", Route: "research",
+				ID: "researcher-id", Name: "researcher", Route: "research",
 				PromptOverlay: "Consult sources before answering.",
 				Tools:         []string{"search_web"},
 				Memory:        false,
@@ -1839,15 +1839,15 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 		t.Fatal("unknown agent accepted")
 	}
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: "researcher"})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: "researcher-id"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
 
 	sent := chatRequest(t, gw)
-	if sent.Route != "research" || sent.Agent != "researcher" {
-		t.Fatalf("route/agent = %s/%s, want research/researcher", sent.Route, sent.Agent)
+	if sent.Route != "research" || sent.Agent != "researcher-id" {
+		t.Fatalf("route/agent = %s/%s, want research/researcher-id", sent.Route, sent.Agent)
 	}
 	if !slices.Equal(sent.ToolAllow, []string{"search_web", "retrieve_output"}) {
 		t.Fatalf("tool allowlist = %v, want authored list plus retrieve_output", sent.ToolAllow)
@@ -1857,6 +1857,50 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 	}
 	if recalled || strings.Contains(sent.System, "MEMORY BLOCK") {
 		t.Fatal("memory recall ran for a memory-off agent")
+	}
+}
+
+// TestRetryFallsBackToNameForOldSessionEvents covers the read-time
+// compatibility path (issue #615): a session's last user_message
+// persisted before agents were addressed by id still carries a name in
+// its agent field. Retry's id lookup misses that value, so it must
+// fall back to the name resolver wired via SetAgentResolverByName.
+func TestRetryFallsBackToNameForOldSessionEvents(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	if _, err := log.Append(t.Context(), "s1", session.KindUserMessage, session.UserMessage{
+		Text: "the question", Route: "mini", Agent: "researcher",
+	}); err != nil {
+		t.Fatalf("seed user_message: %v", err)
+	}
+	gw := &fakeGW{events: okEvents("the answer")}
+	byID := func(_ context.Context, id string) (agents.Agent, bool) {
+		if id == "" {
+			return agents.Agent{ID: "general-id", Name: "general", Route: "default"}, true
+		}
+		return agents.Agent{}, false // "researcher" is a name, not an id: unknown here
+	}
+	byName := func(_ context.Context, name string) (agents.Agent, bool) {
+		if name == "researcher" {
+			return agents.Agent{ID: "researcher-id", Name: "researcher", Route: "research"}, true
+		}
+		return agents.Agent{}, false
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, byID, discard())
+	svc.SetAgentResolverByName(byName)
+
+	_, ch, err := svc.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+
+	// Route is Retry's persisted verbatim (last.Route), not the
+	// resolved profile's: only the agent id resolution is under test
+	// here.
+	sent := chatRequest(t, gw)
+	if sent.Route != "mini" || sent.Agent != "researcher-id" {
+		t.Fatalf("route/agent = %s/%s, want mini/researcher-id (resolved via name fallback)", sent.Route, sent.Agent)
 	}
 }
 
@@ -2596,7 +2640,7 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
 			ApprovalAllowlist: []string{"list_calendar_events"}}, true
 	}
@@ -2604,7 +2648,7 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what's on my calendar", Agent: "scheduler"})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what's on my calendar", Agent: "agent-1"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -2624,14 +2668,14 @@ func TestChatWithoutAllowlistGrantsNothing(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-2", Name: "plain", Memory: true}, true
 	}
 	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: "plain"})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: "agent-2"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -2650,7 +2694,7 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
 			ApprovalAllowlist: []string{"list_calendar_events"}}, true
 	}
@@ -2658,7 +2702,7 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "scheduler"})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "agent-1"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -2667,7 +2711,7 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 	// drain returns, not synchronously with it (D-042).
 	waitFor(t, func() bool { return !svc.TurnActive("s1") })
 
-	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "scheduler"})
+	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "agent-1"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -2686,12 +2730,12 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
-		switch name {
-		case "scheduler":
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
+		switch id {
+		case "agent-1":
 			return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
 				ApprovalAllowlist: []string{"list_calendar_events"}}, true
-		case "mailer":
+		case "agent-2":
 			return agents.Agent{ID: "agent-2", Name: "mailer", Memory: true,
 				ApprovalAllowlist: []string{"gmail_search"}}, true
 		default:
@@ -2702,7 +2746,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "scheduler"})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "agent-1"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -2711,7 +2755,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 	// drain returns, not synchronously with it (D-042).
 	waitFor(t, func() bool { return !svc.TurnActive("s1") })
 
-	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "mailer"})
+	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "agent-2"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -3310,20 +3354,20 @@ func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("done")}
 	log := newFakeLog()
-	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
-		switch name {
-		case "", "general":
-			return agents.Agent{Name: "general", Route: "default"}, true
-		case "researcher":
-			return agents.Agent{Name: "researcher", Route: "research"}, true
+	resolver := func(_ context.Context, id string) (agents.Agent, bool) {
+		switch id {
+		case "", "general-id":
+			return agents.Agent{ID: "general-id", Name: "general", Route: "default"}, true
+		case "researcher-id":
+			return agents.Agent{ID: "researcher-id", Name: "researcher", Route: "research"}, true
 		default:
 			return agents.Agent{}, false
 		}
 	}
 	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	candidates := []agents.Agent{
-		{Name: "general", Description: "everyday tasks"},
-		{Name: "researcher", Description: "consults sources"},
+		{ID: "general-id", Name: "general", Description: "everyday tasks"},
+		{ID: "researcher-id", Name: "researcher", Description: "consults sources"},
 	}
 	svc.SetAutoDispatch(
 		func(context.Context) []agents.Agent { return candidates },
@@ -3337,7 +3381,7 @@ func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {
 	drain(t, ch)
 
 	sent := chatRequest(t, gw)
-	if sent.Agent != "general" || sent.Route != "default" {
-		t.Fatalf("agent/route = %s/%s, want general/default (dispatch fallback on classify error)", sent.Agent, sent.Route)
+	if sent.Agent != "general-id" || sent.Route != "default" {
+		t.Fatalf("agent/route = %s/%s, want general-id/default (dispatch fallback on classify error)", sent.Agent, sent.Route)
 	}
 }

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -412,7 +412,7 @@ CREATE TABLE IF NOT EXISTS connectors (
 -- default: the zero-click choice a new session gets.
 CREATE TABLE IF NOT EXISTS agents (
     id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    name           text UNIQUE NOT NULL,
+    name           text NOT NULL,
     description    text NOT NULL DEFAULT '',
     prompt_overlay text NOT NULL DEFAULT '',
     route          text NOT NULL DEFAULT '',
@@ -442,6 +442,11 @@ CREATE TABLE IF NOT EXISTS agents (
 
 CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
     ON agents ((true)) WHERE is_default;
+
+-- Case-insensitive unique name, trimmed: agents.name is a plain-text
+-- display name (issue #615), not a slug, so uniqueness is enforced
+-- here rather than as a column constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS agents_name_ci ON agents (lower(btrim(name)));
 
 -- Seed exactly one agent: 'general', because exactly one default
 -- agent must exist. Every other agent is created by the operator in

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -34,3 +34,19 @@ COMMIT;
 `mission_events` is append-only and is deliberately left alone: its
 historical rows keep whatever phase string they were written with, and
 `parsePhase` translates them on read.
+
+## Plain-text renameable agent names (issue #615)
+
+`agents.name` is now a trimmed, case-insensitive-unique display name
+instead of a lowercase-slug column constraint. Drop the old UNIQUE
+constraint and add the trimmed case-insensitive index.
+
+```sql
+BEGIN;
+
+ALTER TABLE agents DROP CONSTRAINT agents_name_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS agents_name_ci ON agents (lower(btrim(name)));
+
+COMMIT;
+```

--- a/web/src/components/AgentRoutePicker.test.tsx
+++ b/web/src/components/AgentRoutePicker.test.tsx
@@ -87,7 +87,7 @@ describe('AgentRoutePicker', () => {
     const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
     vi.mocked(listAgents).mockResolvedValue(agents)
     vi.mocked(listRoutes).mockResolvedValue(routes)
-    render(<AgentRoutePicker agent="general" onAgent={vi.fn()} route="local" onRoute={vi.fn()} />)
+    render(<AgentRoutePicker agent="1" onAgent={vi.fn()} route="local" onRoute={vi.fn()} />)
 
     const trigger = await screen.findByRole('button', { name: 'Agent and route' })
     await waitFor(() => expect(trigger).toHaveTextContent('general · local'))
@@ -102,7 +102,7 @@ describe('AgentRoutePicker', () => {
     ])
     render(
       <AgentRoutePicker
-        agent="general"
+        agent="1"
         onAgent={vi.fn()}
         route="disabled-route"
         onRoute={vi.fn()}
@@ -190,6 +190,6 @@ describe('AgentRoutePicker', () => {
     await screen.findByRole('button', { name: 'Agent and route' })
     openMenu('Agent and route')
     fireEvent.click(await screen.findByText('researcher'))
-    expect(onAgent).toHaveBeenCalledWith('researcher')
+    expect(onAgent).toHaveBeenCalledWith('2')
   })
 })

--- a/web/src/components/AgentRoutePicker.tsx
+++ b/web/src/components/AgentRoutePicker.tsx
@@ -34,7 +34,7 @@ export function AgentRoutePicker({
   const isAuto = agent === AUTO_AGENT
   const current = isAuto
     ? null
-    : (agents.find((a) => a.name === agent) ?? agents.find((a) => a.is_default) ?? null)
+    : (agents.find((a) => a.id === agent) ?? agents.find((a) => a.is_default) ?? null)
   const showRoutes = Boolean(onRoute) && routes !== null
   const isRouteAuto = !route
   const currentRoute = isRouteAuto
@@ -79,17 +79,17 @@ export function AgentRoutePicker({
           {isAuto && <Check className="mt-1 size-4 shrink-0" />}
         </DropdownMenuItem>
         {agents.map((a) => {
-          const selected = a.name === (current?.name ?? '')
+          const selected = a.id === (current?.id ?? '')
           return (
             <DropdownMenuItem
               key={a.id}
-              onSelect={() => onAgent(a.name)}
+              onSelect={() => onAgent(a.id)}
               data-selected={selected || undefined}
               className="h-auto items-start gap-3 rounded-md px-2.5 py-2 data-selected:bg-muted"
             >
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium capitalize">{a.name}</span>
+                  <span className="text-sm font-medium">{a.name}</span>
                   {a.is_default && <Badge variant="outline">Default</Badge>}
                 </div>
                 {a.description && (

--- a/web/src/components/settings/AgentAdd.test.tsx
+++ b/web/src/components/settings/AgentAdd.test.tsx
@@ -44,22 +44,22 @@ describe('AgentAdd', () => {
     const create = await screen.findByRole('button', { name: 'Create agent' })
     expect((create as HTMLButtonElement).disabled).toBe(true)
 
-    fireEvent.change(screen.getByPlaceholderText('infra, homelab, writer…'), { target: { value: 'infra' } })
+    fireEvent.change(screen.getByPlaceholderText('Infra, Homelab, Writer…'), { target: { value: 'infra' } })
     expect((create as HTMLButtonElement).disabled).toBe(false)
   })
 
-  it('creates the agent with slugified name and navigates to the list', async () => {
+  it('creates the agent with the plain-text name and navigates to the list', async () => {
     vi.mocked(createAgent).mockResolvedValue('a-new')
     renderAdd()
 
-    fireEvent.change(await screen.findByPlaceholderText('infra, homelab, writer…'), {
+    fireEvent.change(await screen.findByPlaceholderText('Infra, Homelab, Writer…'), {
       target: { value: 'My Infra Agent' },
     })
     fireEvent.click(screen.getByRole('button', { name: 'Create agent' }))
 
     await waitFor(() =>
       expect(createAgent).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'my-infra-agent', enabled: true, memory: true, harness: '' }),
+        expect.objectContaining({ name: 'My Infra Agent', enabled: true, memory: true, harness: '' }),
       ),
     )
     expect(await screen.findByText('agents list')).toBeTruthy()
@@ -69,7 +69,7 @@ describe('AgentAdd', () => {
     vi.mocked(createAgent).mockRejectedValue(new Error('name already exists'))
     renderAdd()
 
-    fireEvent.change(await screen.findByPlaceholderText('infra, homelab, writer…'), { target: { value: 'infra' } })
+    fireEvent.change(await screen.findByPlaceholderText('Infra, Homelab, Writer…'), { target: { value: 'infra' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create agent' }))
 
     await waitFor(() =>
@@ -81,7 +81,7 @@ describe('AgentAdd', () => {
   it('Cancel navigates to the agents list with no create call', async () => {
     renderAdd()
 
-    await screen.findByPlaceholderText('infra, homelab, writer…')
+    await screen.findByPlaceholderText('Infra, Homelab, Writer…')
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(await screen.findByText('agents list')).toBeTruthy()
@@ -103,7 +103,7 @@ describe('AgentAdd', () => {
     vi.mocked(createAgent).mockResolvedValue('a-new')
     renderAdd()
 
-    fireEvent.change(await screen.findByPlaceholderText('infra, homelab, writer…'), { target: { value: 'infra' } })
+    fireEvent.change(await screen.findByPlaceholderText('Infra, Homelab, Writer…'), { target: { value: 'infra' } })
     fireEvent.change(
       screen.getByPlaceholderText('Instructions, persona, house rules… Markdown supported.'),
       { target: { value: 'Be careful.' } },
@@ -131,7 +131,7 @@ describe('AgentAdd', () => {
     vi.mocked(createAgent).mockResolvedValue('a-new')
     renderAdd()
 
-    fireEvent.change(await screen.findByPlaceholderText('infra, homelab, writer…'), { target: { value: 'infra' } })
+    fireEvent.change(await screen.findByPlaceholderText('Infra, Homelab, Writer…'), { target: { value: 'infra' } })
     fireEvent.click(screen.getByRole('combobox', { name: 'agent harness' }))
     fireEvent.click(await screen.findByRole('option', { name: 'Claude Code' }))
     fireEvent.click(screen.getByRole('button', { name: 'Create agent' }))

--- a/web/src/components/settings/AgentAdd.tsx
+++ b/web/src/components/settings/AgentAdd.tsx
@@ -10,7 +10,6 @@ import { PageShell } from '../timothy/page-shell'
 import { AgentForm, useAgentForm } from './AgentForm'
 import { settingsArea } from './settingsAreas'
 import { errText } from '../../lib/errors'
-import { slugify } from '../../lib/slugify'
 
 const area = settingsArea('agents')
 
@@ -27,8 +26,9 @@ export function AgentAdd() {
   const submit = async () => {
     setBusy(true)
     try {
+      const name = value.name.trim()
       await createAgent({
-        name: slugify(value.name),
+        name,
         description: value.description,
         prompt_overlay: value.overlay,
         route: value.route,
@@ -39,7 +39,7 @@ export function AgentAdd() {
         harness: value.harness,
         enabled: true,
       })
-      toast.success('Agent created', { description: `${slugify(value.name)} is ready to serve sessions.` })
+      toast.success('Agent created', { description: `${name} is ready to serve sessions.` })
       navigate('/settings/agents')
     } catch (err) {
       toast.error('Could not create agent', { description: errText(err) })
@@ -66,7 +66,7 @@ export function AgentAdd() {
           void submit()
         }}
       >
-        <AgentForm isNew routes={routes} fields={fields} />
+        <AgentForm routes={routes} fields={fields} />
 
         <FormActions>
           <Button type="button" variant="outline" disabled={busy} onClick={() => navigate('/settings/agents')}>

--- a/web/src/components/settings/AgentEdit.test.tsx
+++ b/web/src/components/settings/AgentEdit.test.tsx
@@ -114,6 +114,18 @@ describe('AgentEdit', () => {
     )
   })
 
+  it('renders name as an editable field and includes it in the PATCH payload', async () => {
+    vi.mocked(patchAgent).mockResolvedValue()
+    renderEdit()
+
+    fireEvent.change(await screen.findByDisplayValue(coder.name), { target: { value: 'Coder Two' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchAgent).toHaveBeenCalledWith('a1', expect.objectContaining({ name: 'Coder Two' })),
+    )
+  })
+
   it('stages edits to overlay, route, memory, skills, and tools, all landing in the one PATCH', async () => {
     vi.mocked(patchAgent).mockResolvedValue()
     vi.mocked(listRoutes).mockResolvedValue([

--- a/web/src/components/settings/AgentEdit.tsx
+++ b/web/src/components/settings/AgentEdit.tsx
@@ -66,6 +66,7 @@ function AgentEditForm({
     setSaveError(null)
     try {
       await patchAgent(agent.id, {
+        name: staged.value.name.trim(),
         description: staged.value.description,
         prompt_overlay: staged.value.overlay,
         route: staged.value.route,
@@ -125,7 +126,7 @@ function AgentEditForm({
           void save()
         }}
       >
-        <AgentForm isNew={false} routes={routes} fields={staged.fields} />
+        <AgentForm routes={routes} fields={staged.fields} />
 
         {saveError && (
           <Alert tone="destructive">

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -11,7 +11,6 @@ import {
 import { Switch } from '../ui/switch'
 import { Field, FieldGroup } from '../timothy/field'
 import { UNSET } from './util'
-import { slugify } from '../../lib/slugify'
 import { AllowlistPicker } from './AllowlistPicker'
 import { EXECUTOR_DEFAULT, executorChoices } from '../missions/MissionForm'
 import { listKbCollections, listSkills, listTools } from '../../api/client'
@@ -55,7 +54,7 @@ export function useAgentForm() {
 
   return {
     value,
-    canSubmit: slugify(name) !== '',
+    canSubmit: name.trim() !== '',
     fields: {
       name,
       setName,
@@ -79,10 +78,11 @@ export function useAgentForm() {
   }
 }
 
-export type AgentStagedValue = Omit<AgentFormValue, 'name'>
+export type AgentStagedValue = AgentFormValue
 
 function baselineFrom(agent: AdminAgent): AgentStagedValue {
   return {
+    name: agent.name,
     description: agent.description,
     overlay: agent.prompt_overlay,
     route: agent.route,
@@ -108,8 +108,8 @@ export function useAgentEditForm(agent: AdminAgent) {
     rebase: (next: AdminAgent) => staged.rebase(baselineFrom(next)),
     value: staged.values,
     fields: {
-      name: agent.name,
-      setName: () => undefined,
+      name: staged.values.name,
+      setName: (v: string) => staged.setField('name', v),
       description: staged.values.description,
       setDescription: (v: string) => staged.setField('description', v),
       overlay: staged.values.overlay,
@@ -131,29 +131,24 @@ export function useAgentEditForm(agent: AdminAgent) {
 }
 
 // AgentForm renders the shared field set for both create and edit:
-// name is a one-time slug fixed at creation (it lives in ledger rows
-// and event payloads), so it's the only field Add shows that Edit
-// doesn't.
+// name is plain text, editable on both pages (the uuid is the stable
+// key, not the name).
 export function AgentForm({
-  isNew,
   routes,
   fields,
 }: {
-  isNew: boolean
   routes: AdminRoute[]
   fields: ReturnType<typeof useAgentForm>['fields'] | ReturnType<typeof useAgentEditForm>['fields']
 }) {
   return (
     <FieldGroup>
-      {isNew && (
-        <Field label="Name" description="unique slug, immutable after creation">
-          <Input
-            value={fields.name}
-            onChange={(e) => fields.setName(e.target.value)}
-            placeholder="infra, homelab, writer…"
-          />
-        </Field>
-      )}
+      <Field label="Name" description="unique, case-insensitive">
+        <Input
+          value={fields.name}
+          onChange={(e) => fields.setName(e.target.value)}
+          placeholder="Infra, Homelab, Writer…"
+        />
+      </Field>
       <Field label="Description" description="shown in the picker">
         <Input
           value={fields.description}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -106,9 +106,9 @@ export function Chat({
   // The serving agent's own bound collections: always searched, never
   // pinned by the user. Re-derived from the live agent selection (not
   // snapshotted) so switching agents mid-session updates the chips.
-  // Same fallback as AgentRoutePicker: an empty/unmatched agent name
+  // Same fallback as AgentRoutePicker: an empty/unmatched agent id
   // resolves to the default agent, the one that actually serves it.
-  const servingAgent = agents.find((a) => a.name === agent) ?? agents.find((a) => a.is_default)
+  const servingAgent = agents.find((a) => a.id === agent) ?? agents.find((a) => a.is_default)
   const agentKnowledge = servingAgent?.knowledge ?? []
   const [loadError, setLoadError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState(false)

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -129,7 +129,7 @@ describe('Home', () => {
     renderHome()
     fireEvent.click(await screen.findByRole('button', { name: /research/ }))
     expect(landed?.pathname).toBe('/chat')
-    expect(landed?.state?.agent).toBe('research')
+    expect(landed?.state?.agent).toBe('a2')
   })
 
   it('the Memory shortcut navigates to the memory page', () => {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -41,9 +41,9 @@ export function Home() {
   const [route, setRoute] = useState(() => localStorage.getItem(routeKey) ?? '')
   const [attachments, setAttachments] = useState<PendingAttachment[]>([])
   const [knowledge, setKnowledge] = useState<string[]>([])
-  // Same fallback as AgentRoutePicker: an empty/unmatched agent name
+  // Same fallback as AgentRoutePicker: an empty/unmatched agent id
   // resolves to the default agent, the one that actually serves it.
-  const servingAgent = agents.find((a) => a.name === agent) ?? agents.find((a) => a.is_default)
+  const servingAgent = agents.find((a) => a.id === agent) ?? agents.find((a) => a.is_default)
   const agentKnowledge = servingAgent?.knowledge ?? []
 
   const pickAgent = (a: string) => {
@@ -71,9 +71,9 @@ export function Home() {
     })
   }
 
-  const openAgent = (name: string) => {
-    pickAgent(name)
-    navigate('/chat', { state: { agent: name } satisfies ChatIntent })
+  const openAgent = (id: string) => {
+    pickAgent(id)
+    navigate('/chat', { state: { agent: id } satisfies ChatIntent })
   }
 
   return (
@@ -115,9 +115,9 @@ export function Home() {
               asChild
               className="flex flex-col gap-2 text-left"
             >
-              <button type="button" onClick={() => openAgent(a.name)} aria-label={a.name}>
+              <button type="button" onClick={() => openAgent(a.id)} aria-label={a.name}>
                 <div className="flex items-center gap-2">
-                  <span className="truncate text-sm font-semibold capitalize">{a.name}</span>
+                  <span className="truncate text-sm font-semibold">{a.name}</span>
                   {a.is_default && (
                     <Badge variant="brand" size="sm">
                       Default


### PR DESCRIPTION
## What

Agent names become plain text ("Hackathon Copilot"), editable after creation. The uuid is the only key.

- `agents.name`: trimmed, 1 to 64 runes, no control characters; unique case-insensitive via `agents_name_ci` on `lower(btrim(name))`. Slug regex removed. `0001_init.sql` edited in place, derived ALTER in `scripts/pending-alters.md`.
- PATCH accepts `name`; rename is audited; duplicate name returns `409 name_conflict`.
- Chat request `agent` is a uuid, `auto`, or empty. Names are rejected with the existing 400. Session event payloads and `cost_ledger.agent` carry the uuid from now on; the resume path falls back to a name lookup only for rows written before this change.
- Dispatch returns ids. Missions ledger sentinel labels are unchanged.
- Web: no slugify, name editable on the edit page and sent in PATCH, picker and chat state keyed by id, `capitalize` dropped from name labels.

## Verify

- `make build test vet lint`: pass, 0 lint issues
- `go vet -tags integration ./...`: pass
- web build, lint, test in Docker: pass (1845 tests)

## Deploy note

Run the ALTER from `scripts/pending-alters.md` on the homelab database after the image rolls out.

Closes #615

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791501856&installation_model_id=431401&pr_number=617&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F617&signature=91a8cc777be1a8790c2b67588ddb3a0e886324e877d74f9c4d3061b52c61d9c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->