### PR TITLE
feat(tools): state the negative space in tool descriptions

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1091,12 +1091,17 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// when the packet is built. Retrieval is global: memoryd's
 	// handleRetrieve ignores session_id, so the empty session here
 	// recalls the same set chat does.
-	nativeRunner.SetSearchMemory(func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error) {
+	nativeRunner.SetSearchMemory(func(ctx context.Context, query string, limit int) ([]builtin.SearchMemoryHit, error) {
 		rctx, cancel := context.WithTimeout(ctx, retrieveBudget)
 		defer cancel()
 		memories, err := mc.Retrieve(rctx, "", query)
 		if err != nil {
 			return nil, err
+		}
+		// /v1/retrieve has no limit parameter; the tool's ceiling is
+		// applied to the returned set.
+		if len(memories) > limit {
+			memories = memories[:limit]
 		}
 		out := make([]builtin.SearchMemoryHit, len(memories))
 		for i, m := range memories {

--- a/internal/brain/connectors/caldav_tools.go
+++ b/internal/brain/connectors/caldav_tools.go
@@ -34,7 +34,7 @@ func (s *caldavSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "list_calendar_events",
 		ReadOnly:    true,
-		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
+		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event. Do not use this to search mail for an invitation or a booking confirmation; use search_mail for that. This tool lists a calendar window, it does not search by keyword.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"time_min":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
 			"time_max":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -1219,3 +1219,18 @@ func TestGoogleSourceTestRefreshesToken(t *testing.T) {
 		t.Fatal("corrupt bundle accepted")
 	}
 }
+
+// TestSearchDriveDescriptionNamesReadDriveFile is issue #645's drift
+// guard for the drive search surface, kept here rather than in the
+// cross-kind test because search_drive is google-only.
+func TestSearchDriveDescriptionNamesReadDriveFile(t *testing.T) {
+	t.Parallel()
+	src, _ := connectedDriveDocsSource(t, &fakeGoogle{})
+	desc := toolByName(t, src, "search_drive").Description
+	if !strings.Contains(strings.ToLower(desc), "do not use this") {
+		t.Error("search_drive: description states no negative space")
+	}
+	if !strings.Contains(desc, "read_drive_file") {
+		t.Error("search_drive: description does not name read_drive_file")
+	}
+}

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -299,7 +299,10 @@ func (s *googleSource) gmailSearch() *tools.Tool {
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
 read_mail with an id for the full body. See the tool description's
-Connected accounts list for this account's query syntax.`,
+Connected accounts list for this account's query syntax.
+Do not use this to read a message you already have an id for; use
+read_mail for that. Search returns snippets, read_mail returns the
+body.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
 			"max_results":{"type":"integer","minimum":1,"maximum":25}
@@ -389,7 +392,7 @@ func (s *googleSource) gmailRead() *tools.Tool {
 	return &tools.Tool{
 		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content. Do not use this to find messages, and never guess an id; use search_mail and read_mail only on an id it returned.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -528,7 +531,7 @@ func (s *googleSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "list_calendar_events",
 		ReadOnly:    true,
-		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
+		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event. Do not use this to search mail for an invitation or a booking confirmation; use search_mail for that. This tool lists a calendar window, it does not search by keyword.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"time_min":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
 			"time_max":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
@@ -670,7 +673,10 @@ func (s *googleSource) driveSearch() *tools.Tool {
 against file names and, for supported formats, document content
 (Drive's "fullText contains" search). Returns up to max_results
 (default 20) files as id, name, mimeType, modifiedTime, webViewLink.
-Use read_drive_file with an id to read a file's content.`,
+Use read_drive_file with an id to read a file's content.
+Do not use this to read a file you already have an id for; use
+read_drive_file for that. Search lists files, read_drive_file returns
+the content.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"words to match against file name and content"},
 			"max_results":{"type":"integer","minimum":1,"maximum":50}

--- a/internal/brain/connectors/imap_tools.go
+++ b/internal/brain/connectors/imap_tools.go
@@ -393,7 +393,10 @@ func (s *imapSource) mailSearch() *tools.Tool {
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
 read_mail with an id for the full body. See the tool description's
-Connected accounts list for this account's query syntax.`,
+Connected accounts list for this account's query syntax.
+Do not use this to read a message you already have an id for; use
+read_mail for that. Search returns snippets, read_mail returns the
+body.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
 			"max_results":{"type":"integer","minimum":1,"maximum":25}
@@ -444,7 +447,7 @@ func (s *imapSource) mailRead() *tools.Tool {
 	return &tools.Tool{
 		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content. Do not use this to find messages, and never guess an id; use search_mail and read_mail only on an id it returned.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),

--- a/internal/brain/connectors/microsoft_tools.go
+++ b/internal/brain/connectors/microsoft_tools.go
@@ -215,7 +215,10 @@ func (s *microsoftSource) mailSearch() *tools.Tool {
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
 read_mail with an id for the full body. See the tool description's
-Connected accounts list for this account's query syntax.`,
+Connected accounts list for this account's query syntax.
+Do not use this to read a message you already have an id for; use
+read_mail for that. Search returns snippets, read_mail returns the
+body.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
 			"max_results":{"type":"integer","minimum":1,"maximum":25}
@@ -260,7 +263,7 @@ func (s *microsoftSource) mailRead() *tools.Tool {
 	return &tools.Tool{
 		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content. Do not use this to find messages, and never guess an id; use search_mail and read_mail only on an id it returned.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -456,7 +459,7 @@ func (s *microsoftSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "list_calendar_events",
 		ReadOnly:    true,
-		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
+		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event. Do not use this to search mail for an invitation or a booking confirmation; use search_mail for that. This tool lists a calendar window, it does not search by keyword.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"time_min":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
 			"time_max":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},

--- a/internal/brain/connectors/unified_tools_test.go
+++ b/internal/brain/connectors/unified_tools_test.go
@@ -1,6 +1,7 @@
 package connectors
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -85,5 +86,33 @@ func TestSharedToolSchemasMatchAcrossKinds(t *testing.T) {
 	}
 	if shared == 0 {
 		t.Fatal("no shared tool names found across kinds: test setup is broken")
+	}
+
+	// Issue #645: the read-vs-search and list-vs-search contrasts must
+	// stay in these descriptions so the model routes between them
+	// without guessing.
+	contrasts := map[string]string{
+		"search_mail":          "read_mail",
+		"read_mail":            "search_mail",
+		"list_calendar_events": "search_mail",
+	}
+	for name, want := range contrasts {
+		var checked int
+		for kind, tls := range byKind {
+			shape, ok := tls[name]
+			if !ok {
+				continue
+			}
+			checked++
+			if !strings.Contains(strings.ToLower(shape.desc), "do not use this") {
+				t.Errorf("tool %s (%s): description states no negative space", name, kind)
+			}
+			if !strings.Contains(shape.desc, want) {
+				t.Errorf("tool %s (%s): description does not name %s", name, kind, want)
+			}
+		}
+		if checked == 0 {
+			t.Errorf("tool %s was served by no kind: test setup is broken", name)
+		}
 	}
 }

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -516,7 +516,7 @@ type KBSearchFunc func(ctx context.Context, query string, boostCollections []str
 // SearchMemoryFunc runs one search_memory recall over long-term
 // memory: main curries memclient.Client.Retrieve in, the same call
 // chat's own per-turn recall makes.
-type SearchMemoryFunc func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error)
+type SearchMemoryFunc func(ctx context.Context, query string, limit int) ([]builtin.SearchMemoryHit, error)
 
 // KBReadFunc loads one kb document by id, unscoped by collection
 // (D-078: collections no longer gate read access: issue #368).
@@ -592,8 +592,8 @@ func (r *nativeRunner) searchMemoryTool() *tools.Tool {
 	if r.recall == nil {
 		return nil
 	}
-	return builtin.SearchMemory(func(ctx context.Context, query string) ([]builtin.SearchMemoryHit, error) {
-		return r.recall(ctx, query)
+	return builtin.SearchMemory(func(ctx context.Context, query string, limit int) ([]builtin.SearchMemoryHit, error) {
+		return r.recall(ctx, query, limit)
 	})
 }
 

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3381,7 +3381,7 @@ func hasTool(req loop.Request, name string) bool {
 // tool is offered where the operator's preferences change the work, and
 // withheld from review, whose tool set is deliberately narrow (D-093).
 func TestSearchMemoryReachesWorkingPhases(t *testing.T) {
-	recall := func(context.Context, string) ([]builtin.SearchMemoryHit, error) {
+	recall := func(context.Context, string, int) ([]builtin.SearchMemoryHit, error) {
 		return []builtin.SearchMemoryHit{{Type: "semantic", Content: "Prefers Go."}}, nil
 	}
 	m := Mission{ID: "m1", Route: "default", ReviewRoute: "default", Goal: "build a thing"}
@@ -3480,7 +3480,7 @@ func TestSearchMemoryPlanNotForcedWhenOffered(t *testing.T) {
 
 	withMem := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
 	mr := newTestRunner(withMem)
-	mr.SetSearchMemory(func(context.Context, string) ([]builtin.SearchMemoryHit, error) { return nil, nil })
+	mr.SetSearchMemory(func(context.Context, string, int) ([]builtin.SearchMemoryHit, error) { return nil, nil })
 	if _, err := mr.PlanSession(context.Background(), m, ""); err != nil {
 		t.Fatalf("PlanSession with memory: %v", err)
 	}

--- a/internal/brain/tools/builtin/kbread.go
+++ b/internal/brain/tools/builtin/kbread.go
@@ -38,6 +38,9 @@ Use after search_kb when the returned passages are not enough — to see
 a passage's surrounding context, or to read the whole document a hit
 came from.
 
+Do not use this to find a document you do not already have a reference
+for; use search_kb first and read_kb only on a reference it returned.
+
 Arguments:
 - ref (string, required): the "kb://<document-id>" reference from a
   search_kb result's "Source:" line (the bare document id also works).

--- a/internal/brain/tools/builtin/kbsearch.go
+++ b/internal/brain/tools/builtin/kbsearch.go
@@ -55,6 +55,9 @@ Use when the user asks about something that might be documented in the
 knowledge base (internal docs, reference material, uploaded files)
 rather than general knowledge or long-term memory.
 
+Do not use this to recall the operator's own preferences, conventions,
+or past decisions; use search_memory for those.
+
 Arguments:
 - query (string, required): what to search for.
 - mode (string, optional): "hybrid" (default, vector + keyword),

--- a/internal/brain/tools/builtin/negativespace_test.go
+++ b/internal/brain/tools/builtin/negativespace_test.go
@@ -1,0 +1,44 @@
+package builtin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// TestDescriptionsNameTheirContrastedTool is a drift guard for issue
+// #645: every overlapping tool must say which neighbouring tool to
+// reach for instead, so the model routes without guessing.
+func TestDescriptionsNameTheirContrastedTool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		tool      *tools.Tool
+		contrasts []string
+	}{
+		{SearchMemory(func(context.Context, string, int) ([]SearchMemoryHit, error) { return nil, nil }), []string{"search_kb"}},
+		{KBSearch(func(context.Context, string, string, int) ([]KBSearchHit, error) { return nil, nil }), []string{"search_memory"}},
+		{KBRead(func(context.Context, string) (KBDocument, error) { return KBDocument{}, nil }), []string{"search_kb"}},
+		{WebSearch(""), []string{"fetch_url"}},
+		{WebFetch(WebFetchConfig{}), []string{"search_web"}},
+		{Remember(func(context.Context, string, string) (string, error) { return "", nil }), []string{"search_memory"}},
+		{Shell(ShellConfig{}), []string{"write_file"}},
+		{WriteFile(WriteFileConfig{}), []string{"shell"}},
+		{RetrieveOutput(nil), []string{"shell", "search_web"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tool.Name, func(t *testing.T) {
+			t.Parallel()
+			lower := strings.ToLower(tc.tool.Description)
+			if !strings.Contains(lower, "do not use this") {
+				t.Fatalf("%s: description states no negative space", tc.tool.Name)
+			}
+			for _, want := range tc.contrasts {
+				if !strings.Contains(tc.tool.Description, want) {
+					t.Fatalf("%s: description does not name %s", tc.tool.Name, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/brain/tools/builtin/remember.go
+++ b/internal/brain/tools/builtin/remember.go
@@ -30,6 +30,9 @@ Use ONLY when the user explicitly asks to remember something ("remember
 that...", "don't forget...", "make a note that..."). Never store facts
 the user did not ask to keep — routine facts are captured automatically.
 
+Do not use this to look something up; use search_memory to read what
+is already stored. This tool only writes.
+
 Arguments:
 - content (string, required): the fact, one self-contained sentence
   with absolute dates and full names (no "he", "it", "tomorrow").

--- a/internal/brain/tools/builtin/retrieve.go
+++ b/internal/brain/tools/builtin/retrieve.go
@@ -30,6 +30,10 @@ when the digest is not enough and you need the complete output — for
 example to quote an exact line, inspect a section the excerpt cut, or
 process the whole result.
 
+Do not use this to re-run the tool that produced the digest; the
+output is already stored, so retrieve_output returns it without
+spending another call on shell or search_web.
+
 Arguments:
 - ref (string, required): the ref id exactly as it appeared in the
   digest, e.g. "9be4c1d2-04a7-47a1-a1a9-3f6d2c9f1e10".

--- a/internal/brain/tools/builtin/searchmemory.go
+++ b/internal/brain/tools/builtin/searchmemory.go
@@ -10,6 +10,11 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
+const (
+	searchMemoryDefaultLimit = 8
+	searchMemoryMaxLimit     = 20
+)
+
 // SearchMemoryHit is one recalled long-term memory; memclient.Memory
 // satisfies this shape, passed in as a plain struct to keep this
 // package free of a memclient import.
@@ -21,10 +26,11 @@ type SearchMemoryHit struct {
 
 // SearchMemoryFunc runs one retrieval over long-term memory; main
 // curries memclient.Client.Retrieve in with the session already bound.
-type SearchMemoryFunc func(ctx context.Context, query string) ([]SearchMemoryHit, error)
+type SearchMemoryFunc func(ctx context.Context, query string, limit int) ([]SearchMemoryHit, error)
 
 type searchMemoryArgs struct {
 	Query string `json:"query"`
+	Limit *int   `json:"limit"`
 }
 
 // SearchMemory lets the model recall what Timothy knows about the
@@ -42,9 +48,15 @@ asked for, tools and infrastructure they already run, decisions they
 have already made. Search before assuming a default that the operator
 may have already stated.
 
+Do not use this to look up documented reference material, internal
+docs, or uploaded files; use search_kb for those. This tool answers
+what the operator has told Timothy, not what a document says.
+
 Arguments:
 - query (string, required): what to recall, in the operator's terms
   ("preferred programming language", "deployment setup").
+- limit (integer, optional): how many memories to return, 1-20,
+  default 8.
 
 Returns numbered memories, each with its tier (semantic for durable
 facts and preferences, episodic for events, procedural for how-tos).
@@ -56,6 +68,12 @@ the operator has no preference.`,
 				"query": {
 					"type": "string",
 					"description": "What to recall about the operator."
+				},
+				"limit": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 20,
+					"description": "Number of memories to return; defaults to 8."
 				}
 			},
 			"required": ["query"],
@@ -69,9 +87,21 @@ the operator has no preference.`,
 			if strings.TrimSpace(args.Query) == "" {
 				return "", fmt.Errorf("search_memory: query must not be empty")
 			}
-			hits, err := recall(ctx, args.Query)
+			limit := searchMemoryDefaultLimit
+			if args.Limit != nil {
+				limit = *args.Limit
+				if limit < 1 || limit > searchMemoryMaxLimit {
+					return "", fmt.Errorf("search_memory: limit must be between 1 and %d, got %d", searchMemoryMaxLimit, limit)
+				}
+			}
+			hits, err := recall(ctx, args.Query, limit)
 			if err != nil {
 				return "", fmt.Errorf("search_memory: %w", err)
+			}
+			// memoryd's /v1/retrieve has no limit parameter, so the
+			// ceiling is enforced here rather than trusted to a backend.
+			if len(hits) > limit {
+				hits = hits[:limit]
 			}
 			return formatMemoryHits(hits), nil
 		},

--- a/internal/brain/tools/builtin/searchmemory_test.go
+++ b/internal/brain/tools/builtin/searchmemory_test.go
@@ -39,6 +39,22 @@ func TestSearchMemory(t *testing.T) {
 			want: "1. Bare fact.",
 		},
 		{
+			name: "limit truncates the returned set",
+			args: `{"query":"anything","limit":1}`,
+			hits: []SearchMemoryHit{{Content: "First."}, {Content: "Second."}},
+			want: "1. First.",
+		},
+		{
+			name:    "limit above the maximum rejected",
+			args:    `{"query":"anything","limit":21}`,
+			wantErr: "limit must be between 1 and 20",
+		},
+		{
+			name:    "limit below one rejected",
+			args:    `{"query":"anything","limit":0}`,
+			wantErr: "limit must be between 1 and 20",
+		},
+		{
 			name:    "empty query rejected",
 			args:    `{"query":"   "}`,
 			wantErr: "query must not be empty",
@@ -59,8 +75,10 @@ func TestSearchMemory(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var gotQuery string
-			tool := SearchMemory(func(_ context.Context, query string) ([]SearchMemoryHit, error) {
+			var gotLimit int
+			tool := SearchMemory(func(_ context.Context, query string, limit int) ([]SearchMemoryHit, error) {
 				gotQuery = query
+				gotLimit = limit
 				return tc.hits, tc.recErr
 			})
 			if tool.Name != "search_memory" {
@@ -82,12 +100,15 @@ func TestSearchMemory(t *testing.T) {
 			if gotQuery == "" {
 				t.Fatal("query was not passed through to the backend")
 			}
+			if gotLimit < 1 {
+				t.Fatalf("limit passed to the backend = %d, want at least 1", gotLimit)
+			}
 		})
 	}
 }
 
 func TestSearchMemorySchemaValid(t *testing.T) {
-	tool := SearchMemory(func(context.Context, string) ([]SearchMemoryHit, error) { return nil, nil })
+	tool := SearchMemory(func(context.Context, string, int) ([]SearchMemoryHit, error) { return nil, nil })
 	var schema map[string]any
 	if err := json.Unmarshal(tool.InputSchema, &schema); err != nil {
 		t.Fatalf("input schema is not valid json: %v", err)
@@ -95,5 +116,16 @@ func TestSearchMemorySchemaValid(t *testing.T) {
 	req, ok := schema["required"].([]any)
 	if !ok || len(req) != 1 || req[0] != "query" {
 		t.Fatalf("required = %v, want [query]", schema["required"])
+	}
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties = %v, want an object", schema["properties"])
+	}
+	limit, ok := props["limit"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no limit property")
+	}
+	if limit["maximum"] != float64(searchMemoryMaxLimit) {
+		t.Fatalf("limit maximum = %v, want %d", limit["maximum"], searchMemoryMaxLimit)
 	}
 }

--- a/internal/brain/tools/builtin/shell.go
+++ b/internal/brain/tools/builtin/shell.go
@@ -92,6 +92,9 @@ the workspace. The command executes with /bin/sh -c, so pipes,
 redirects, and globs work. Every command starts in the workspace root
 — use absolute paths under it or paths relative to it.
 
+Do not use this to create or update a file; use write_file, which is
+the only supported way to write in the workspace.
+
 Arguments:
 - command (string, required): the command line to run, e.g.
   "ls -la reports/" or "grep -rn 'TODO' src/ | head -20".

--- a/internal/brain/tools/builtin/webfetch.go
+++ b/internal/brain/tools/builtin/webfetch.go
@@ -61,6 +61,9 @@ Use to read the content of a specific URL the user gave you or one you
 already know. It is a plain GET — no search, no JavaScript rendering,
 no login. Private and internal addresses are refused.
 
+Do not use this to find a page when you have no URL yet; use
+search_web first and fetch_url on a result.
+
 Arguments:
 - url (string, required): full http:// or https:// URL including
   scheme, e.g. "https://example.com/pricing".

--- a/internal/brain/tools/builtin/websearch.go
+++ b/internal/brain/tools/builtin/websearch.go
@@ -65,6 +65,9 @@ fetch_url) to find options and prices, then tell the user what you
 found and that they need to complete the booking themselves — do not
 retry the search hoping for a different kind of result.
 
+Do not use this to read a URL you already have; use fetch_url for
+that. Search finds pages, fetch_url reads one.
+
 Arguments:
 - query (string, required): the search query.
 - time_range (string, optional): "day", "week", "month", or "year" —

--- a/internal/brain/tools/builtin/writefile.go
+++ b/internal/brain/tools/builtin/writefile.go
@@ -41,6 +41,9 @@ This is the ONLY correct way to create or update a file — do not use
 shell redirects (>, >>) or heredocs, which require interactive
 approval and often fail.
 
+Do not use this to inspect, move, or delete existing files; use shell
+for those. This tool only writes whole file contents.
+
 Arguments:
 - path (string, required): workspace-relative file path, e.g.
   "summary.md" or "reports/http-429.md". Absolute paths and paths


### PR DESCRIPTION
## What

Every overlapping tool description now carries a short "do not use this for X, use Y" line naming its nearest confusable neighbour, and `search_memory` gains a `limit` argument with a default of 8 and a maximum of 20.

Builtin tools covered: `search_memory` (points at `search_kb`), `search_kb` (points back at `search_memory`), `read_kb`, `search_web`, `fetch_url`, `remember`, `shell`, `write_file` and `retrieve_output`. Connector aggregate tools covered: `search_mail`, `read_mail`, `list_calendar_events` and `search_drive`. The drive search tool does exist under the name `search_drive`, in `google_tools.go`, and it is google-only rather than a merged aggregate, so its contrast points at `read_drive_file`.

## Why

Descriptions were strong on the positive axis but almost silent on the negative one, so a model facing two plausible tools had nothing telling it which one is wrong. `search_memory` and `search_kb` are the most confusable pair and neither mentioned the other from the memory side. `search_memory` was also the only list tool with no way to cap how much comes back, which makes a broad recall query expensive in a mission turn where memory is read as a tool rather than injected.

## How

The description edits stay inside the existing structure, adding one short paragraph and no new sections. Connector descriptions are byte-identical across kinds by construction, so the same text landed in google, microsoft, imap and caldav together, which keeps `TestSharedToolSchemasMatchAcrossKinds` satisfied.

For the limit, memoryd's `/v1/retrieve` accepts no limit parameter, so nothing new goes over the wire. `SearchMemoryFunc` takes a `limit int` the way `KBSearchFunc` takes `k`, validation of the 1 to 20 range lives in the tool's Execute exactly as `search_kb` validates `k`, and the returned set is truncated in Go both at the wiring point in `cmd/brain/main.go` and defensively in the builtin, so the ceiling holds whatever backend is wired. The missions runner passes the value straight through.

Two drift guards were added: a table in `internal/brain/tools/builtin/negativespace_test.go` asserting each builtin description names its contrasted tool, and an extension to the existing cross-kind connector test doing the same for the mail and calendar aggregates, plus one small google-only case for `search_drive`.

## Verification

`make build`, `make test`, `make vet` and `make lint` all pass from a clean run, with lint reporting zero issues. The connectors, missions and builtin packages were exercised directly by the suite. No em dashes were introduced anywhere in the change.

Closes #645

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791611882&installation_model_id=431401&pr_number=658&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F658&signature=a2665d05d0b3a08280f3ba00c7f68907fbb0b19a4c183ed1c3b2c9a53eefcb58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->