### PR TITLE
feat(gateway): record tool-definition token estimate per turn

### DIFF
--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -51,6 +51,11 @@ type StreamRequest struct {
 	// ProviderState is opaque driver continuation state (D-067), echoed
 	// back from the previous step's done Meta.ProviderState.
 	ProviderState json.RawMessage `json:"provider_state,omitempty"`
+	// ToolDefTokensEstimate is the brain-side tokenizer's estimate of
+	// what the Tools array costs in prompt tokens. Ledger tag only:
+	// it never affects routing or the provider call, and is never
+	// priced (cost stays on provider-reported usage).
+	ToolDefTokensEstimate int `json:"tool_def_tokens_estimate,omitempty"`
 }
 
 // ErrGatewayUnavailable reports that the gateway itself is not yet

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -429,6 +429,20 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	for _, d := range defs {
 		toolNames[d.Name] = true
 	}
+	// toolDefTokens is the tokenizer's estimate of what the offered
+	// tool schemas cost on every step of this turn. Measurement only:
+	// it rides to the ledger next to prompt tokens so tool-surface
+	// overhead is visible per session and per mission, and is never
+	// priced (cost stays on provider-reported usage).
+	toolDefTokens, err := session.EstimateToolTokens(defs)
+	if err != nil {
+		a.logger.Warn("tool def token estimate failed", "error", err, "tools", len(defs))
+		toolDefTokens = 0
+	}
+	a.logger.Debug("turn assembled",
+		"session_id", req.SessionID, "mission_id", req.MissionID,
+		"agent", req.Agent, "route", req.Route,
+		"tools", len(defs), "tool_def_tokens", toolDefTokens)
 	// ForceTool is wire-invalid against a tool the turn doesn't actually
 	// offer (D-063) — defensive only, callers are expected to name a
 	// tool already in their own ToolAllow.
@@ -496,6 +510,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			MissionID:     req.MissionID,
 			ForceTool:     forceTool,
 			ProviderState: providerState,
+			// Ledger tag only, never priced (issue #642).
+			ToolDefTokensEstimate: toolDefTokens,
 		}
 		switch directive {
 		case tools.StepWarnFinalize:
@@ -507,6 +523,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			// offered is a wire error.
 			sreq.Tools = nil
 			sreq.ForceTool = ""
+			sreq.ToolDefTokensEstimate = 0
 		}
 
 		// Inner attempt loop: a stream that dies before anything

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -2579,5 +2580,46 @@ func TestAgentLoadSkillErrorDigestIsTruthful(t *testing.T) {
 	}
 	if !saw {
 		t.Fatal("no tool_result event")
+	}
+}
+
+// TestAgentToolDefTokensEstimate pins issue #642: the turn's tool
+// definitions are measured once and the estimate rides every outgoing
+// StreamRequest, except the forced-synthesis step that offers no
+// schemas at all. Three identical echo calls trip RepeatGuard's
+// "stuck" path, which forces synthesis on the next step.
+func TestAgentToolDefTokensEstimate(t *testing.T) {
+	t.Parallel()
+	repeat := toolCallStep([2]string{"echo", `{"text":"x"}`})
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		repeat, repeat, repeat, finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 4 {
+		t.Fatalf("requests = %d, want 4 (3 repeats + forced synthesis)", len(gw.requests))
+	}
+	want, err := session.EstimateToolTokens(gw.requests[0].Tools)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want <= 0 {
+		t.Fatalf("estimate for the offered tools = %d, want positive", want)
+	}
+	for i, req := range gw.requests[:3] {
+		if req.ToolDefTokensEstimate != want {
+			t.Fatalf("request %d ToolDefTokensEstimate = %d, want %d", i, req.ToolDefTokensEstimate, want)
+		}
+	}
+	last := gw.requests[3]
+	if len(last.Tools) != 0 || last.ToolDefTokensEstimate != 0 {
+		t.Fatalf("forced-synthesis request = %d tools / estimate %d, want 0 / 0",
+			len(last.Tools), last.ToolDefTokensEstimate)
 	}
 }

