### PR TITLE
ci(release): rebuild the go images when skills change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           fi
           files=$(git diff --name-only "${{ steps.prev.outputs.tag }}" "$GITHUB_SHA")
           changed() { echo "$files" | grep -qE "$1"; }
-          go_pattern='^(go\.mod|go\.sum|migrations/|internal/|cmd/|deploy/Dockerfile)'
+          go_pattern='^(go\.mod|go\.sum|migrations/|internal/|cmd/|skills/|deploy/Dockerfile)'
           for name in brain gateway memoryd sandboxd; do
             changed "$go_pattern" && echo "$name=true" >> "$GITHUB_OUTPUT" || echo "$name=false" >> "$GITHUB_OUTPUT"
           done


### PR DESCRIPTION
## What

Adds `skills/` to the release workflow's change filter for the Go images.

`deploy/Dockerfile` copies `skills/` into the brain image, but the filter only watched `go.mod`, `go.sum`, `migrations/`, `internal/`, `cmd/` and the Dockerfile. alpha.74 changed only `skills/` and `web/`, so the brain image was copied forward from alpha.73 and the deployed `/v1/admin/skills` still lists four packs.

Same fix would apply to any future non-Go input to the brain image; there are none today.

## Verify

Next tag (alpha.75) must rebuild brain, gateway, memoryd and sandboxd and `/v1/admin/skills` on the deployed instance lists `hackathon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791546302&installation_model_id=431401&pr_number=624&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F624&signature=69073bdedf2067dba626441b00c1973dbd9ddda4892f6e6e23605ffefe93cb82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->