### PR TITLE
feat(missions): search_memory so missions can recall on demand

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1083,6 +1083,27 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		return out, nil
 	}
 	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, kbReadFromStore(kb.New(db)), log)
+	// search_memory: nil-safe in the same sense as kbSearch above (mc
+	// is never nil), calling the same memclient.Retrieve chat's own
+	// per-turn recall uses. Missions read memory as a tool rather than
+	// a packet block (issue #627): a mission spans four phases and many
+	// turns, so what it needs to know about the operator is not knowable
+	// when the packet is built. Retrieval is global: memoryd's
+	// handleRetrieve ignores session_id, so the empty session here
+	// recalls the same set chat does.
+	nativeRunner.SetSearchMemory(func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error) {
+		rctx, cancel := context.WithTimeout(ctx, retrieveBudget)
+		defer cancel()
+		memories, err := mc.Retrieve(rctx, "", query)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]builtin.SearchMemoryHit, len(memories))
+		for i, m := range memories {
+			out[i] = builtin.SearchMemoryHit{Type: m.Type, Content: m.Content, Score: m.Score}
+		}
+		return out, nil
+	})
 	if conns != nil {
 		nativeRunner.SetConnectorReads(missionConnectorReadsResolver(agentReg, conns))
 	}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -214,6 +214,13 @@ type nativeRunner struct {
 	// as kbSearch.
 	kbRead KBReadFunc
 
+	// recall backs the per-turn search_memory ExtraTool: same nil
+	// contract as kbSearch. Missions get memory as a tool rather than
+	// a packet block (issue #627): a mission runs too many turns
+	// across too many phases for a create-time snapshot to hold what
+	// a given turn needs.
+	recall SearchMemoryFunc
+
 	// connectorReads resolves a mission's agent to the read-only
 	// connector tools (gmail/calendar reads) it may use on worker/discover
 	// turns (see SetConnectorReads): nil-safe: unset means no connector
@@ -430,6 +437,11 @@ func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
 // live-agent-boosted calls.
 type KBSearchFunc func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
+// SearchMemoryFunc runs one search_memory recall over long-term
+// memory: main curries memclient.Client.Retrieve in, the same call
+// chat's own per-turn recall makes.
+type SearchMemoryFunc func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error)
+
 // KBReadFunc loads one kb document by id, unscoped by collection
 // (D-078: collections no longer gate read access: issue #368).
 type KBReadFunc func(ctx context.Context, documentID string) (builtin.KBDocument, error)
@@ -487,6 +499,25 @@ func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
 	}
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		return r.kbRead(ctx, documentID)
+	})
+}
+
+// SetSearchMemory wires long-term memory recall for mission turns.
+// Optional: unwired means search_memory is never offered, exactly as
+// kbSearch behaves.
+func (r *nativeRunner) SetSearchMemory(fn SearchMemoryFunc) { r.recall = fn }
+
+// searchMemoryTool builds this turn's search_memory ExtraTool, gated
+// exactly like kbSearchTool. Offered in discover, plan and build, not
+// in review: the reviewer's tool set is deliberately narrow (D-093)
+// and what the operator prefers is not evidence about whether the work
+// under review is correct.
+func (r *nativeRunner) searchMemoryTool() *tools.Tool {
+	if r.recall == nil {
+		return nil
+	}
+	return builtin.SearchMemory(func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error) {
+		return r.recall(ctx, query)
 	})
 }
 
@@ -1103,6 +1134,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
+	if t := r.searchMemoryTool(); t != nil {
+		extra = append(extra, t)
+	}
 	extra = append(extra, r.connectorReadTools(ctx, m)...)
 	if t := r.askUserTool(m, PhaseBuild); t != nil {
 		extra = append(extra, t)
@@ -1251,6 +1285,9 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, s
 		extra = append(extra, t)
 	}
 	if t := r.kbReadTool(m); t != nil {
+		extra = append(extra, t)
+	}
+	if t := r.searchMemoryTool(); t != nil {
 		extra = append(extra, t)
 	}
 	extra = append(extra, r.connectorReadTools(ctx, m)...)
@@ -1676,6 +1713,9 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		extra = append(extra, t)
 	}
 	if t := r.kbReadTool(m); t != nil {
+		extra = append(extra, t)
+	}
+	if t := r.searchMemoryTool(); t != nil {
 		extra = append(extra, t)
 	}
 	if t := r.askUserTool(m, PhasePlan); t != nil {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3361,3 +3361,130 @@ func TestSkillsIndexAbsentWithoutResolverOrAgent(t *testing.T) {
 		})
 	}
 }