--- a/internal/brain/session/tokens.go
+++ b/internal/brain/session/tokens.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -48,4 +49,25 @@ func EstimateTokens(msgs []provider.Message) (int, error) {
 		total += len(e.Encode(m.Content, nil, nil)) + perMessageOverhead
 	}
 	return total, nil
+}
+
+// EstimateToolTokens counts tokens in the serialized tool definitions
+// a turn offers. Measurement only: the figure is logged and recorded
+// alongside prompt tokens so tool-surface overhead is visible, and is
+// never used for cost (billing stays on provider-reported usage).
+// json.Marshal reproduces the Anthropic wire bytes for the tool array
+// exactly and is close for the OpenAI shapes.
+func EstimateToolTokens(defs []provider.ToolDef) (int, error) {
+	if len(defs) == 0 {
+		return 0, nil
+	}
+	e, err := encoder()
+	if err != nil {
+		return 0, err
+	}
+	b, err := json.Marshal(defs)
+	if err != nil {
+		return 0, fmt.Errorf("session: marshal tool defs: %w", err)
+	}
+	return len(e.Encode(string(b), nil, nil)), nil
 }

--- a/internal/brain/session/tokens_test.go
+++ b/internal/brain/session/tokens_test.go
@@ -1,0 +1,41 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+func TestEstimateToolTokens(t *testing.T) {
+	t.Parallel()
+
+	if got, err := EstimateToolTokens(nil); err != nil || got != 0 {
+		t.Fatalf("EstimateToolTokens(nil) = %d, %v; want 0, nil", got, err)
+	}
+
+	one := []provider.ToolDef{{
+		Name:        "read_file",
+		Description: "Read a file from the workspace.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+	}}
+	single, err := EstimateToolTokens(one)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if single <= 0 {
+		t.Fatalf("EstimateToolTokens(one def) = %d, want positive", single)
+	}
+
+	two, err := EstimateToolTokens(append(one, provider.ToolDef{
+		Name:        "write_file",
+		Description: "Write a file into the workspace.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"body":{"type":"string"}}}`),
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if two <= single {
+		t.Fatalf("two defs = %d tokens, want more than one def's %d", two, single)
+	}
+}

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -130,6 +130,11 @@ type streamRequest struct {
 	// ProviderState is opaque driver continuation state (D-067), echoed
 	// back from the previous step's done Meta.ProviderState.
 	ProviderState json.RawMessage `json:"provider_state,omitempty"`
+	// ToolDefTokensEstimate is the brain-side tokenizer's estimate of
+	// what the Tools array costs in prompt tokens. Ledger tag only:
+	// it never affects routing or the provider call, and is never
+	// priced (cost stays on provider-reported usage).
+	ToolDefTokensEstimate int `json:"tool_def_tokens_estimate,omitempty"`
 }
 
 // requiredVisionCapability derives whether this request needs a
@@ -291,6 +296,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 			Provider: att.ProviderName, Model: att.Model,
 			Route: req.Route, Agent: req.Agent, Purpose: req.Purpose,
 			SessionID: req.SessionID, MissionID: req.MissionID, Local: local,
+			ToolDefTokensEstimate: req.ToolDefTokensEstimate,
 		}, prices, send)
 
 		if res.failedOver() {

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -120,6 +120,10 @@ type SeriesPoint struct {
 	Errors               int64     `json:"errors"`
 	UnpricedInputTokens  int64     `json:"unpriced_input_tokens"`
 	UnpricedOutputTokens int64     `json:"unpriced_output_tokens"`
+	// ToolDefTokensEstimate is the summed brain-side estimate of the
+	// prompt tokens this bucket's tool definitions cost. Estimate, not
+	// provider-reported, and never priced.
+	ToolDefTokensEstimate int64 `json:"tool_def_tokens_estimate"`
 }
 
 // Series returns bucketed usage grouped by provider, model, or
@@ -145,7 +149,8 @@ func (a *Aggregator) Series(ctx context.Context, from, to time.Time, bucket, gro
 			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
 			COUNT(*), COUNT(*) FILTER (WHERE status = 'error'),
 			COALESCE(SUM(input_tokens) FILTER (WHERE cost IS NULL), 0),
-			COALESCE(SUM(output_tokens) FILTER (WHERE cost IS NULL), 0)
+			COALESCE(SUM(output_tokens) FILTER (WHERE cost IS NULL), 0),
+			COALESCE(SUM(tool_def_tokens_estimate), 0)
 		FROM cost_ledger
 		WHERE ts >= $1 AND ts < $2 AND `+notTest+`
 		GROUP BY 1, 2, 3 ORDER BY 1, 2, 3`, from, to)
@@ -159,7 +164,7 @@ func (a *Aggregator) Series(ctx context.Context, from, to time.Time, bucket, gro
 		var p SeriesPoint
 		if err := rows.Scan(&p.Bucket, &p.Group, &p.Currency, &p.Cost, &p.UnbilledCost,
 			&p.InputTokens, &p.OutputTokens, &p.Requests, &p.Errors,
-			&p.UnpricedInputTokens, &p.UnpricedOutputTokens); err != nil {
+			&p.UnpricedInputTokens, &p.UnpricedOutputTokens, &p.ToolDefTokensEstimate); err != nil {
 			return nil, fmt.Errorf("usage series: %w", err)
 		}
 		out = append(out, p)

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -74,10 +74,10 @@ func seedAgg(t *testing.T, led *Ledger) (from, to time.Time) {
 	rows := []Entry{
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", SessionID: "s1",
 			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20},
-			LatencyMS: 100, Status: "ok", Cost: usd(0.10)},
+			LatencyMS: 100, Status: "ok", Cost: usd(0.10), ToolDefTokensEstimate: 400},
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", SessionID: "s1",
 			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100},
-			LatencyMS: 300, Status: "ok", Cost: usd(0.20)},
+			LatencyMS: 300, Status: "ok", Cost: usd(0.20), ToolDefTokensEstimate: 600},
 		{Provider: aggMarker + "b", Model: "m2", Route: "mini", SessionID: "s2",
 			Usage:     &stream.Usage{InputTokens: 10, OutputTokens: 5},
 			LatencyMS: 50, Status: "ok", Cost: usd(0.01)},
@@ -115,6 +115,7 @@ func TestAggregateSummaryExcludesTestTraffic(t *testing.T) {
 			agg.OutputTokens += p.OutputTokens
 			agg.Requests += p.Requests
 			agg.Errors += p.Errors
+			agg.ToolDefTokensEstimate += p.ToolDefTokensEstimate
 			byProvider[p.Group] = agg
 		}
 	}
@@ -122,6 +123,11 @@ func TestAggregateSummaryExcludesTestTraffic(t *testing.T) {
 	// Provider a: 2 real rows (the 99-dollar test probe must be gone).
 	if a.Requests != 2 || a.Cost != 0.30 || a.InputTokens != 300 || a.OutputTokens != 150 {
 		t.Fatalf("provider a = %+v, want 2 req / $0.30 / 300 in / 150 out", a)
+	}
+	// Tool-def estimate aggregates alongside prompt tokens; the excluded
+	// probe row carries none, so the sum is exactly the two real rows.
+	if a.ToolDefTokensEstimate != 1000 {
+		t.Fatalf("provider a tool_def_tokens_estimate = %d, want 1000", a.ToolDefTokensEstimate)
 	}
 	if b.Requests != 2 || b.Errors != 1 || b.Cost != 0.01 {
 		t.Fatalf("provider b = %+v, want 2 req / 1 error / $0.01", b)

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -50,6 +50,10 @@ type Entry struct {
 	// from ID (Timothy's row id) — lets a row be reconciled against the
 	// provider's own usage export.
 	ProviderRequestID string
+	// ToolDefTokensEstimate is the brain-side tokenizer's estimate of
+	// the prompt tokens spent on this turn's tool definitions. Recorded
+	// for tool-surface overhead visibility only, never priced.
+	ToolDefTokensEstimate int
 }
 
 // Recorder is what the API layer depends on; tests supply an in-memory
@@ -102,11 +106,13 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 	_, err = db.Exec(wctx, `INSERT INTO cost_ledger
 		(id, provider, model, route, agent, purpose, session_id, mission_id,
 		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
-		 latency_ms, status, error_code, cost, currency, unbilled, provider_request_id)
+		 latency_ms, status, error_code, cost, currency, unbilled, provider_request_id,
+		 tool_def_tokens_estimate)
 		VALUES (COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
-		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''), $17, $18, $19, NULLIF($20, ''))`,
+		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''), $17, $18, $19, NULLIF($20, ''), $21)`,
 		e.ID, e.Provider, e.Model, e.Route, e.Agent, e.Purpose, e.SessionID, e.MissionID,
-		in, out, cr, cw, rt, e.LatencyMS, e.Status, e.ErrorCode, e.Cost, currency, e.Unbilled, e.ProviderRequestID)
+		in, out, cr, cw, rt, e.LatencyMS, e.Status, e.ErrorCode, e.Cost, currency, e.Unbilled, e.ProviderRequestID,
+		e.ToolDefTokensEstimate)
 	if err != nil {
 		l.log.Warn("ledger write failed", "error", err, "provider", e.Provider, "status", e.Status)
 	}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -91,7 +91,12 @@ CREATE TABLE IF NOT EXISTS cost_ledger (
     -- Provider's own id for this request (OpenAI resp_.../chatcmpl-...,
     -- Anthropic msg_...), distinct from id above: lets a row be
     -- reconciled against the provider's own usage export.
-    provider_request_id text
+    provider_request_id text,
+    -- Brain-side tokenizer estimate of what this turn's tool
+    -- definitions cost in prompt tokens: measurement only, so the
+    -- operator can see the tool surface's share of prompt spend.
+    -- Never billed, cost stays on provider-reported usage.
+    tool_def_tokens_estimate integer
 );
 
 CREATE INDEX IF NOT EXISTS cost_ledger_ts_idx ON cost_ledger (ts);

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -4,4 +4,6 @@ Additive schema changes not yet applied to any live database. Safe to
 run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
