### PR TITLE
fix(missions): let the planner call load_skill when it has skills

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1696,7 +1696,8 @@ func planSystemPrompt(hasPlan bool) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
-	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx) + r.skillsNudge(ctx, m)
+	skillsHint := r.skillsNudge(ctx, m)
+	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx) + skillsHint
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if discoverNotes != "" {
 		user += "\n\nDiscovery findings:\n" + NeutralizeSlot(discoverNotes)
@@ -1735,7 +1736,12 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		// the turn's only BASE tool is none: a planner that reaches for
 		// shell parked a live canary on the permission gate for ten
 		// minutes trying to do the worker's job in plan phase.
-		ToolAllow:    []string{planToolName},
+		// load_skill is the one base tool let through, and only when
+		// the agent has skills to load (issue #638): it is read-only,
+		// and the skills nudge above asks the planner to call it, so
+		// filtering it out left the planner an instruction it could
+		// not follow and a plan that guessed at the artifact names.
+		ToolAllow:    planToolAllow(skillsHint),
 		ExtraTools:   extra,
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
@@ -1744,8 +1750,9 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 	}
 	// Force submit_plan only when it is the turn's sole tool (D-063):
 	// a KB-attached mission also offers search_kb/read_kb here, and a
-	// forced choice would make consulting them impossible.
-	if len(extra) == 1 {
+	// forced choice would make consulting them impossible. The same
+	// holds when load_skill is allowed (issue #638).
+	if len(extra) == 1 && skillsHint == "" {
 		req.ForceTool = planToolName
 	}
 	res, err := r.runTurn(ctx, req, planToolName, PhasePlan)
@@ -1986,4 +1993,15 @@ func defaultScope(artifacts []string) []string {
 		}
 	}
 	return out
+}
+
+// planToolAllow is the planner's base-tool allowlist: submit_plan
+// alone, plus load_skill when the turn carries a skills index to act
+// on (issue #638). Both are read-only from the workspace's point of
+// view, so the planner still cannot act.
+func planToolAllow(skillsHint string) []string {
+	if skillsHint == "" {
+		return []string{planToolName}
+	}
+	return []string{planToolName, "load_skill"}
 }

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3488,3 +3488,39 @@ func TestSearchMemoryPlanNotForcedWhenOffered(t *testing.T) {
 		t.Fatalf("ForceTool = %q, want empty when search_memory is also offered", withMem.requests[0].ForceTool)
 	}
 }
+
+// TestPlanSessionAllowsLoadSkillWithIndex pins issue #638: the skills
+// nudge asked the planner to call load_skill while ToolAllow filtered
+// it out, so the planner guessed at artifact names the skill defines.
+// With an index the tool is allowed and submit_plan is not forced;
+// without one the turn is exactly as before.
+func TestPlanSessionAllowsLoadSkillWithIndex(t *testing.T) {
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	m := Mission{ID: "m1", AgentID: "a1", Route: "default", Goal: "enter the hackathon"}
+
+	withIndex := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	r := newTestRunner(withIndex)
+	r.SetSkillsIndex(func(context.Context, string) string { return "Available skills:\n- hackathon" })
+	if _, err := r.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession with index: %v", err)
+	}
+	req := withIndex.requests[0]
+	if !slices.Contains(req.ToolAllow, "load_skill") || !slices.Contains(req.ToolAllow, planToolName) {
+		t.Fatalf("ToolAllow = %v, want submit_plan and load_skill", req.ToolAllow)
+	}
+	if req.ForceTool != "" {
+		t.Fatalf("ForceTool = %q, want empty so the planner can load the skill first", req.ForceTool)
+	}
+
+	without := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	br := newTestRunner(without)
+	if _, err := br.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession without index: %v", err)
+	}
+	if allow := without.requests[0].ToolAllow; len(allow) != 1 || allow[0] != planToolName {
+		t.Fatalf("ToolAllow = %v, want [%s] with no skills index", allow, planToolName)
+	}
+	if without.requests[0].ForceTool != planToolName {
+		t.Fatalf("ForceTool = %q, want %s with no skills index", without.requests[0].ForceTool, planToolName)
+	}
+}


### PR DESCRIPTION
Closes #638.

## What

When the plan turn carries a skills index, `ToolAllow` becomes `[submit_plan, load_skill]` and `ForceTool` is left empty. Without an index the turn is byte-identical to before.

## Why

#632 put the skill index in the plan prompt with "Load a skill with load_skill before deciding". The plan turn filtered `load_skill` out (`ToolAllow: []string{planToolName}`; `load_skill` is a base tool), so the planner could not obey.

Seen on `0849c6b7` (alpha.77, hackathon skill): `load_skill` fired once in discover, four times in build, zero in plan. Plan assumption recorded: "No exact artifact names were specified". Units produced `idea-ranking.md` and `setup-plan.md`; the skill names `rules-checklist.md` and `ideas.md`. Build then loaded the skill and worked the wrong plan to done.

## How

`planToolAllow(skillsHint)` returns the allowlist; the D-063 force guard gains `&& skillsHint == ""`, joining the existing carve-out for `search_kb`/`search_memory`. `load_skill` is read-only and permission-exempt, so the planner still cannot act.

## Verification

- `make build test vet lint` clean, 0 lint issues.
- `make canary` PASS.
- `TestPlanSessionAllowsLoadSkillWithIndex`: with an index, `ToolAllow` contains both tools and `ForceTool` is empty; without one, `[submit_plan]` and forced, as before. Existing `TestPlanSessionNoForceToolWithKB` and the ToolAllow pin at line 750 still pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791585188&installation_model_id=431401&pr_number=641&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F641&signature=b3af07935d64be062768c7ef8d208fe3b6da65c3b16debc1abf2be3d035018e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->