### PR TITLE
build(brain): note the release filter next to the skills copy

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -29,6 +29,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM alpine:3.22.2 AS runtime-shell
 RUN apk add --no-cache curl git openssh-keygen
 COPY --from=build /out/app /app
+# Skill packs ship inside the brain image; release.yml's change filter
+# lists skills/ so a pack edit rebuilds it instead of copying forward.
 COPY skills/ /skills/
 RUN mkdir -p /workspace /attachments && chown nobody:nobody /workspace /attachments
 USER nobody


### PR DESCRIPTION
## What

Comment next to `COPY skills/ /skills/` in `deploy/Dockerfile` pointing at the release change filter.

## Why now

alpha.74 copied the brain image forward because the filter ignored `skills/`. #624 fixed the filter, but alpha.75's diff window (alpha.74..alpha.75) contained only the workflow change, so the brain was copied forward again. No published image has the hackathon pack. This commit touches a watched path, so the next tag rebuilds the Go images; the note keeps the two places in sync.

## Verify

After alpha.76 deploys, `/v1/admin/skills` on homelab lists `hackathon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791547545&installation_model_id=431401&pr_number=625&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F625&signature=13efc88c53d19aaccb5d888064e036b3391c1cec9115bbc6d9ac0d55b81b3554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->