### PR TITLE
feat(missions): carry skills loaded in discover into the plan prompt

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1155,6 +1155,20 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// defines the mission's output shape is loadable before the plan is
 	// committed rather than first seen in build.
 	nativeRunner.SetSkillsIndex(missionSkillsIndex)
+	// Issue #649: a skill discover loaded reaches the plan prompt as
+	// its body, resolved against the agent's allowed packs.
+	nativeRunner.SetSkillBody(func(ctx context.Context, agentID, name string) string {
+		a, ok := agentReg.ResolveByID(ctx, agentID)
+		if !ok {
+			return ""
+		}
+		for _, sk := range skills.Allowed(packs, a.Skills) {
+			if sk.Name == name {
+				return sk.Body
+			}
+		}
+		return ""
+	})
 	if conns != nil && secrets != nil {
 		// A repo_url mission's clone token: resolve connector_id straight
 		// to its credential_ref's secret value, same as resolveSecret does

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -244,6 +244,10 @@ type nativeRunner struct {
 	// same nil-safe contract as every resolver above.
 	skillsIndex func(ctx context.Context, agentID string) string
 
+	// skillBody resolves a skill discover loaded to its body for the
+	// plan prompt (issue #649); nil-safe like skillsIndex.
+	skillBody func(ctx context.Context, agentID, name string) string
+
 	// askParker backs ask_user's park (D-088): nil means ask_user is
 	// never offered on any mission turn, same nil-safe contract as
 	// kbSearch/kbRead: a store wiring bug degrades to "no ask_user"
@@ -321,6 +325,78 @@ func (r *nativeRunner) SetLocation(loc func(ctx context.Context) *time.Location)
 // the behavior before this existed.
 func (r *nativeRunner) SetSkillsIndex(fn func(ctx context.Context, agentID string) string) {
 	r.skillsIndex = fn
+}
+
+// SetSkillBody wires the resolver that turns a skill name discover
+// loaded into the pack's body for the plan prompt (issue #649). Nil
+// means the plan prompt carries the index alone, as before.
+func (r *nativeRunner) SetSkillBody(fn func(ctx context.Context, agentID, name string) string) {
+	r.skillBody = fn
+}
+
+// loadedSkillsPrefix opens the first line of discover notes when the
+// discover turn loaded skills: "Skills loaded in discover: a, b". The
+// notes column is the one channel that already crosses from discover
+// to plan, and the marker goes first so the notes cap cannot cut it.
+const loadedSkillsPrefix = "Skills loaded in discover: "
+
+func loadedSkillsMarker(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	return loadedSkillsPrefix + strings.Join(names, ", ") + "\n\n"
+}
+
+// parseLoadedSkills reads the marker loadedSkillsMarker wrote, if the
+// notes start with one.
+func parseLoadedSkills(notes string) []string {
+	first, _, _ := strings.Cut(notes, "\n")
+	rest, ok := strings.CutPrefix(first, loadedSkillsPrefix)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, n := range strings.Split(rest, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// loadSkillArgName extracts the name from a load_skill call's args.
+func loadSkillArgName(args json.RawMessage) string {
+	var a struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(a.Name)
+}
+
+// loadedSkillsForPlan renders the bodies of the skills discover loaded
+// into the plan prompt (issue #649). Two earlier fixes put the index in
+// front of the planner and let it call load_skill; on a live run it
+// still went straight to submit_plan in under three seconds and named
+// artifacts the skill does not. What discover learned already reaches
+// the plan as notes; what discover loaded reaches it the same way.
+func (r *nativeRunner) loadedSkillsForPlan(ctx context.Context, m Mission, discoverNotes string) string {
+	if r.skillBody == nil || m.AgentID == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, name := range parseLoadedSkills(discoverNotes) {
+		body := r.skillBody(ctx, m.AgentID, name)
+		if body == "" {
+			continue
+		}
+		b.WriteString("\n\nThe skill \"")
+		b.WriteString(name)
+		b.WriteString("\" was loaded in discover and applies to this mission. Its rules set the artifacts, their names, and the evidence the plan must deliver:\n\n")
+		b.WriteString(body)
+	}
+	return b.String()
 }
 
 // operatorNotePrefix marks a progress note as operator-authored
@@ -721,6 +797,7 @@ type turnResult struct {
 	text         string
 	sentinelArgs json.RawMessage
 	seenURLs     []string
+	loadedSkills []string // names passed to successful load_skill calls, in order
 	finalSeg     string
 	askedUser    bool
 	provider     string
@@ -776,7 +853,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	}
 	var b, finalB strings.Builder
 	var sentinelArgs json.RawMessage
-	var seenURLs []string
+	var seenURLs, loadedSkills []string
 	askedUser := false
 	// parked tracks in-flight parks by CallID, not a single flag: a
 	// turn can issue concurrent tool calls (executeAll runs up to
@@ -836,6 +913,11 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			}
 			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_web" {
 				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Content)...)
+			}
+			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "load_skill" {
+				if name := loadSkillArgName(ev.ToolResult.Args); name != "" && !slices.Contains(loadedSkills, name) {
+					loadedSkills = append(loadedSkills, name)
+				}
 			}
 			// D-088: a successful ask_user call ends the turn with no
 			// sentinel call at all: the caller must not read that as a