-(none)
+```sql
+ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS tool_def_tokens_estimate integer;
+```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -321,6 +321,10 @@ export interface UsagePoint extends ConvertedMoney {
   errors: number
   unpriced_input_tokens: number
   unpriced_output_tokens: number
+  // tool_def_tokens_estimate is a brain-side tokenizer estimate of the
+  // prompt tokens this bucket's tool definitions cost. Displayed as an
+  // estimate, never used for cost.
+  tool_def_tokens_estimate: number
 }
 
 // GroupTotal is one group's totals over a whole range: the

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -265,6 +265,7 @@ describe('Analytics unpriced usage', () => {
         errors: 0,
         unpriced_input_tokens: 1_000_000,
         unpriced_output_tokens: 100_000,
+        tool_def_tokens_estimate: 0,
       },
     ])
     renderPage()
@@ -294,6 +295,7 @@ const providerPoint: UsagePoint = {
   errors: 0,
   unpriced_input_tokens: 0,
   unpriced_output_tokens: 0,
+  tool_def_tokens_estimate: 40,
 }
 
 const providerTotal: GroupTotal = {
@@ -358,6 +360,25 @@ describe('Analytics chart legend selection', () => {
     // Ctrl-click again restores just that entry.
     fireEvent.click(inputEntry, { ctrlKey: true })
     await waitFor(() => expect(inputEntry).not.toHaveStyle({ textDecoration: 'line-through' }))
+  })
+
+  // Issue #642: the tool-definition estimate is its own series beside
+  // prompt and completion tokens, and its label says "est." so it never
+  // reads as provider-reported usage.
+  it('shows tool-definition tokens as a labelled estimate series', async () => {
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) =>
+      group === 'provider' ? [providerPoint] : [],
+    )
+    renderPage()
+
+    const chart = (await screen.findByText('Tokens consumption')).closest('[data-density]') as HTMLElement | null
+    if (!chart) throw new Error('chart section not found')
+    const entry = (await within(chart).findAllByText('tool defs (est.)')).find((el) => el.className === '')
+    if (!entry) throw new Error('tool defs legend entry not found')
+    // 40 tokens on the single seeded bucket: mean, max and total all
+    // report the same figure, so one match proves the series is summed
+    // from tool_def_tokens_estimate rather than left at zero.
+    expect(within(chart).getAllByText('40').length).toBeGreaterThan(0)
   })
 })
 
