### PR TITLE
fix(tools): exempt search_memory from the permission prompt

### DIFF
--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -109,6 +109,10 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// read_kb is the same pure read, one document at a time,
 			// with the collection allowlist bound the same way.
 			"read_kb": true,
+			// search_memory is the same class of read over long-term
+			// memory (issue #648): the query is the only argument and
+			// nothing it returns reaches a side effect.
+			"search_memory": true,
 		},
 	}
 }

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -193,6 +193,21 @@ func TestResolveShortCircuits(t *testing.T) {
 		}
 	})
 
+	// search_kb, read_kb and search_memory are pure reads over stores
+	// scoped in Go; a prompt on them parks a mission on nothing (#648).
+	t.Run("store read tools exempt", func(t *testing.T) {
+		t.Parallel()
+		for _, tool := range []string{"search_kb", "read_kb", "search_memory"} {
+			res, err := p.Resolve(ctx, "s1", tool, json.RawMessage(`{"query":"q"}`))
+			if err != nil {
+				t.Fatalf("Resolve(%s): %v", tool, err)
+			}
+			if res.Decision != DecisionAllow {
+				t.Fatalf("Resolve(%s) = %+v, want allow", tool, res)
+			}
+		}
+	})
+
 	t.Run("mission sentinel tools exempt", func(t *testing.T) {
 		t.Parallel()
 		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan", "discover_notes", "ask_user"} {


### PR DESCRIPTION
Closes #648.

## What

`search_memory` joins `search_kb` and `read_kb` in the permission exempt map.

## Why

#634 shipped the tool and called it permission-exempt in the PR; the map was not updated. On `1c400061` (alpha.78) the discover turn called it with "operator preferred languages stack infrastructure hackathon preferences", the chain parked it with rationale "no standing grant", the ask timed out after ten minutes (#650), and the mission continued without memory. That is the exact situation #627 set out to remove.

Same reasoning as the two KB reads: a pure read over a store scoped in Go, one query argument, nothing it returns reaches a side effect.

## Verification

`make build test vet lint` clean. New subtest "store read tools exempt" asserts `search_kb`, `read_kb` and `search_memory` all resolve to allow with no grant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791588080&installation_model_id=431401&pr_number=651&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F651&signature=92f04a86784d7aaf67ade3b4df58934f7252bec85e9a0e5971f9b104a0ba14da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->