@@ -898,7 +980,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	if servedModel != "" && r.belowFloor(servedModel) {
 		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, nil
+	return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, loadedSkills: loadedSkills, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, nil
 }
 
 // webFetchArgURL extracts the url arg from a fetch_url call's raw
@@ -1320,7 +1402,7 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, s
 		return "", "", "", ErrAskedUser
 	}
 	if report, ok := tryParseFindings(res.sentinelArgs); ok {
-		return r.applyDiscoverReport(ctx, m, report), res.provider, res.model, nil
+		return loadedSkillsMarker(res.loadedSkills) + r.applyDiscoverReport(ctx, m, report), res.provider, res.model, nil
 	}
 
 	// One recovery re-run, same ladder shape as RunWorker/PlanSession.
@@ -1697,7 +1779,7 @@ func planSystemPrompt(hasPlan bool) string {
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
 	skillsHint := r.skillsNudge(ctx, m)
-	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx) + skillsHint
+	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx) + skillsHint + r.loadedSkillsForPlan(ctx, m, discoverNotes)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if discoverNotes != "" {
 		user += "\n\nDiscovery findings:\n" + NeutralizeSlot(discoverNotes)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3524,3 +3524,66 @@ func TestPlanSessionAllowsLoadSkillWithIndex(t *testing.T) {
 		t.Fatalf("ForceTool = %q, want %s with no skills index", without.requests[0].ForceTool, planToolName)
 	}
 }