@@ -461,6 +482,7 @@ describe('Analytics zero-cost exclusion', () => {
     errors: 0,
     unpriced_input_tokens: 0,
     unpriced_output_tokens: 0,
+    tool_def_tokens_estimate: 0,
   }
   const freeModelTotal: GroupTotal = {
     group: 'local-llama',

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -174,6 +174,15 @@ const bucketLabel = (iso: string, bucket: string) => {
     : d.toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
+// TOOL_DEFS is the tokens panel's third series: the brain-side
+// tokenizer's estimate of what a turn's tool definitions cost in
+// prompt tokens. The key doubles as the legend label (StatsLegend
+// renders the group name), so it says "est." to keep it from reading
+// as provider-reported usage. It is never used in any cost figure.
+const TOOL_DEFS = 'tool defs (est.)'
+const TOKEN_SERIES = ['input', 'output', TOOL_DEFS]
+const tokenSeriesColor = (g: string) => (g === 'input' ? palette[0] : g === 'output' ? palette[2] : palette[3])
+
 // ChartView is the bars/lines toggle shared by the two cost-over-time
 // panels — a compact segmented control matching the range picker's style.
 type ChartView = 'bars' | 'lines'
@@ -295,11 +304,12 @@ export function Analytics() {
   )
   const tokens = useMemo(() => {
     if (!data) return []
-    const byBucket = new Map<string, { bucket: string; input: number; output: number }>()
+    const byBucket = new Map<string, { bucket: string; input: number; output: number; [TOOL_DEFS]: number }>()
     for (const p of data.byProvider) {
-      const row = byBucket.get(p.bucket) ?? { bucket: p.bucket, input: 0, output: 0 }
+      const row = byBucket.get(p.bucket) ?? { bucket: p.bucket, input: 0, output: 0, [TOOL_DEFS]: 0 }
       row.input += p.input_tokens
       row.output += p.output_tokens
+      row[TOOL_DEFS] += p.tool_def_tokens_estimate
       byBucket.set(p.bucket, row)
     }
     return [...byBucket.values()]
@@ -329,7 +339,7 @@ export function Analytics() {
   )
 
   const costLegend = useSeriesSelection(cost.groups)
-  const tokensLegend = useSeriesSelection(['input', 'output'])
+  const tokensLegend = useSeriesSelection(TOKEN_SERIES)
   const modelCostLegend = useSeriesSelection(modelCost.groups)
   const modelTokensLegend = useSeriesSelection(modelTokens.groups)
 
@@ -604,17 +614,17 @@ export function Analytics() {
         <EChart
           option={(tokensView === 'bars' ? stackedBarsOption : areaLinesOption)(
             tokens as unknown as Record<string, number | string>[],
-            ['input', 'output'],
+            TOKEN_SERIES,
             tokensLegend.hidden,
-            (g) => (g === 'input' ? palette[0] : palette[2]),
+            tokenSeriesColor,
             (v) => bucketLabel(v, bucket),
             compact,
           )}
         />
         <StatsLegend
           rows={tokens as unknown as Record<string, number | string>[]}
-          groups={['input', 'output']}
-          colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
+          groups={TOKEN_SERIES}
+          colorOf={tokenSeriesColor}
           hidden={tokensLegend.hidden}
           onSelect={tokensLegend.onSelect}
           valueLabel={compact}


### PR DESCRIPTION
## What

Every model turn now measures how many prompt tokens its tool definitions consume, and that figure travels from the loop to the ledger to the analytics page:

- `session.EstimateToolTokens(defs)` tokenizes the serialized tool array with the same offline o200k tiktoken encoder `EstimateTokens` already uses.
- The loop computes it once per turn, logs `turn assembled` at debug level with `tools` and `tool_def_tokens`, and sets `ToolDefTokensEstimate` on every outgoing `gwclient.StreamRequest`.
- The gateway mirrors the field on `streamRequest`, seeds it into `ledger.Entry`, and writes it to the new nullable `cost_ledger.tool_def_tokens_estimate` column.
- `Series` sums the column per bucket, and the analytics "Tokens consumption" panel plots it as a third series labelled `tool defs (est.)` beside input and output.

## Why

The tool surface (builtin, connector, MCP) is re-sent on every turn and can dominate a prompt, but nothing measured it. Without a number the operator cannot tell whether trimming or deferring tools is worth doing, or whether a growing connector set is quietly a cost. A real tokenizer already existed for compaction budgeting; it was simply never pointed at the tool array.

This is measurement only. Cost stays on provider-reported usage, the estimate is never priced, and routing, caching and tool exposure are unchanged.

## How

`json.Marshal(defs)` is the serialization: it reproduces the Anthropic wire bytes for the tool array exactly and is close for the OpenAI shapes, so no new brain-side serializer was introduced. On a tokenizer error the loop warns and falls back to 0 rather than failing the turn.

The forced-synthesis step drops the schemas (`sreq.Tools = nil`), so the estimate is zeroed alongside `ForceTool` on that step. A ledger row for a synthesis step therefore truthfully records no tool overhead.

The UI label carries "(est.)" because `StatsLegend` renders the series key directly, so the key itself is the label the operator reads. A distinct palette slot separates it from the two provider-reported series.

Two deviations from the scoped plan, both deliberate:

- `Summary` and `Totals` were left alone. Adding the figure there is a three-line change per struct (field, SELECT, Scan) plus a web type with no consumer, and the acceptance criteria only ask for the analytics series. It is a clean follow-up if a header tile ever wants it.
- `scripts/schema-consolidation-delta.sql` was not touched. `scripts/schema-parity-check.sh` can no longer run at all (`fatal: path 'migrations/0002_gateway.sql' does not exist in 'main'`), since the pre-consolidation migration files it reads via `git show main:` are gone from main. The delta script has not been updated since #448 while `0001_init.sql` has taken several additive columns since, so it is a spent historical artifact rather than a live parity contract.

## Verification

- `make build test vet lint` green (0 lint issues), before and after merging `origin/main` (which brought in #658).
- `go vet -tags integration ./...` clean.
- `docker run ... node:24.18.0-alpine sh -c "npm run build && npm run lint && npm test"` green: 140 files, 1847 tests passed, 0 lint errors (75 pre-existing warnings).
- New tests: `TestEstimateToolTokens` (zero for nil, positive for one def, grows with a second), `TestAgentToolDefTokensEstimate` (the estimate reaches all three tool-offering requests and is zero on the forced-synthesis step), an Analytics test asserting the `tool defs (est.)` legend entry renders with its summed value, and the aggregate integration fixture now seeds and asserts the column sum.
- `scripts/schema-parity-check.sh` cannot run in this repo state, see above.

## Pending alter

`scripts/pending-alters.md` carries the live-DB change:

```sql
ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS tool_def_tokens_estimate integer;
```

Closes #642

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791613107&installation_model_id=431401&pr_number=659&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F659&signature=b4b368c6fbd3261de96e678dafe97e57f7199fb2d8c03eb6b90d22b4f8deead5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->