+
+// toolNames lists the ExtraTools a recorded request offered.
+func toolNames(req loop.Request) []string {
+	names := make([]string, 0, len(req.ExtraTools))
+	for _, t := range req.ExtraTools {
+		names = append(names, t.Name)
+	}
+	return names
+}
+
+func hasTool(req loop.Request, name string) bool {
+	return slices.Contains(toolNames(req), name)
+}
+
+// TestSearchMemoryReachesWorkingPhases pins issue #627: missions had no
+// read path to long-term memory at all, so a preference the operator
+// stated once in chat was silently absent from every mission turn. The
+// tool is offered where the operator's preferences change the work, and
+// withheld from review, whose tool set is deliberately narrow (D-093).
+func TestSearchMemoryReachesWorkingPhases(t *testing.T) {
+	recall := func(context.Context, string) ([]builtin.SearchMemoryHit, error) {
+		return []builtin.SearchMemoryHit{{Type: "semantic", Content: "Prefers Go."}}, nil
+	}
+	m := Mission{ID: "m1", Route: "default", ReviewRoute: "default", Goal: "build a thing"}
+
+	cases := []struct {
+		name  string
+		event stream.StreamEvent
+		run   func(r *nativeRunner) error
+		want  bool
+	}{
+		{
+			name:  "discover",
+			event: toolEndEvent(discoverNotesToolName, `{"findings":"ok"}`),
+			run: func(r *nativeRunner) error {
+				_, _, _, err := r.DiscoverSession(context.Background(), m)
+				return err
+			},
+			want: true,
+		},
+		{
+			name:  "plan",
+			event: toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`),
+			run: func(r *nativeRunner) error {
+				_, err := r.PlanSession(context.Background(), m, "")
+				return err
+			},
+			want: true,
+		},
+		{
+			name:  "build",
+			event: toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"tests pass"}`),
+			run: func(r *nativeRunner) error {
+				_, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"})
+				return err
+			},
+			want: true,
+		},
+		{
+			name:  "review",
+			event: toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`),
+			run: func(r *nativeRunner) error {
+				_, err := r.RunReview(context.Background(), m, ReviewPacket{Goal: "goal", Diff: "d"})
+				return err
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &scriptedAgent{batches: [][]stream.StreamEvent{{tc.event}}}
+			r := newTestRunner(agent)
+			r.SetSearchMemory(recall)
+			if err := tc.run(r); err != nil {
+				t.Fatalf("%s phase: %v", tc.name, err)
+			}
+			if got := hasTool(agent.requests[0], "search_memory"); got != tc.want {
+				t.Fatalf("%s offered search_memory = %v, want %v (tools: %v)",
+					tc.name, got, tc.want, toolNames(agent.requests[0]))
+			}
+		})
+	}
+}
+
+// TestSearchMemoryAbsentWithoutBackend pins the nil-safe contract: an
+// unwired runner never offers the tool, exactly as kbSearch behaves.
+func TestSearchMemoryAbsentWithoutBackend(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"tests pass"}`)},
+	}}
+	r := newTestRunner(agent)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if hasTool(agent.requests[0], "search_memory") {
+		t.Fatal("search_memory offered with no backend wired")
+	}
+}
+
+// TestSearchMemoryPlanNotForcedWhenOffered pins the D-063 interaction:
+// submit_plan is force-called only when it is the turn's sole tool, so
+// a planner offered search_memory can consult it before planning
+// instead of being forced straight into the plan.
+func TestSearchMemoryPlanNotForcedWhenOffered(t *testing.T) {
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	m := Mission{ID: "m1", Route: "default", Goal: "build a thing"}
+
+	bare := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	br := newTestRunner(bare)
+	if _, err := br.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession without memory: %v", err)
+	}
+	if bare.requests[0].ForceTool != planToolName {
+		t.Fatalf("ForceTool = %q, want %q when submit_plan is the only tool", bare.requests[0].ForceTool, planToolName)
+	}
+
+	withMem := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	mr := newTestRunner(withMem)
+	mr.SetSearchMemory(func(context.Context, string) ([]builtin.SearchMemoryHit, error) { return nil, nil })
+	if _, err := mr.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession with memory: %v", err)
+	}
+	if withMem.requests[0].ForceTool != "" {
+		t.Fatalf("ForceTool = %q, want empty when search_memory is also offered", withMem.requests[0].ForceTool)
+	}
+}