+
+// TestLoadedSkillsCarryIntoPlan pins issue #649: a skill the discover
+// turn loaded reaches the plan prompt as its body, through the notes
+// channel that already crosses phases. Without a body resolver the
+// marker is still written and the plan prompt is untouched.
+func TestLoadedSkillsCarryIntoPlan(t *testing.T) {
+	m := Mission{ID: "m1", AgentID: "a1", Route: "default", Goal: "enter the hackathon"}
+	discoverAgent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		finishedToolResultEvent("c1", "load_skill", "ok", `{"name":"hackathon"}`, 5),
+		finishedToolResultEvent("c2", "load_skill", "ok", `{"name":"hackathon"}`, 5),
+		toolEndEvent(discoverNotesToolName, `{"findings":"rules read"}`),
+	}}}
+	dr := newTestRunner(discoverAgent)
+	notes, _, _, err := dr.DiscoverSession(context.Background(), m)
+	if err != nil {
+		t.Fatalf("DiscoverSession: %v", err)
+	}
+	if !strings.HasPrefix(notes, "Skills loaded in discover: hackathon\n\n") || !strings.Contains(notes, "rules read") {
+		t.Fatalf("discover notes = %q, want marker line then findings", notes)
+	}
+	if got := parseLoadedSkills(notes); len(got) != 1 || got[0] != "hackathon" {
+		t.Fatalf("parseLoadedSkills = %v, want [hackathon] (deduplicated)", got)
+	}
+
+	const body = "Produce a rules checklist as the first artifact, rules-checklist.md"
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	planAgent := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	pr := newTestRunner(planAgent)
+	var askedFor string
+	pr.SetSkillBody(func(_ context.Context, agentID, name string) string {
+		askedFor = agentID + "/" + name
+		return body
+	})
+	if _, err := pr.PlanSession(context.Background(), m, notes); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if askedFor != "a1/hackathon" {
+		t.Fatalf("resolver asked for %q, want a1/hackathon", askedFor)
+	}
+	if sys := planAgent.requests[0].System; !strings.Contains(sys, body) || !strings.Contains(sys, `"hackathon" was loaded in discover`) {
+		t.Fatalf("plan system prompt missing loaded skill body: %s", sys)
+	}
+
+	bare := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
+	br := newTestRunner(bare)
+	if _, err := br.PlanSession(context.Background(), m, notes); err != nil {
+		t.Fatalf("PlanSession without resolver: %v", err)
+	}
+	if strings.Contains(bare.requests[0].System, "was loaded in discover") {
+		t.Fatal("plan prompt carried a skill body with no resolver wired")
+	}
+}
+
+func TestParseLoadedSkillsIgnoresPlainNotes(t *testing.T) {
+	for _, notes := range []string{"", "Stack: go.\n\nfindings", "Skills loaded elsewhere: x"} {
+		if got := parseLoadedSkills(notes); got != nil {
+			t.Fatalf("parseLoadedSkills(%q) = %v, want nil", notes, got)
+		}
+	}
+	if got := parseLoadedSkills("Skills loaded in discover: a, b ,\n\nx"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("parseLoadedSkills = %v, want [a b]", got)
+	}
+}


### PR DESCRIPTION
Closes #649.

## What

A skill the discover turn loaded reaches the plan prompt as its body. Discover notes open with `Skills loaded in discover: <names>`; `PlanSession` parses that line, resolves each name through a `SetSkillBody` resolver wired from `cmd/brain/main.go`, and renders the body with a heading saying the skill sets the plan's artifacts and evidence.

## Why

Third fix in this line. #632 put the skill index in the plan prompt. #638 let the planner call `load_skill`. On `1c400061` (alpha.78, both live) discover loaded the hackathon skill and ran ten minutes; plan took 2.5 s, called only `submit_plan`, and produced one unit writing `everyday_agents_ideas.md`. The skill names `rules-checklist.md` and `ideas.md`.

Asking the planner to reload is the wrong shape. Each phase is a cold session, and the planner is the one turn in the mission tuned to be short. Discover's findings already cross as notes; what discover loaded should cross the same way.

## How

- `turnResult.loadedSkills`: names from successful `load_skill` results in the turn's trace, deduplicated.
- `DiscoverSession` prefixes `loadedSkillsMarker` to the notes. First line, so `discoverNotesCap` cannot truncate it.
- `PlanSession` calls `loadedSkillsForPlan`: parses the marker, resolves bodies, appends after the skills nudge. Index and `load_skill` stay for skills discover did not load.
- Resolver in main resolves against `skills.Allowed(packs, agent.Skills)`, so a name the agent may not use returns nothing.
- Nil resolver or no agent: plan prompt byte-identical to before.

No schema: `discover_notes` is the existing channel.

## Verification

- `make build test vet lint` clean, 0 lint issues.
- `make canary` PASS.
- `TestLoadedSkillsCarryIntoPlan`: discover with two `load_skill` results writes one deduplicated marker; plan with a resolver carries the body and asks for `agent/name`; plan without a resolver carries nothing.
- `TestParseLoadedSkillsIgnoresPlainNotes`: plain notes, stack-prefixed notes and a look-alike line all parse to nil; trailing commas and spaces are tolerated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791588128&installation_model_id=431401&pr_number=652&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F652&signature=a2c62711bc71b38a53684eade5e89618a3723a0407738e2bf2929df7071ac3c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->