### PR TITLE
fix(skills): pin hackathon row IDs so ideas cannot cite invented rows

### DIFF
--- a/skills/hackathon/SKILL.md
+++ b/skills/hackathon/SKILL.md
@@ -10,10 +10,12 @@ description: Carries a hackathon from its published rules to a submission-ready 
 - Rules before ideas. Given a link, fetch the main page with fetch_url and then every linked rules, FAQ, prizes, schedule, judging criteria, sponsor track, and terms page, HTML and PDF alike, before proposing anything. Follow links found on those pages as well until no new rules-bearing page appears.
 - If a search_kb tool is available, search the knowledge base for past entries, rubrics, and sponsor notes on the same event or organizer before the web.
 - Produce a rules checklist as the first artifact, `rules-checklist.md`, with one row per constraint: eligibility, team size, registration and submission deadlines, required deliverables (repository, demo video, writeup, sponsor technology), IP and license terms, disallowed content and data, and judging criteria with weights when published. Every row carries the source URL and the quoted sentence it comes from. Nothing enters the checklist without a quote.
+- Number the rows R1 upward with no gaps, and state the last ID used at the end of the file as `Rows: R1-Rn`. Every later reference to a row, in any file, uses one of those IDs. A row ID that is not in the checklist is a fabricated citation.
 - Convert every deadline to Europe/Amsterdam with convert_time and show both the original and the converted time. State the remaining time from now to the submission deadline; that number drives feasibility later.
 - Given an inline brief instead of a link, build the same checklist from the pasted text. Anything the brief leaves open goes under `## Open questions`, one line per gap. Never fill a gap with an assumption.
 - Login-walled pages (Devpost dashboards, Discord, private docs) are unreachable through fetch_url. When one is hit, stop, name the page, and ask the operator for the pasted text. Do not guess what it says.
 - Propose three to five ideas in `ideas.md`, ranked by three factors in this order: feasibility in the remaining time, prize and judging fit, novelty. Each idea states which checklist rows constrain it and how it complies with each. An idea that violates any row is dropped and listed under `## Dropped` with the violated row; it is never ranked low instead.
+- Before writing `ideas.md`, re-read `rules-checklist.md` and cite only IDs you can see in it. Cite the row for what it actually says: quote or paraphrase each row you name, so a wrong ID is visible as a mismatch. Never continue an ID sequence past the last row, and never carry a row number over from another event.
 - Stop after the ideas. The build starts only after the operator picks one. When the mission has a followup_mission tool, offer to open the build mission with the chosen idea and the checklist attached.
 - In the build mission, the plan lists the submission pack as explicit units alongside the code: a README that maps each judging criterion to where the project meets it, a writeup draft in the platform's required shape and length, and a demo script timed to the allowed video length. A plan that only builds code is incomplete.
 - Every build unit that ships a deliverable names the checklist row it satisfies. Before declaring done, walk the checklist top to bottom and mark each row met, not applicable, or open; open rows go to the operator.
@@ -31,6 +33,7 @@ description: Carries a hackathon from its published rules to a submission-ready 
 | "The brief did not mention team size, so there is no limit"     | Silence in a brief is an open question, not permission.                                                            |
 | "I remember how Devpost submissions work"                       | Platforms change their required fields; read this event's page or ask for the pasted text.                         |
 | "The sponsor API is hard, I'll mention it in the writeup"       | Sponsor tracks are judged on real use; the technology must run in the code.                                        |
+| "A row roughly like R31 must cover this, the checklist is long" | Open the checklist and read the ID. An unverified row number is a fabricated citation, not a shortcut.              |
 
 ## Red flags: stop and re-check
 
@@ -38,6 +41,7 @@ description: Carries a hackathon from its published rules to a submission-ready 
 - A checklist row has a source URL but no quoted sentence, or a quote that was never retrieved.
 - A deadline appears in one timezone only.
 - An idea's compliance section names no checklist rows.
+- A cited row ID is above the checklist's last row, or names a constraint the row does not contain.
 - A dropped idea is ranked instead of listed under `## Dropped`.
 - The build plan has no unit for the README criteria map, the writeup, or the demo script.
 - Code is being written before the operator picked an idea.
@@ -45,7 +49,7 @@ description: Carries a hackathon from its published rules to a submission-ready 
 
 ## Evidence required
 
-- `rules-checklist.md` with one row per constraint, each carrying a source URL and a quoted sentence, deadlines shown in the organizer's zone and Europe/Amsterdam, and an `## Open questions` section (empty is acceptable, missing is not).
-- `ideas.md` with three to five ranked ideas, each naming the checklist rows it complies with, and a `## Dropped` section for rule-violating ideas.
+- `rules-checklist.md` with one row per constraint, each carrying a row ID, a source URL and a quoted sentence, deadlines shown in the organizer's zone and Europe/Amsterdam, a closing `Rows: R1-Rn` line, and an `## Open questions` section (empty is acceptable, missing is not).
+- `ideas.md` with three to five ranked ideas, each naming checklist rows that exist in `rules-checklist.md`, and a `## Dropped` section for rule-violating ideas.
 - In the build mission: a README with a judging-criteria map, a writeup draft, a demo script, and the final checklist walk with each row marked met, not applicable, or open.
 - Actual fetch_url results for every cited page; a search snippet or a remembered URL is not evidence.


### PR DESCRIPTION
Closes #630.

## What

Mission `72f12459-7ab3-4b1b-9788-ad1b2ff23905` produced a `rules-checklist.md` with 25 rows and an `ideas.md` citing R26 through R35. Every one of those IDs is invented. The checklist itself is accurate and the ideas' prose reasoning is sound; only the cross-references point nowhere, which makes them look like traceability while being unfollowable.

The skill required each idea to name checklist rows, and flagged an idea that named none. Nothing covered an idea that named rows which do not exist.

## How

- The checklist contract now numbers rows R1 upward with no gaps and closes with a `Rows: R1-Rn` line, so the valid range lives in the artifact instead of being inferred by counting.
- The ideas step re-reads the checklist before writing and cites only IDs found there, quoting or paraphrasing each cited row so a wrong ID reads as a mismatch rather than a bare number.
- New red flag: a cited ID above the last row, or naming a constraint the row does not contain.
- New anti-rationalization row for guessing a plausible row number rather than opening the file.

## Verification

`make skills-validate` passes, 5 skills valid, embedding similarity check included.

Behavioral verification needs a mission run against the new pack, which requires a release since skills ship inside the brain image. Worth confirming on the next hackathon mission that `ideas.md` cites only rows present in `rules-checklist.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791570211&installation_model_id=431401&pr_number=631&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F631&signature=b461000e39fa996b6d4815c16f5cd0d02f6f46ef42d4773ee5cb4cc6b19de8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->