### PR TITLE
feat(missions): show the skill index in discover and plan

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1122,13 +1122,18 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// build so agent edits apply on the next turn. The load_skill tool
 	// is already in the mission builtin set; this makes the packs
 	// discoverable there.
-	driver.SetSkillsIndex(func(ctx context.Context, agentID string) string {
+	missionSkillsIndex := func(ctx context.Context, agentID string) string {
 		a, ok := agentReg.ResolveByID(ctx, agentID)
 		if !ok {
 			return ""
 		}
 		return skills.Index(skills.Allowed(packs, a.Skills))
-	})
+	}
+	driver.SetSkillsIndex(missionSkillsIndex)
+	// Issue #628: discover and plan get the same index, so a skill that
+	// defines the mission's output shape is loadable before the plan is
+	// committed rather than first seen in build.
+	nativeRunner.SetSkillsIndex(missionSkillsIndex)
 	if conns != nil && secrets != nil {
 		// A repo_url mission's clone token: resolve connector_id straight
 		// to its credential_ref's secret value, same as resolveSecret does

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -230,6 +230,13 @@ type nativeRunner struct {
 	// discover/plan prompts' date line; nil means UTC.
 	location func(ctx context.Context) *time.Location
 
+	// skillsIndex renders the agent's skill index for the discover and
+	// plan prompts (issue #628), so a skill that defines the mission's
+	// shape is loadable before the plan is committed rather than only
+	// in build. nil, or a mission with no agent, means no index: the
+	// same nil-safe contract as every resolver above.
+	skillsIndex func(ctx context.Context, agentID string) string
+
 	// askParker backs ask_user's park (D-088): nil means ask_user is
 	// never offered on any mission turn, same nil-safe contract as
 	// kbSearch/kbRead: a store wiring bug degrades to "no ask_user"
@@ -299,6 +306,14 @@ func (r *nativeRunner) SetProgressReader(pr ProgressReader) {
 // runner is built alongside).
 func (r *nativeRunner) SetLocation(loc func(ctx context.Context) *time.Location) {
 	r.location = loc
+}
+
+// SetSkillsIndex wires the per-agent skill index into the discover and
+// plan prompts (issue #628). Same resolver the driver renders into
+// worker packets; unset means those two phases show no index, which is
+// the behavior before this existed.
+func (r *nativeRunner) SetSkillsIndex(fn func(ctx context.Context, agentID string) string) {
+	r.skillsIndex = fn
 }
 
 // operatorNotePrefix marks a progress note as operator-authored
@@ -486,6 +501,23 @@ func (r *nativeRunner) kbDiscoverNudge(m Mission) string {
 		return ""
 	}
 	return " A curated knowledge base is available via search_kb: search it for anything relevant to the goal before concluding no research is needed."
+}
+
+// skillsNudge renders the agent's skill index for a discover or plan
+// prompt (issue #628). Before this, the index reached the work packet
+// only, so an agent whose skill defines the mission's whole output
+// shape planned without it and discovered the contract in build, with
+// the plan already committed. Empty when no resolver is wired, the
+// mission has no agent, or the agent lists no skills.
+func (r *nativeRunner) skillsNudge(ctx context.Context, m Mission) string {
+	if r.skillsIndex == nil || m.AgentID == "" {
+		return ""
+	}
+	index := r.skillsIndex(ctx, m.AgentID)
+	if index == "" {
+		return ""
+	}
+	return "\n\n" + index + "\nLoad a skill with load_skill before deciding how to approach the goal: a skill that fits sets the output contract this mission is judged against."
 }
 
 // connectorReadTools resolves m's read-only connector tools (nil
@@ -1198,7 +1230,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // failure. provider/model (issue #507) are who served the turn that
 // produced the returned notes; empty when the turn errored.
 func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, servedProvider, servedModel string, err error) {
-	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the build phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
+	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the build phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx) + r.skillsNudge(ctx, m)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if pc := m.ParentContext(); pc != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(pc)
@@ -1627,7 +1659,7 @@ func planSystemPrompt(hasPlan bool) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
-	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx)
+	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx) + r.skillsNudge(ctx, m)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if discoverNotes != "" {
 		user += "\n\nDiscovery findings:\n" + NeutralizeSlot(discoverNotes)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3294,3 +3294,70 @@ func TestRenderReviewContentCriteriaReplaceGoal(t *testing.T) {
 		t.Fatalf("legacy packet must render the goal:\n%s", legacy)
 	}
 }
