### PR TITLE
fix(web): let callers override Input size classes

### DIFF
--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -125,7 +125,7 @@ export function SessionList() {
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search chats…"
               size="sm"
-              className="data-[size=sm]:pl-8"
+              className="pl-8"
             />
           </div>
         </SidebarGroupContent>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -124,7 +124,8 @@ export function SessionList() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search chats…"
-              className="h-8 pl-8"
+              size="sm"
+              className="data-[size=sm]:pl-8"
             />
           </div>
         </SidebarGroupContent>

--- a/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
@@ -43,7 +43,7 @@ export function KnowledgeCollectionAdd() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="product-docs, runbooks…"
-              className="mt-1.5 h-10"
+              className="mt-1.5"
             />
           </Field>
           <Field label="Description" description="what this collection covers">
@@ -51,7 +51,7 @@ export function KnowledgeCollectionAdd() {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What documents live here"
-              className="mt-1.5 h-10"
+              className="mt-1.5"
             />
           </Field>
         </div>

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -16,7 +16,11 @@ function Input({
       data-slot="input"
       data-size={size}
       className={cn(
-        "flex w-full min-w-0 rounded-md border border-input bg-card text-sm transition-[border-color,box-shadow,background-color] duration-100 ease-out outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-brand focus-visible:glow disabled:pointer-events-none disabled:cursor-not-allowed disabled:border-transparent disabled:bg-muted disabled:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive data-[size=default]:h-9 data-[size=default]:px-3.5 data-[size=sm]:h-8 data-[size=sm]:px-2.5",
+        "flex w-full min-w-0 rounded-md border border-input bg-card text-sm transition-[border-color,box-shadow,background-color] duration-100 ease-out outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-brand focus-visible:glow disabled:pointer-events-none disabled:cursor-not-allowed disabled:border-transparent disabled:bg-muted disabled:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive",
+        // Plain utilities, not data-[size] variants: variant utilities
+        // sort after plain ones in the generated CSS, so a caller's
+        // h-10 or pl-8 would never win against them.
+        size === "sm" ? "h-8 px-2.5" : "h-9 px-3.5",
         className
       )}
       {...props}

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -213,7 +213,6 @@ function Browser() {
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && search()}
           data-testid="memory-search"
-          className="h-10"
         />
         <Button onClick={search} disabled={busy}>
           Search
@@ -284,10 +283,9 @@ function Browser() {
             onChange={(e) => setNewFact(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && add()}
             data-testid="manual-add"
-            className="h-10"
           />
           <Select value={newType} onValueChange={setNewType}>
-            <SelectTrigger className="h-10 w-36" aria-label="Memory type">
+            <SelectTrigger className="w-36" aria-label="Memory type">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## What

The chats sidebar search icon overlapped the typed text. `Input` set padding and height through `data-[size=...]` variants; those utilities come after plain ones in the generated CSS, so every caller override on `Input` was silently ignored: the sidebar's `pl-8`/`h-8`, the inline rename's `h-6 px-1`, the design page's `pr-12` next to a trailing addon, and the `h-10` on the Memory and knowledge-collection forms.

Two commits:

1. Sidebar search uses `size="sm"` (the intended 32px input).
2. `Input` applies its size classes as plain utilities (`h-9 px-3.5` / `h-8 px-2.5`) so tailwind-merge and source order let callers override. The stale `h-10` overrides in `Memory.tsx` and `KnowledgeCollectionAdd.tsx` are removed: they predate the 36px control standard and would otherwise take effect next to 36px buttons and the `SelectTrigger`, whose own `h-10` is still ignored by the same variant pattern.

`SelectTrigger` and `Button` keep their variant-based sizing; nothing overrides them today except that dropped `h-10`.

## Verify

Playwright against the rebuilt local web, computed styles:

- sidebar search: padding-left 32px, height 32px, icon clear of the text
- sidebar rename input: 24px, padding 4px (the `h-6 px-1` the code always asked for)
- Memory search row and add row: input, button and select all 36px
- design page daily budget field: padding-right 48px, "USD" addon no longer overlaps

`npm run build`, `npm run lint` (0 errors), `npm test` (1845 passed) in node:24.18.0-alpine.
