### PR TITLE
feat(skills): add the hackathon skill pack

### DIFF
--- a/skills/hackathon/SKILL.md
+++ b/skills/hackathon/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: hackathon
+description: Carries a hackathon from its published rules to a submission-ready project. Extracts every rule and constraint first, ranks ideas that all comply, and builds toward the exact deliverables the judges expect. Use when a mission is given a hackathon link or an inline hackathon brief. Do not use for general coding or research tasks that have no rules document, deadline, or judging rubric to satisfy.
+---
+
+# Hackathon discipline
+
+## Rules
+
+- Rules before ideas. Given a link, fetch the main page with fetch_url and then every linked rules, FAQ, prizes, schedule, judging criteria, sponsor track, and terms page, HTML and PDF alike, before proposing anything. Follow links found on those pages as well until no new rules-bearing page appears.
+- If a search_kb tool is available, search the knowledge base for past entries, rubrics, and sponsor notes on the same event or organizer before the web.
+- Produce a rules checklist as the first artifact, `rules-checklist.md`, with one row per constraint: eligibility, team size, registration and submission deadlines, required deliverables (repository, demo video, writeup, sponsor technology), IP and license terms, disallowed content and data, and judging criteria with weights when published. Every row carries the source URL and the quoted sentence it comes from. Nothing enters the checklist without a quote.
+- Convert every deadline to Europe/Amsterdam with convert_time and show both the original and the converted time. State the remaining time from now to the submission deadline; that number drives feasibility later.
+- Given an inline brief instead of a link, build the same checklist from the pasted text. Anything the brief leaves open goes under `## Open questions`, one line per gap. Never fill a gap with an assumption.
+- Login-walled pages (Devpost dashboards, Discord, private docs) are unreachable through fetch_url. When one is hit, stop, name the page, and ask the operator for the pasted text. Do not guess what it says.
+- Propose three to five ideas in `ideas.md`, ranked by three factors in this order: feasibility in the remaining time, prize and judging fit, novelty. Each idea states which checklist rows constrain it and how it complies with each. An idea that violates any row is dropped and listed under `## Dropped` with the violated row; it is never ranked low instead.
+- Stop after the ideas. The build starts only after the operator picks one. When the mission has a followup_mission tool, offer to open the build mission with the chosen idea and the checklist attached.
+- In the build mission, the plan lists the submission pack as explicit units alongside the code: a README that maps each judging criterion to where the project meets it, a writeup draft in the platform's required shape and length, and a demo script timed to the allowed video length. A plan that only builds code is incomplete.
+- Every build unit that ships a deliverable names the checklist row it satisfies. Before declaring done, walk the checklist top to bottom and mark each row met, not applicable, or open; open rows go to the operator.
+- Use only libraries, models, and data the rules allow. When a sponsor technology is required for a track, it appears in the code, not only in the writeup.
+- Submitting on the platform and recording the demo video belong to the operator. Prepare the text, the script, and the repository state; do not claim either was done.
+
+## Anti-rationalization
+
+| Excuse                                                          | Rebuttal                                                                                                           |
+|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| "The rules page is long, the summary on the landing page is enough" | Landing pages omit eligibility and IP terms; fetch the full rules and quote them.                                |
+| "This idea is great, it only bends one rule"                    | A rule violation disqualifies the whole entry. Drop the idea and say which row it broke.                            |
+| "The deadline is obviously in my timezone"                      | Hackathon deadlines are published in the organizer's zone; convert and show both.                                   |
+| "I'll write the README and video script at the end if time allows" | The submission pack is a deliverable the judges score. It is planned as units, not leftovers.                    |
+| "The brief did not mention team size, so there is no limit"     | Silence in a brief is an open question, not permission.                                                            |
+| "I remember how Devpost submissions work"                       | Platforms change their required fields; read this event's page or ask for the pasted text.                         |
+| "The sponsor API is hard, I'll mention it in the writeup"       | Sponsor tracks are judged on real use; the technology must run in the code.                                        |
+
+## Red flags: stop and re-check
+
+- Ideas are being proposed and no `rules-checklist.md` exists yet.
+- A checklist row has a source URL but no quoted sentence, or a quote that was never retrieved.
+- A deadline appears in one timezone only.
+- An idea's compliance section names no checklist rows.
+- A dropped idea is ranked instead of listed under `## Dropped`.
+- The build plan has no unit for the README criteria map, the writeup, or the demo script.
+- Code is being written before the operator picked an idea.
+- A login wall was met and the mission is inferring the hidden content.
+
+## Evidence required
+
+- `rules-checklist.md` with one row per constraint, each carrying a source URL and a quoted sentence, deadlines shown in the organizer's zone and Europe/Amsterdam, and an `## Open questions` section (empty is acceptable, missing is not).
+- `ideas.md` with three to five ranked ideas, each naming the checklist rows it complies with, and a `## Dropped` section for rule-violating ideas.
+- In the build mission: a README with a judging-criteria map, a writeup draft, a demo script, and the final checklist walk with each row marked met, not applicable, or open.
+- Actual fetch_url results for every cited page; a search snippet or a remembered URL is not evidence.


### PR DESCRIPTION
## What

Adds `skills/hackathon/SKILL.md`, following the `coding` pack layout (rules, anti-rationalization table, red flags, evidence required).

The pack encodes the flow the Hackathon Copilot agent runs today from its prompt overlay:

- rules first: fetch the landing page plus every linked rules, FAQ, prizes, schedule, judging, sponsor and terms page (HTML and PDF through `fetch_url`), search the knowledge base, then write `rules-checklist.md` with a source URL and quoted sentence per row and deadlines converted to Europe/Amsterdam
- inline briefs produce the same checklist with gaps under `## Open questions`, never assumed
- login-walled pages stop the mission and ask for pasted text
- three to five ideas ranked by feasibility, prize fit, novelty; each names the checklist rows it complies with; violating ideas land under `## Dropped`, not ranked low
- build plans list the submission pack (README criteria map, writeup, demo script) as explicit units
- no safety decisions in the prompt; allowlists and gates stay in Go

Closes #613

## Verify

- `make skills-validate`: `ok: 5 skills valid`, embedding similarity check passed
- `go test -race ./internal/brain/skills/`: pass

## After merge

Release and homelab pin bump, then add `hackathon` to the agent's `skills` list via the admin API (the overlay stays as a short identity line).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791543446&installation_model_id=431401&pr_number=621&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F621&signature=c5192ea9906639131e4edf2b28b36cfa3b3b93c395c6f2252399c5cf63aa872c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->