--- a/internal/brain/tools/builtin/searchmemory.go
+++ b/internal/brain/tools/builtin/searchmemory.go
@@ -1,0 +1,98 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// SearchMemoryHit is one recalled long-term memory; memclient.Memory
+// satisfies this shape, passed in as a plain struct to keep this
+// package free of a memclient import.
+type SearchMemoryHit struct {
+	Type    string
+	Content string
+	Score   float64
+}
+
+// SearchMemoryFunc runs one retrieval over long-term memory; main
+// curries memclient.Client.Retrieve in with the session already bound.
+type SearchMemoryFunc func(ctx context.Context, query string) ([]SearchMemoryHit, error)
+
+type searchMemoryArgs struct {
+	Query string `json:"query"`
+}
+
+// SearchMemory lets the model recall what Timothy knows about the
+// operator. Chat renders memory into every turn's system prompt; a
+// mission runs too many turns across too many phases for that to fit,
+// so a mission asks when the answer depends on it (issue #627).
+func SearchMemory(recall SearchMemoryFunc) *tools.Tool {
+	return &tools.Tool{
+		Name: "search_memory",
+		Description: `Searches long-term memory for what is known about the operator and returns matching memories.
+
+Use when the answer depends on the operator rather than on general
+knowledge: their preferred language or stack, conventions they have
+asked for, tools and infrastructure they already run, decisions they
+have already made. Search before assuming a default that the operator
+may have already stated.
+
+Arguments:
+- query (string, required): what to recall, in the operator's terms
+  ("preferred programming language", "deployment setup").
+
+Returns numbered memories, each with its tier (semantic for durable
+facts and preferences, episodic for events, procedural for how-tos).
+Zero matches is a normal answer and means nothing is recorded, not that
+the operator has no preference.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "string",
+					"description": "What to recall about the operator."
+				}
+			},
+			"required": ["query"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args searchMemoryArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("search_memory: invalid arguments: %w", err)
+			}
+			if strings.TrimSpace(args.Query) == "" {
+				return "", fmt.Errorf("search_memory: query must not be empty")
+			}
+			hits, err := recall(ctx, args.Query)
+			if err != nil {
+				return "", fmt.Errorf("search_memory: %w", err)
+			}
+			return formatMemoryHits(hits), nil
+		},
+	}
+}
+
+func formatMemoryHits(hits []SearchMemoryHit) string {
+	if len(hits) == 0 {
+		return "nothing recorded for that query"
+	}
+	var b strings.Builder
+	for i, h := range hits {
+		b.WriteString(strconv.Itoa(i + 1))
+		b.WriteString(". ")
+		if h.Type != "" {
+			b.WriteString("[")
+			b.WriteString(h.Type)
+			b.WriteString("] ")
+		}
+		b.WriteString(h.Content)
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/brain/tools/builtin/searchmemory_test.go
+++ b/internal/brain/tools/builtin/searchmemory_test.go
@@ -1,0 +1,99 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSearchMemory(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		hits    []SearchMemoryHit
+		recErr  error
+		want    string
+		wantErr string
+	}{
+		{
+			name: "returns numbered memories with tier",
+			args: `{"query":"preferred language"}`,
+			hits: []SearchMemoryHit{
+				{Type: "semantic", Content: "Prefers Go for every new project.", Score: 0.9},
+				{Type: "procedural", Content: "Runs the stack with docker compose.", Score: 0.4},
+			},
+			want: "1. [semantic] Prefers Go for every new project.\n2. [procedural] Runs the stack with docker compose.",
+		},
+		{
+			name: "zero matches is a normal answer",
+			args: `{"query":"favourite colour"}`,
+			hits: nil,
+			want: "nothing recorded for that query",
+		},
+		{
+			name: "memory without a tier still renders",
+			args: `{"query":"anything"}`,
+			hits: []SearchMemoryHit{{Content: "Bare fact."}},
+			want: "1. Bare fact.",
+		},
+		{
+			name:    "empty query rejected",
+			args:    `{"query":"   "}`,
+			wantErr: "query must not be empty",
+		},
+		{
+			name:    "invalid json rejected",
+			args:    `{"query":`,
+			wantErr: "invalid arguments",
+		},
+		{
+			name:    "backend error surfaces",
+			args:    `{"query":"stack"}`,
+			recErr:  errors.New("memoryd unreachable"),
+			wantErr: "memoryd unreachable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotQuery string
+			tool := SearchMemory(func(_ context.Context, query string) ([]SearchMemoryHit, error) {
+				gotQuery = query
+				return tc.hits, tc.recErr
+			})
+			if tool.Name != "search_memory" {
+				t.Fatalf("tool name = %q, want search_memory", tool.Name)
+			}
+			out, err := tool.Execute(context.Background(), json.RawMessage(tc.args))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out != tc.want {
+				t.Fatalf("output =\n%q\nwant\n%q", out, tc.want)
+			}
+			if gotQuery == "" {
+				t.Fatal("query was not passed through to the backend")
+			}
+		})
+	}
+}
+
+func TestSearchMemorySchemaValid(t *testing.T) {
+	tool := SearchMemory(func(context.Context, string) ([]SearchMemoryHit, error) { return nil, nil })
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
+		t.Fatalf("input schema is not valid json: %v", err)
+	}
+	req, ok := schema["required"].([]any)
+	if !ok || len(req) != 1 || req[0] != "query" {
+		t.Fatalf("required = %v, want [query]", schema["required"])
+	}
+}


### PR DESCRIPTION
Closes #627.

## What

Missions get `search_memory`, a read-only tool that recalls long-term memory on demand. Offered in discover, plan and build; withheld from review.

## Why

Chat renders recalled memory into every turn's system prompt. Missions had no read path at all: `SetMemoryExtract` writes on a terminal phase, and nothing ever read back. A preference the operator stated once in chat was recalled in chat and absent from every mission turn, so it had to be restated in each goal, and a mission started from a link or a pasted brief had nowhere natural to put it.

Observed on mission `3cff23b2`: the plan proposed a stack without reference to the operator's standing language preference, because no memory reached the turn.

## Why a tool and not a packet block

The issue originally proposed retrieving a block at mission create and rendering it into the phase prompt. That is the wrong shape here. A mission spans four phases and many turns, and what it needs to know about the operator is not knowable when the packet is built: the discoverer does not yet know the goal turns on implementation language. A snapshot either misses the memory that matters or pads every turn with memory that does not.

The knowledge base already answered this question the same way. Missions reach the KB through `search_kb` and `read_kb` as per-turn tools, and #482 removed the mission's Knowledge snapshot once it proved to only reorder results rather than gate them. Adding a memory snapshot next to that would reintroduce what #482 took out.

## How

`memclient.Retrieve` already exists and is the call chat makes, so this is a tool wrapper plus wiring, with nothing changed in memoryd.

- `builtin.SearchMemory` in `internal/brain/tools/builtin/searchmemory.go`, shaped after `kbsearch.go`: a plain hit struct so the package keeps no memclient import, query validation, and a numbered render carrying each memory's tier.
- `SearchMemoryFunc` field and `SetSearchMemory` on `nativeRunner`, nil-safe: unwired means the tool is not offered, exactly as `kbSearch` behaves.
- Appended to the discover, plan and build `ExtraTools`. Review is left alone: its tool set is deliberately narrow under D-093, and what the operator prefers is not evidence about whether the work under review is correct.
- Curried in `cmd/brain/main.go` from the same `mc` client and `retrieveBudget` chat uses. Session id is passed empty because `handleRetrieve` ignores it: retrieval is global, and passing a mission session would imply a scoping that does not exist.

Read-only, so permission-exempt per the builtin-tool convention.

One interaction worth noting: the planner force-calls `submit_plan` only when it is the turn's sole tool (D-063). Offering `search_memory` lifts that force, which is the wanted behaviour and is covered by a test.

## Verification

- `make build test vet lint` clean, 0 lint issues.
- `make canary` PASS, full discover to done progression.
- New tests: tool render, tiers, empty result, empty query, malformed args, backend error, schema shape; runner-side coverage that the three working phases offer the tool, that review does not, that an unwired runner offers nothing, and that `ForceTool` lifts when the tool is present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575305&installation_model_id=431401&pr_number=634&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F634&signature=d60d13bca74f08ff0ab4be8b6534fe0c0443144ac571d828e78ecc22ac1d20c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->