### PR TITLE
feat(skills): hackathon ideas carry research, build sketch and risk

### DIFF
--- a/skills/hackathon/SKILL.md
+++ b/skills/hackathon/SKILL.md
@@ -14,7 +14,24 @@ description: Carries a hackathon from its published rules to a submission-ready 
 - Convert every deadline to Europe/Amsterdam with convert_time and show both the original and the converted time. State the remaining time from now to the submission deadline; that number drives feasibility later.
 - Given an inline brief instead of a link, build the same checklist from the pasted text. Anything the brief leaves open goes under `## Open questions`, one line per gap. Never fill a gap with an assumption.
 - Login-walled pages (Devpost dashboards, Discord, private docs) are unreachable through fetch_url. When one is hit, stop, name the page, and ask the operator for the pasted text. Do not guess what it says.
-- Propose three to five ideas in `ideas.md`, ranked by three factors in this order: feasibility in the remaining time, prize and judging fit, novelty. Each idea states which checklist rows constrain it and how it complies with each. An idea that violates any row is dropped and listed under `## Dropped` with the violated row; it is never ranked low instead.
+- Generate a wide pool of candidates first, at least fifteen, and cut before researching. Drop the rule violators, the thin wrappers, the ones whose sponsor use is decorative, and the ones that cannot be demoed. Research only what survives; researching the whole pool wastes the time the build needs.
+- Research each surviving candidate against what already exists: products, GitHub, papers, articles, prior entries to this event, sponsor examples. Name the closest existing solution, what it already solves, and what this idea does differently. A candidate with no named comparison has not been researched.
+- Rate differentiation in words, not numbers: highly differentiated, differentiated, somewhat differentiated, crowded, incremental, or unclear. An empty search result means unclear, never novel. Say what the searches covered and what they could not reach.
+- Propose five ideas in `ideas.md` (three or four only when the rules narrow the space that far), ranked by three factors in this order: feasibility in the remaining time, prize and judging fit, novelty. Each idea states which checklist rows constrain it and how it complies with each. When the rules publish weighted judging criteria, rank against those weights and say which criterion decided a close call. Do not sum the criteria into one score: a total to two figures reads as a measurement, and this is a judgement. An idea that violates any row is dropped and listed under `## Dropped` with the violated row; it is never ranked low instead. `## Dropped` also carries the pool candidates that were cut, one line each with the reason: rule violation and its row, too generic, crowded, infeasible in the time, or undemoable. A cut with no reason is an idea that was forgotten, not judged.
+- Each idea carries enough for the operator to choose without asking a follow-up question, in this shape, roughly a page:
+
+```
+### <name>
+**Pitch:** one or two sentences: the problem, who has it, what the thing does end to end.
+**Fit:** why this event and this operator, naming the checklist rows that constrain it and how it complies with each.
+**Differentiation:** closest existing solution, what it already solves, what this does differently, and the rating in words.
+**Build:** components, sponsor technology, data and integrations, what runs where, and the thinnest version that still wins on the judging criteria.
+**Demo:** three or four beats, ending on what a judge remembers.
+**Why choose it:** the strongest single reason.
+**Why not:** the biggest risk to finishing in the time left, or the weakness a judge will find.
+```
+- Name what a judge would find non-obvious about each idea, and what the agent does that a single prompt or a scripted workflow could not. When the judging criteria weigh originality, the obvious framing of the event's own theme is the entry every other submission files: say so and go past it.
+- Ideas are for this operator, not a generic entrant. Use what the mission knows about them, their languages and stack, the infrastructure and data they already run, and the tasks they actually repeat. When a required sponsor technology rules out a standing preference, say which preference yields and why.
 - Before writing `ideas.md`, re-read `rules-checklist.md` and cite only IDs you can see in it. Cite the row for what it actually says: quote or paraphrase each row you name, so a wrong ID is visible as a mismatch. Never continue an ID sequence past the last row, and never carry a row number over from another event.
 - Stop after the ideas. The build starts only after the operator picks one. When the mission has a followup_mission tool, offer to open the build mission with the chosen idea and the checklist attached.
 - In the build mission, the plan lists the submission pack as explicit units alongside the code: a README that maps each judging criterion to where the project meets it, a writeup draft in the platform's required shape and length, and a demo script timed to the allowed video length. A plan that only builds code is incomplete.
@@ -33,6 +50,10 @@ description: Carries a hackathon from its published rules to a submission-ready 
 | "The brief did not mention team size, so there is no limit"     | Silence in a brief is an open question, not permission.                                                            |
 | "I remember how Devpost submissions work"                       | Platforms change their required fields; read this event's page or ask for the pasted text.                         |
 | "The sponsor API is hard, I'll mention it in the writeup"       | Sponsor tracks are judged on real use; the technology must run in the code.                                        |