+
+// TestSkillsIndexReachesDiscoverAndPlan pins issue #628: the agent's
+// skill index reached the work packet only, so a mission whose agent
+// carries a skill defining the output contract planned without it and
+// first loaded it in build, with the plan already committed.
+func TestSkillsIndexReachesDiscoverAndPlan(t *testing.T) {
+	const index = "Available skills:\n- hackathon: rules first, then ideas"
+	resolver := func(ctx context.Context, agentID string) string { return index }
+	m := Mission{ID: "m1", AgentID: "a1", Route: "default", Goal: "enter the hackathon"}
+
+	discoverAgent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(discoverNotesToolName, `{"findings":"ok"}`)},
+	}}
+	dr := newTestRunner(discoverAgent)
+	dr.SetSkillsIndex(resolver)
+	if _, _, _, err := dr.DiscoverSession(context.Background(), m); err != nil {
+		t.Fatalf("DiscoverSession: %v", err)
+	}
+	if got := discoverAgent.requests[0].System; !strings.Contains(got, index) {
+		t.Fatalf("discover system prompt missing skills index: %s", got)
+	}
+
+	planAgent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`)},
+	}}
+	pr := newTestRunner(planAgent)
+	pr.SetSkillsIndex(resolver)
+	if _, err := pr.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if got := planAgent.requests[0].System; !strings.Contains(got, index) {
+		t.Fatalf("plan system prompt missing skills index: %s", got)
+	}
+}
+
+// TestSkillsIndexAbsentWithoutResolverOrAgent pins the nil-safe
+// contract: no resolver, no agent, or an agent with no packs each
+// leave both prompts exactly as they were before #628.
+func TestSkillsIndexAbsentWithoutResolverOrAgent(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolver func(ctx context.Context, agentID string) string
+		agentID  string
+	}{
+		{name: "no resolver", resolver: nil, agentID: "a1"},
+		{name: "no agent", resolver: func(context.Context, string) string { return "Available skills:\n- x" }, agentID: ""},
+		{name: "agent with no packs", resolver: func(context.Context, string) string { return "" }, agentID: "a1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+				{toolEndEvent(discoverNotesToolName, `{"findings":"ok"}`)},
+			}}
+			r := newTestRunner(agent)
+			if tc.resolver != nil {
+				r.SetSkillsIndex(tc.resolver)
+			}
+			m := Mission{ID: "m1", AgentID: tc.agentID, Route: "default"}
+			if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
+				t.Fatalf("DiscoverSession: %v", err)
+			}
+			if got := agent.requests[0].System; strings.Contains(got, "Available skills") || strings.Contains(got, "load_skill") {
+				t.Fatalf("discover system prompt should carry no skill index: %s", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #628.

## What

`Driver.packet` renders the per-agent skill index, and `packet` is called only from `runExecute`. That made `load_skill` effectively a build-phase tool: discover and plan built their prompts elsewhere and never saw the index.

An agent whose skill defines the mission's output contract therefore planned without it, and met the contract only after the plan was already committed.

## Why

Mission `3cff23b2-6166-4827-99d6-a7f1fa2bb472` ran the Hackathon Copilot agent, whose overlay says every mission starts by loading the hackathon skill. The first `load_skill` call landed in build. By then the submitted plan was a single unit producing one merged document, where the skill's contract is two files with a hard stop between them for the operator's pick. The mission produced the wrong shape because the plan predated the skill.

## How

`nativeRunner` gains a nil-safe `skillsIndex` resolver alongside its existing ones, and `skillsNudge` renders it into the discover and plan system prompts, following `kbDiscoverNudge`'s shape. `main.go` wires the same closure the driver already gets, so there is one resolver and one definition of what an agent's packs are.

`load_skill` was already in the mission builtin set, so no tool surface changes. Only the index was missing.

Nothing else moves: prove and review are unchanged, and the delegated path still renders no index since it offers no `load_skill`.

## Verification

`make build test vet lint` passes with 0 lint issues, and `make canary` passes (4 model turns, 81s, PASS).

Two new tests:

- `TestSkillsIndexReachesDiscoverAndPlan` asserts the index appears in both system prompts.
- `TestSkillsIndexAbsentWithoutResolverOrAgent` covers the three nil-safe cases (no resolver, no agent, agent with no packs) and asserts neither prompt gains skill text.

Behavioral confirmation needs a release, since skills ship in the brain image. The check on the next hackathon mission is that `load_skill` appears in discover rather than build, and that the plan's units match the skill's two-file contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791571043&installation_model_id=431401&pr_number=632&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F632&signature=a30e8576a271e4e1e37485f7b9b35c0db0497b94f3b8f97e880eb50c93b745a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->