+| "The operator can flesh out the interesting ideas themselves"   | An idea without a build sketch and a named risk cannot be chosen between. Cost the work before ranking it.          |
+| "The first ideas that fit the theme are the ideas"              | The obvious reading of the theme is what every other entry submits; originality is scored, so go past it.           |
+| "The search found nothing like it, so it is novel"              | An empty result is unclear, not novel. Name what was searched and what it could not reach.                          |
+| "Fifteen candidates is a lot of writing for five slots"         | The pool is thinking, not writing. One line each, then cut, then research the survivors.                            |
 | "A row roughly like R31 must cover this, the checklist is long" | Open the checklist and read the ID. An unverified row number is a fabricated citation, not a shortcut.              |
 
 ## Red flags: stop and re-check
@@ -42,6 +63,10 @@ description: Carries a hackathon from its published rules to a submission-ready 
 - A deadline appears in one timezone only.
 - An idea's compliance section names no checklist rows.
 - A cited row ID is above the checklist's last row, or names a constraint the row does not contain.
+- An idea is a one-liner with no build sketch, no demo beats, and no named risk.
+- An idea claims novelty, or names no existing solution to compare against.
+- The five ideas were written straight out, with no wider pool cut down first.
+- Every idea is the event theme's most obvious reading, or could have been written without knowing anything about this operator.
 - A dropped idea is ranked instead of listed under `## Dropped`.
 - The build plan has no unit for the README criteria map, the writeup, or the demo script.
 - Code is being written before the operator picked an idea.
@@ -50,6 +75,6 @@ description: Carries a hackathon from its published rules to a submission-ready 
 ## Evidence required
 
 - `rules-checklist.md` with one row per constraint, each carrying a row ID, a source URL and a quoted sentence, deadlines shown in the organizer's zone and Europe/Amsterdam, a closing `Rows: R1-Rn` line, and an `## Open questions` section (empty is acceptable, missing is not).
-- `ideas.md` with three to five ranked ideas, each naming checklist rows that exist in `rules-checklist.md`, and a `## Dropped` section for rule-violating ideas.
+- `ideas.md` with five ranked ideas (three or four only when the rules narrow the space that far), each naming checklist rows that exist in `rules-checklist.md`, each carrying pitch, fit, differentiation with a named closest solution and a worded rating, build sketch, demo beats, thinnest winning version, non-obvious angle, why choose it and why not, and a `## Dropped` section listing both the rule-violating ideas and the cut pool candidates, each with its reason.
 - In the build mission: a README with a judging-criteria map, a writeup draft, a demo script, and the final checklist walk with each row marked met, not applicable, or open.
 - Actual fetch_url results for every cited page; a search snippet or a remembered URL is not evidence.


### PR DESCRIPTION
## What

The hackathon skill stopped at a ranked list of ideas with a one-line pitch each. Choosing between them meant asking for the detail that actually decides it, so the artifact never stood on its own. Nothing checked whether an idea already existed, so a claim of novelty rested on the model not having looked.

Ideas now follow a fixed template: pitch, fit against the checklist rows, differentiation, build sketch, demo beats, why choose it, why not. Five ideas rather than three to five, roughly a page each.

Candidates come from a pool of at least fifteen that gets cut before any research, so the research budget goes to the survivors rather than the pool. Each survivor names its closest existing solution, what that already solves, and what this does differently, rated in words: highly differentiated through crowded to unclear. An empty search result is unclear, never novel. Cut candidates land under `## Dropped` with their reason.

Where the rules publish weighted judging criteria, the ranking follows those weights and says which criterion decided a close call. The criteria are not summed.

## Why

Two runs against the Agents for Humans hackathon produced lists that were correct and unusable. The first gave the four most obvious entries any submission to that event would file. The second, pushed for novelty, gave sharper concepts but still a paragraph each, with no build sketch and no risk, so the ranking could not be checked against what the work would cost. Neither run compared an idea to anything that already exists.

Two related additions the runs argued for:

- Name what a judge would find non-obvious, and what the agent does that a single prompt or a scripted workflow could not. Originality is a fifth of the score at this event, and the theme's obvious reading is what every other entry submits.
- Write for this operator rather than a generic entrant: their stack, the infrastructure they already run, the tasks they repeat. When a required sponsor technology rules out a standing preference, say which preference yields and why. The first run silently proposed a stack without noting that the required SDK does not support the operator's default language.

On the composite score: a weighted total over dimensions the model scores itself reads as a measurement when it is a judgement. The weights are worth following, the sum is not, so the skill takes the weights and forbids the total.

## How

Six rule lines added or extended across the ideas step, an output template block, four red flags, four anti-rationalization rows, and the evidence contract updated to match. The row-ID discipline, named artifacts, login-wall stop, both-timezone deadlines and submission-pack plan units are unchanged.

## Verification

`make skills-validate` passes, 5 skills valid, embedding similarity check included. No em dashes.

Behavioral verification needs a release, since skills ship inside the brain image. The check on the next hackathon mission is that a one-line goal produces five ideas, each carrying a build sketch, demo beats, a named closest existing solution and a named risk, with the cut pool visible under `## Dropped`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791573041&installation_model_id=431401&pr_number=633&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F633&signature=2c8076a462e875516a36cbee7fb7cf5e77322fe39c38040d3636431b02cee96a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->