### PR TITLE
feat(gateway): one-hour prompt cache ttl for mission turns

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -278,6 +278,15 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		ForceTool:     req.ForceTool,
 		ProviderState: req.ProviderState,
 	}
+	// A mission turn asks for the extended prompt-cache tier: missions
+	// idle past the five-minute default on verify waits, ask_user parks,
+	// and phase transitions, so the default tier throws the cached
+	// system prefix away between turns. The driver gets the intent, not
+	// the mission id: purpose is hardcoded "chat" on this path, so
+	// MissionID is the only honest mission signal here.
+	if req.MissionID != "" {
+		completion.CacheTTL = "1h"
+	}
 
 	var codes []string
 	for i, att := range attempts {

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -1231,3 +1231,57 @@ func TestIsLocalBaseURL(t *testing.T) {
 		})
 	}
 }
+
+// anthropicSnapshotFor builds a one-provider snapshot on the anthropic
+// driver, so a test can read the native Messages API body the driver
+// actually sends.
+func anthropicSnapshotFor(t *testing.T, baseURL string) *router.Snapshot {
+	t.Helper()
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "one", Kind: "api", Driver: "anthropic", BaseURL: baseURL,
+			DefaultModel: "m1", Enabled: true},
+	}
+	routes := []router.RouteRow{
+		{Name: "coding", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" }, nil)
+	return snap
+}
+
+// TestStreamMissionTurnAsksForExtendedCacheTTL pins the mission-turn
+// derivation: a request carrying mission_id gets CacheTTL "1h", which
+// the Anthropic driver puts on the system block; a chat turn without
+// one keeps the five-minute default. MissionID is the signal because
+// purpose is hardcoded "chat" on this path.
+func TestStreamMissionTurnAsksForExtendedCacheTTL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		reqBody string
+		wantTTL bool
+	}{
+		{"mission turn", `{"route":"coding","mission_id":"m-1","system":"sys","messages":[{"role":"user","content":"hi"}]}`, true},
+		{"chat turn", `{"route":"coding","session_id":"s1","system":"sys","messages":[{"role":"user","content":"hi"}]}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var body []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ = io.ReadAll(r.Body)
+				_, _ = fmt.Fprint(w, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+			}))
+			t.Cleanup(srv.Close)
+			a, _ := newAPI(anthropicSnapshotFor(t, srv.URL))
+
+			w := postJSON(t, a.handleStream, tc.reqBody)
+			if w.Code != http.StatusOK {
+				t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+			}
+			got := strings.Contains(string(body), `"ttl":"1h"`)
+			if got != tc.wantTTL {
+				t.Fatalf("body has 1h ttl = %v, want %v:\n%s", got, tc.wantTTL, body)
+			}
+		})
+	}
+}

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -295,6 +295,11 @@ type MissionUsage struct {
 	// cache (D-093): shown next to input_tokens so the caching
 	// breakpoints' effect is visible per mission.
 	CacheReadTokens int64 `json:"cache_read_tokens"`
+	// CacheWriteTokens is what this mission paid to populate that cache,
+	// and HitRatio is read over read plus input: the pair says whether
+	// the caching breakpoints earned their keep on this mission.
+	CacheWriteTokens int64   `json:"cache_write_tokens"`
+	HitRatio         float64 `json:"hit_ratio"`
 	// ReviewInputTokens is the input of the mission's reviewer turns
 	// (rows tagged agent=reviewerAgent), shown against the review token
 	// ceiling (D-097).
@@ -338,14 +343,17 @@ func (a *Aggregator) Mission(ctx context.Context, missionID string) (MissionUsag
 	}
 	err = db.QueryRow(ctx, `SELECT
 			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cache_read_tokens), 0),
+			COALESCE(SUM(cache_write_tokens), 0),
 			COALESCE(SUM(input_tokens) FILTER (WHERE agent = $2), 0),
 			COUNT(*), COUNT(*) FILTER (WHERE cost IS NULL)
 		FROM cost_ledger
 		WHERE mission_id = $1 AND `+notTest, missionID, reviewerAgent).
-		Scan(&m.InputTokens, &m.OutputTokens, &m.CacheReadTokens, &m.ReviewInputTokens, &m.Requests, &m.UnpricedRequests)
+		Scan(&m.InputTokens, &m.OutputTokens, &m.CacheReadTokens, &m.CacheWriteTokens,
+			&m.ReviewInputTokens, &m.Requests, &m.UnpricedRequests)
 	if err != nil {
 		return MissionUsage{}, fmt.Errorf("usage mission: %w", err)
 	}
+	m.HitRatio = cacheHitRatio(m.CacheReadTokens, m.InputTokens)
 	// brain = every billed turn the missions engine ran directly
 	// (explore/plan/worker/review); harness = the delegated CLI
 	// executor's own billed rows (purpose='executor', D-051).
@@ -473,7 +481,13 @@ type SessionUsage struct {
 	Cost         float64 `json:"cost"`
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
-	Requests     int64   `json:"requests"`
+	// CacheReadTokens and CacheWriteTokens expose the session's prompt
+	// caching (D-018/D-093); HitRatio is derived, read over read plus
+	// input, and is zero when the session moved no input at all.
+	CacheReadTokens  int64   `json:"cache_read_tokens"`
+	CacheWriteTokens int64   `json:"cache_write_tokens"`
+	HitRatio         float64 `json:"hit_ratio"`
+	Requests         int64   `json:"requests"`
 }
 
 // TopSessions ranks sessions by real spend only — Cost excludes
@@ -490,7 +504,8 @@ func (a *Aggregator) TopSessions(ctx context.Context, from, to time.Time, limit 
 	}
 	rows, err := db.Query(ctx, `SELECT session_id, currency,
 			COALESCE(SUM(cost) FILTER (WHERE NOT unbilled), 0),
-			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COUNT(*)
+			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(cache_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), COUNT(*)
 		FROM cost_ledger
 		WHERE ts >= $1 AND ts < $2 AND session_id IS NOT NULL AND `+notTest+`
 		GROUP BY session_id, currency ORDER BY 3 DESC LIMIT $3`, from, to, limit)
@@ -502,9 +517,11 @@ func (a *Aggregator) TopSessions(ctx context.Context, from, to time.Time, limit 
 	out := []SessionUsage{}
 	for rows.Next() {
 		var s SessionUsage
-		if err := rows.Scan(&s.SessionID, &s.Currency, &s.Cost, &s.InputTokens, &s.OutputTokens, &s.Requests); err != nil {
+		if err := rows.Scan(&s.SessionID, &s.Currency, &s.Cost, &s.InputTokens, &s.OutputTokens,
+			&s.CacheReadTokens, &s.CacheWriteTokens, &s.Requests); err != nil {
 			return nil, fmt.Errorf("usage sessions: %w", err)
 		}
+		s.HitRatio = cacheHitRatio(s.CacheReadTokens, s.InputTokens)
 		out = append(out, s)
 	}
 	return out, rows.Err()
@@ -558,6 +575,17 @@ type CacheRow struct {
 	HitRatio        float64 `json:"hit_ratio"`
 }
 
+// cacheHitRatio is the share of prompt input that came from cache:
+// reads over reads plus fresh input. Zero when nothing moved, so an
+// idle session or mission reads as 0 rather than dividing by zero.
+func cacheHitRatio(read, input int64) float64 {
+	total := read + input
+	if total <= 0 {
+		return 0
+	}
+	return float64(read) / float64(total)
+}
+
 func (a *Aggregator) Cache(ctx context.Context, from, to time.Time) ([]CacheRow, error) {
 	db, err := a.db.Get()
 	if err != nil {
@@ -579,9 +607,7 @@ func (a *Aggregator) Cache(ctx context.Context, from, to time.Time) ([]CacheRow,
 		if err := rows.Scan(&c.Provider, &c.CacheReadTokens, &c.InputTokens); err != nil {
 			return nil, fmt.Errorf("usage cache: %w", err)
 		}
-		if total := c.CacheReadTokens + c.InputTokens; total > 0 {
-			c.HitRatio = float64(c.CacheReadTokens) / float64(total)
-		}
+		c.HitRatio = cacheHitRatio(c.CacheReadTokens, c.InputTokens)
 		out = append(out, c)
 	}
 	return out, rows.Err()

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -73,7 +73,7 @@ func seedAgg(t *testing.T, led *Ledger) (from, to time.Time) {
 
 	rows := []Entry{
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", SessionID: "s1",
-			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20},
+			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20, CacheWriteTokens: 60},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.10), ToolDefTokensEstimate: 400},
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", SessionID: "s1",
 			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100},
@@ -427,7 +427,7 @@ func TestAggregateMissionUsage(t *testing.T) {
 			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 30},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.10)},
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
-			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100, CacheReadTokens: 10},
+			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100, CacheReadTokens: 10, CacheWriteTokens: 90},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.20)},
 		// A fallback to a second model, the whole point of Models: a
 		// route is a chain, not one model, so both must show up. Tagged
@@ -465,6 +465,12 @@ func TestAggregateMissionUsage(t *testing.T) {
 	}
 	if got.CacheReadTokens != 40 {
 		t.Fatalf("CacheReadTokens = %d, want 40 (D-093: cached reads summed per mission)", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens != 90 {
+		t.Fatalf("CacheWriteTokens = %d, want 90", got.CacheWriteTokens)
+	}
+	if want := 40.0 / 390.0; got.HitRatio != want {
+		t.Fatalf("HitRatio = %v, want %v (read over read plus input)", got.HitRatio, want)
 	}
 	if got.ReviewInputTokens != 40 {
 		t.Fatalf("ReviewInputTokens = %d, want 40 (D-097: only the reviewer-tagged row)", got.ReviewInputTokens)
@@ -778,6 +784,18 @@ func TestAggregateTopSessionsAndCache(t *testing.T) {
 	}
 	if p1, p2 := pos["s1"], pos["s2"]; p2 < p1 {
 		t.Fatalf("s2 ($0.01) ranked above s1 ($0.30): %v", pos)
+	}
+	// s1: 20 cached reads and 60 cache writes against 300 fresh input.
+	s1 := sessions[pos["s1"]]
+	if s1.CacheReadTokens != 20 || s1.CacheWriteTokens != 60 {
+		t.Fatalf("s1 cache tokens = read %d write %d, want 20 and 60", s1.CacheReadTokens, s1.CacheWriteTokens)
+	}
+	if want := 20.0 / 320.0; s1.HitRatio != want {
+		t.Fatalf("s1 hit ratio = %v, want %v (read over read plus input)", s1.HitRatio, want)
+	}
+	// s2 never touched the cache: a zero ratio, not a division by zero.
+	if s2 := sessions[pos["s2"]]; s2.HitRatio != 0 {
+		t.Fatalf("s2 hit ratio = %v, want 0", s2.HitRatio)
 	}
 
 	cache, err := agg.Cache(t.Context(), from, to)

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -95,9 +95,10 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 	wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), writeTimeout)
 	defer cancel()
 
-	var in, out, cr, cw, rt *int
+	var in, out, cr, cw, cw1h, rt *int
 	if e.Usage != nil {
 		in, out, cr, cw, rt = &e.Usage.InputTokens, &e.Usage.OutputTokens, &e.Usage.CacheReadTokens, &e.Usage.CacheWriteTokens, &e.Usage.ReasoningTokens
+		cw1h = &e.Usage.CacheWrite1hTokens
 	}
 	currency := e.Currency
 	if currency == "" {
@@ -105,13 +106,13 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 	}
 	_, err = db.Exec(wctx, `INSERT INTO cost_ledger
 		(id, provider, model, route, agent, purpose, session_id, mission_id,
-		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
+		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, cache_write_1h_tokens, reasoning_tokens,
 		 latency_ms, status, error_code, cost, currency, unbilled, provider_request_id,
 		 tool_def_tokens_estimate)
 		VALUES (COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
-		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''), $17, $18, $19, NULLIF($20, ''), $21)`,
+		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, ''), $18, $19, $20, NULLIF($21, ''), $22)`,
 		e.ID, e.Provider, e.Model, e.Route, e.Agent, e.Purpose, e.SessionID, e.MissionID,
-		in, out, cr, cw, rt, e.LatencyMS, e.Status, e.ErrorCode, e.Cost, currency, e.Unbilled, e.ProviderRequestID,
+		in, out, cr, cw, cw1h, rt, e.LatencyMS, e.Status, e.ErrorCode, e.Cost, currency, e.Unbilled, e.ProviderRequestID,
 		e.ToolDefTokensEstimate)
 	if err != nil {
 		l.log.Warn("ledger write failed", "error", err, "provider", e.Provider, "status", e.Status)
@@ -148,7 +149,7 @@ func (l *Ledger) LastSuccess(ctx context.Context, sessionID, route string) (prov
 // billableUsage reports whether u carries any tokens that would have
 // been priced had the catalog known this model.
 func billableUsage(u *stream.Usage) bool {
-	return u != nil && u.InputTokens+u.OutputTokens+u.CacheReadTokens+u.CacheWriteTokens > 0
+	return u != nil && u.InputTokens+u.OutputTokens+u.CacheReadTokens+u.CacheWriteTokens+u.CacheWrite1hTokens > 0
 }
 
 // NewID returns a random UUIDv4 for pre-assigning ledger rows.
@@ -169,10 +170,18 @@ func Cost(prices *router.ModelPrices, u *stream.Usage) *float64 {
 	if prices == nil || u == nil {
 		return nil
 	}
+	// A one-hour cache write bills above the five-minute write, and no
+	// catalog carries that rate: without an operator-declared price the
+	// row's real cost is unknown, so it goes in as NULL rather than a
+	// derived multiple of the five-minute rate (D-013).
+	if u.CacheWrite1hTokens > 0 && prices.CacheWrite1hPerMTok == 0 {
+		return nil
+	}
 	const mtok = 1_000_000.0
 	c := float64(u.InputTokens)*prices.InputPerMTok/mtok +
 		float64(u.OutputTokens)*prices.OutputPerMTok/mtok +
 		float64(u.CacheReadTokens)*prices.CacheReadPerMTok/mtok +
-		float64(u.CacheWriteTokens)*prices.CacheWritePerMTok/mtok
+		float64(u.CacheWriteTokens)*prices.CacheWritePerMTok/mtok +
+		float64(u.CacheWrite1hTokens)*prices.CacheWrite1hPerMTok/mtok
 	return &c
 }

--- a/internal/gateway/ledger/ledger_test.go
+++ b/internal/gateway/ledger/ledger_test.go
@@ -51,6 +51,23 @@ func TestCost(t *testing.T) {
 			usage: &stream.Usage{},
 			want:  f(0),
 		},
+		{
+			// No operator-declared one-hour rate: the real cost is
+			// unknown, so it is null, never a derived multiple.
+			name: "unpriced one-hour cache write means unknown", prices: prices,
+			usage: &stream.Usage{InputTokens: 100_000, CacheWrite1hTokens: 200_000},
+			want:  nil,
+		},
+		{
+			name: "one-hour cache write priced when declared",
+			prices: &router.ModelPrices{
+				InputPerMTok: 3, OutputPerMTok: 15,
+				CacheReadPerMTok: 0.3, CacheWritePerMTok: 3.75,
+				CacheWrite1hPerMTok: 6,
+			},
+			usage: &stream.Usage{InputTokens: 100_000, CacheWriteTokens: 200_000, CacheWrite1hTokens: 500_000},
+			want:  f(0.3 + 0.75 + 3),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -101,9 +101,19 @@ type anthropicContentBlock struct {
 	CacheControl json.RawMessage `json:"cache_control,omitempty"`
 }
 
-// anthropicCacheEphemeral is the one cache_control value the driver
-// ever sends.
+// anthropicCacheEphemeral is the default five-minute cache_control
+// value: the conversation breakpoint always uses it, and so does the
+// system block unless the request asks for the extended tier.
 var anthropicCacheEphemeral = json.RawMessage(`{"type":"ephemeral"}`)
+
+// anthropicCacheEphemeral1h is the extended one-hour tier, GA on
+// cache_control with no beta header. Used on the SYSTEM block only,
+// for mission turns (CompletionRequest.CacheTTL == "1h"): the API
+// requires longer-TTL breakpoints to appear before shorter ones, and
+// system-first ordering already satisfies that. Writes at this tier
+// cost more than the five-minute tier, so the usage split keeps them
+// separate for pricing.
+var anthropicCacheEphemeral1h = json.RawMessage(`{"type":"ephemeral","ttl":"1h"}`)
 
 // markLastBlockCached puts the conversation breakpoint on the last
 // content block of the last message (D-093): the system block is the
@@ -234,6 +244,25 @@ type anthropicUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	// CacheCreation is the per-TTL breakdown of CacheCreationInputTokens.
+	// Absent on older responses, hence the pointer: nil means no
+	// breakdown and the whole creation count is treated as five-minute.
+	CacheCreation *anthropicCacheCreation `json:"cache_creation"`
+}
+
+type anthropicCacheCreation struct {
+	Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens"`
+	Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens"`
+}
+
+// splitCacheWrite fills the five-minute and one-hour write counts from
+// the response usage, falling back to the undifferentiated total when
+// the provider sends no breakdown.
+func (u anthropicUsage) splitCacheWrite() (fiveMin, oneHour int) {
+	if u.CacheCreation == nil {
+		return u.CacheCreationInputTokens, 0
+	}
+	return u.CacheCreation.Ephemeral5mInputTokens, u.CacheCreation.Ephemeral1hInputTokens
 }
 
 // Stream implements Provider.
@@ -280,10 +309,14 @@ func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
 		// cache_control on the system block enables prompt caching for
 		// the stable prefix (D-018); the conversation breakpoint above
 		// (D-093) extends that to the growing tool-loop transcript.
+		cc := anthropicCacheEphemeral
+		if req.CacheTTL == "1h" {
+			cc = anthropicCacheEphemeral1h
+		}
 		out.System = []anthropicTextBlock{{
 			Type:         "text",
 			Text:         req.System,
-			CacheControl: anthropicCacheEphemeral,
+			CacheControl: cc,
 		}}
 	}
 	for _, t := range req.Tools {
@@ -316,7 +349,7 @@ func (a *Anthropic) relay(ctx context.Context, body io.Reader, ch chan<- stream.
 		case "message_start":
 			usage.InputTokens = p.Message.Usage.InputTokens
 			usage.CacheReadTokens = p.Message.Usage.CacheReadInputTokens
-			usage.CacheWriteTokens = p.Message.Usage.CacheCreationInputTokens
+			usage.CacheWriteTokens, usage.CacheWrite1hTokens = p.Message.Usage.splitCacheWrite()
 			requestID = p.Message.ID
 		case "content_block_start":
 			if p.ContentBlock.Type == "tool_use" {

--- a/internal/gateway/provider/anthropic_test.go
+++ b/internal/gateway/provider/anthropic_test.go
@@ -354,3 +354,77 @@ func TestAnthropicMissingModel(t *testing.T) {
 		t.Fatal("Stream() with empty model: want error")
 	}
 }
+
+// TestAnthropicCacheTTLHint pins where the extended tier lands: on the
+// system block only, and only when the request asks for it. Longer
+// TTLs must precede shorter ones, which system-first already gives.
+func TestAnthropicCacheTTLHint(t *testing.T) {
+	t.Parallel()
+	a := NewAnthropic(AnthropicConfig{Name: "a"})
+	msgs := []Message{{Role: "user", Content: "hi"}}
+
+	plain, err := json.Marshal(a.buildRequest(CompletionRequest{Model: "m", System: "sys", Messages: msgs}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(plain), `"ttl"`) {
+		t.Fatalf("unhinted request carries a ttl:\n%s", plain)
+	}
+
+	hinted, err := json.Marshal(a.buildRequest(CompletionRequest{
+		Model: "m", System: "sys", Messages: msgs, CacheTTL: "1h",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(hinted), `"cache_control"`); got != 2 {
+		t.Fatalf("cache_control markers = %d, want 2:\n%s", got, hinted)
+	}
+	if !strings.Contains(string(hinted), `"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral","ttl":"1h"}}]`) {
+		t.Fatalf("system block missing the 1h ttl:\n%s", hinted)
+	}
+	// The conversation breakpoint stays on the default tier: only one
+	// ttl in the whole body, and it is not on the message block.
+	if got := strings.Count(string(hinted), `"ttl":"1h"`); got != 1 {
+		t.Fatalf("ttl markers = %d, want 1 (system only):\n%s", got, hinted)
+	}
+	if !strings.Contains(string(hinted), `{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}`) {
+		t.Fatalf("breakpoint left the default tier:\n%s", hinted)
+	}
+}
+
+// TestAnthropicUsageCacheWriteSplit pins the per-TTL write split: the
+// breakdown, when the API sends one, decides which price applies.
+func TestAnthropicUsageCacheWriteSplit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name              string
+		body              string
+		wantFive, wantOne int
+	}{
+		{
+			name:     "no breakdown keeps today's behaviour",
+			body:     `{"cache_creation_input_tokens":900}`,
+			wantFive: 900, wantOne: 0,
+		},
+		{
+			name: "breakdown splits by tier",
+			body: `{"cache_creation_input_tokens":900,
+				"cache_creation":{"ephemeral_5m_input_tokens":200,"ephemeral_1h_input_tokens":700}}`,
+			wantFive: 200, wantOne: 700,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var u anthropicUsage
+			if err := json.Unmarshal([]byte(tc.body), &u); err != nil {
+				t.Fatal(err)
+			}
+			five, one := u.splitCacheWrite()
+			if five != tc.wantFive || one != tc.wantOne {
+				t.Fatalf("split = (%d, %d), want (%d, %d)", five, one, tc.wantFive, tc.wantOne)
+			}
+		})
+	}
+}

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -247,13 +248,15 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 
 			case *types.ConverseStreamOutputMemberMetadata:
 				if v.Value.Usage != nil {
+					write5m, write1h := splitBedrockCacheWrite(v.Value.Usage)
 					if !emit(sctx, outCh, stream.StreamEvent{
 						Type: stream.EventUsage,
 						Usage: &stream.Usage{
-							InputTokens:      int(aws.ToInt32(v.Value.Usage.InputTokens)),
-							OutputTokens:     int(aws.ToInt32(v.Value.Usage.OutputTokens)),
-							CacheReadTokens:  int(aws.ToInt32(v.Value.Usage.CacheReadInputTokens)),
-							CacheWriteTokens: int(aws.ToInt32(v.Value.Usage.CacheWriteInputTokens)),
+							InputTokens:        int(aws.ToInt32(v.Value.Usage.InputTokens)),
+							OutputTokens:       int(aws.ToInt32(v.Value.Usage.OutputTokens)),
+							CacheReadTokens:    int(aws.ToInt32(v.Value.Usage.CacheReadInputTokens)),
+							CacheWriteTokens:   write5m,
+							CacheWrite1hTokens: write1h,
 						},
 					}) {
 						return
@@ -311,7 +314,7 @@ func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStr
 		// converseMessages flattens that history to plain text instead.
 		Messages:   converseMessages(req.Messages, toolConfig != nil),
 		ToolConfig: toolConfig,
-		System:     converseSystem(req.System, req.Model),
+		System:     converseSystem(req.System, req.Model, req.CacheTTL),
 	}
 	if req.MaxTokens > 0 {
 		input.InferenceConfig = &types.InferenceConfiguration{
@@ -510,19 +513,48 @@ func isToolResultTurn(msg types.Message) bool {
 // rejects cachePoint blocks, hence the model-family gate; prefixes
 // shorter than Nova's caching minimum are ignored server-side, not
 // errors.
-func converseSystem(system, model string) []types.SystemContentBlock {
+//
+// cacheTTL "1h" asks the cache point for the extended tier. Only the
+// cache-eligible family can carry it; for anything else the request
+// goes out unchanged and the miss is logged at debug.
+func converseSystem(system, model, cacheTTL string) []types.SystemContentBlock {
 	if system == "" {
 		return nil
 	}
 	blocks := []types.SystemContentBlock{
 		&types.SystemContentBlockMemberText{Value: system},
 	}
-	if strings.Contains(model, "amazon.nova") {
-		blocks = append(blocks, &types.SystemContentBlockMemberCachePoint{
-			Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
-		})
+	if !strings.Contains(model, "amazon.nova") {
+		if cacheTTL != "" {
+			slog.Default().Debug("cache ttl not applied", "model", model, "cache_ttl", cacheTTL)
+		}
+		return blocks
 	}
+	point := types.CachePointBlock{Type: types.CachePointTypeDefault}
+	if cacheTTL == "1h" {
+		point.Ttl = types.CacheTTLOneHour
+	}
+	blocks = append(blocks, &types.SystemContentBlockMemberCachePoint{Value: point})
 	return blocks
+}
+
+// splitBedrockCacheWrite separates the cache write into its
+// five-minute and one-hour parts, which bill at different rates.
+// CacheDetails is the per-TTL breakdown and is empty when no cache
+// creation happened or the model reports no breakdown, in which case
+// the undifferentiated total counts as five-minute.
+func splitBedrockCacheWrite(u *types.TokenUsage) (fiveMin, oneHour int) {
+	if len(u.CacheDetails) == 0 {
+		return int(aws.ToInt32(u.CacheWriteInputTokens)), 0
+	}
+	for _, d := range u.CacheDetails {
+		if d.Ttl == types.CacheTTLOneHour {
+			oneHour += int(aws.ToInt32(d.InputTokens))
+			continue
+		}
+		fiveMin += int(aws.ToInt32(d.InputTokens))
+	}
+	return fiveMin, oneHour
 }
 
 // converseTools maps tool definitions onto a Converse tool config;

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
 
@@ -202,12 +203,12 @@ func TestConverseMessagesKeepsToolBlocksWhenToolsOffered(t *testing.T) {
 
 func TestConverseSystem(t *testing.T) {
 	t.Parallel()
-	if converseSystem("", "us.amazon.nova-pro-v1:0") != nil {
+	if converseSystem("", "us.amazon.nova-pro-v1:0", "") != nil {
 		t.Fatal("empty system must yield nil")
 	}
 
 	// Nova: system text followed by a cache point.
-	blocks := converseSystem("persona", "us.amazon.nova-pro-v1:0")
+	blocks := converseSystem("persona", "us.amazon.nova-pro-v1:0", "")
 	if len(blocks) != 2 {
 		t.Fatalf("nova blocks = %d, want 2", len(blocks))
 	}
@@ -220,9 +221,62 @@ func TestConverseSystem(t *testing.T) {
 	}
 
 	// Non-Nova models must not get a cache point — Titan rejects it.
-	blocks = converseSystem("persona", "amazon.titan-text-premier-v1:0")
+	blocks = converseSystem("persona", "amazon.titan-text-premier-v1:0", "")
 	if len(blocks) != 1 {
 		t.Fatalf("titan blocks = %d, want 1", len(blocks))
+	}
+}
+
+func TestConverseSystemCacheTTL(t *testing.T) {
+	t.Parallel()
+
+	// No hint: the cache point keeps the provider's default lifetime.
+	blocks := converseSystem("persona", "us.amazon.nova-pro-v1:0", "")
+	cp, ok := blocks[1].(*types.SystemContentBlockMemberCachePoint)
+	if !ok {
+		t.Fatalf("block 1 = %#v", blocks[1])
+	}
+	if cp.Value.Ttl != "" {
+		t.Fatalf("default ttl = %q, want empty", cp.Value.Ttl)
+	}
+
+	// Hinted and eligible: the cache point carries the one-hour tier.
+	blocks = converseSystem("persona", "us.amazon.nova-pro-v1:0", "1h")
+	cp, ok = blocks[1].(*types.SystemContentBlockMemberCachePoint)
+	if !ok {
+		t.Fatalf("block 1 = %#v", blocks[1])
+	}
+	if cp.Value.Ttl != types.CacheTTLOneHour {
+		t.Fatalf("ttl = %q, want %q", cp.Value.Ttl, types.CacheTTLOneHour)
+	}
+
+	// Hinted but not cache-eligible: the request goes out unchanged,
+	// no cache point at all (the miss is a debug log, not an error).
+	blocks = converseSystem("persona", "amazon.titan-text-premier-v1:0", "1h")
+	if len(blocks) != 1 {
+		t.Fatalf("titan blocks = %d, want 1 (no cache point)", len(blocks))
+	}
+}
+
+func TestSplitBedrockCacheWrite(t *testing.T) {
+	t.Parallel()
+
+	// No breakdown: the whole write counts as the five-minute tier.
+	five, one := splitBedrockCacheWrite(&types.TokenUsage{CacheWriteInputTokens: aws.Int32(900)})
+	if five != 900 || one != 0 {
+		t.Fatalf("no details = (%d, %d), want (900, 0)", five, one)
+	}
+
+	// Breakdown present: each TTL lands in its own bucket.
+	five, one = splitBedrockCacheWrite(&types.TokenUsage{
+		CacheWriteInputTokens: aws.Int32(900),
+		CacheDetails: []types.CacheDetail{
+			{InputTokens: aws.Int32(700), Ttl: types.CacheTTLOneHour},
+			{InputTokens: aws.Int32(200), Ttl: types.CacheTTLFiveMinutes},
+		},
+	})
+	if five != 200 || one != 700 {
+		t.Fatalf("with details = (%d, %d), want (200, 700)", five, one)
 	}
 }
 

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -122,6 +122,14 @@ type CompletionRequest struct {
 	// (D-063). Empty means auto, today's behavior. Drivers that cannot
 	// express a forced choice on the wire ignore it.
 	ForceTool string
+	// CacheTTL asks for a longer prompt-cache lifetime than the
+	// provider's default: "" is the default (five minutes on every
+	// current provider), "1h" is the extended tier. Like Effort, it is
+	// a hint: drivers apply it where the provider exposes the control
+	// and ignore it otherwise. Set for mission turns, whose verify
+	// waits, ask_user parks, and phase transitions routinely idle past
+	// five minutes and throw the cached prefix away.
+	CacheTTL string
 	// ProviderState is opaque driver continuation state (D-067), echoed
 	// by the caller from the previous response's Meta.ProviderState.
 	// Drivers ignore state naming a different driver or absent entirely.

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -25,7 +25,13 @@ type ModelPrices struct {
 	OutputPerMTok     float64 `json:"output_per_mtok"`
 	CacheReadPerMTok  float64 `json:"cache_read_per_mtok"`
 	CacheWritePerMTok float64 `json:"cache_write_per_mtok"`
-	Currency          string  `json:"currency,omitempty"`
+	// CacheWrite1hPerMTok prices the one-hour cache tier, which no
+	// catalog publishes: it comes from the prices_by_model operator
+	// override only. Left at zero, a request that wrote at that tier
+	// records a null cost rather than a guessed multiple of
+	// CacheWritePerMTok (D-013).
+	CacheWrite1hPerMTok float64 `json:"cache_write_1h_per_mtok"`
+	Currency            string  `json:"currency,omitempty"`
 }
 
 // ProviderRow mirrors one providers table row.

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -204,6 +204,7 @@ func validateModelPrices(p ModelPrices) error {
 		{"output_per_mtok", p.OutputPerMTok},
 		{"cache_read_per_mtok", p.CacheReadPerMTok},
 		{"cache_write_per_mtok", p.CacheWritePerMTok},
+		{"cache_write_1h_per_mtok", p.CacheWrite1hPerMTok},
 	} {
 		if math.IsNaN(f.val) || math.IsInf(f.val, 0) {
 			return fmt.Errorf("%s is not a finite number", f.name)

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -148,6 +148,13 @@ type Usage struct {
 	OutputTokens     int `json:"output_tokens"`
 	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
 	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+	// CacheWrite1hTokens is the part of the cache write that went to the
+	// one-hour tier, which the provider bills at a higher rate than the
+	// five-minute tier. Split out so cost never applies the wrong
+	// multiplier; CacheWriteTokens holds the five-minute remainder.
+	// Zero when the provider reports no per-TTL breakdown, in which case
+	// the whole write sits in CacheWriteTokens.
+	CacheWrite1hTokens int `json:"cache_write_1h_tokens,omitempty"`
 	// ReasoningTokens is already included in OutputTokens and billed as
 	// output (D-013 unaffected); it exists purely so an operator can see
 	// how much output spend went to invisible reasoning.

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -65,6 +65,10 @@ CREATE TABLE IF NOT EXISTS cost_ledger (
     output_tokens      integer,
     cache_read_tokens  integer,
     cache_write_tokens integer,
+    -- Part of cache_write_tokens' total that went to the one-hour
+    -- cache tier, which providers bill above the five-minute tier;
+    -- kept apart so cost never applies the wrong multiplier.
+    cache_write_1h_tokens integer,
     -- Subset of output_tokens already included and billed there (OpenAI
     -- reasoning models); stored separately for spend visibility only.
     reasoning_tokens   integer,

--- a/scripts/canary-mission.sh
+++ b/scripts/canary-mission.sh
@@ -26,7 +26,12 @@ GOALS=(
   "Summarize what DNS TTL means and how it affects record changes, in a markdown file."
   "Explain what an idempotent HTTP method is with examples, in a markdown file."
 )
-GOAL="${GOALS[$((RANDOM % ${#GOALS[@]}))]}"
+# CANARY_GOAL pins the goal instead of drawing one. Only for a
+# deliberate before/after comparison (e.g. measuring a prompt-cache
+# change across two runs), where the goal must be identical and the
+# cache warmth is the thing being measured; a normal canary run must
+# leave it unset so the random draw applies.
+GOAL="${CANARY_GOAL:-${GOALS[$((RANDOM % ${#GOALS[@]}))]}}"
 
 # The API token stays in the shell environment only — sourced here,
 # never printed.
@@ -106,6 +111,21 @@ if failures:
     sys.exit(1)
 print("canary: PASS")
 PY
+
+# Prompt-cache position for this mission, read before the delete below
+# removes the mission the ledger rows are keyed to. Best-effort: a
+# usage endpoint that is unavailable must never flip a PASS to a FAIL.
+if usage="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/admin/usage/mission?id=${id}")"; then
+  CANARY_USAGE="${usage}" python3 <<'USAGEPY'
+import json, os
+u = json.loads(os.environ["CANARY_USAGE"])
+print("canary: input_tokens={} cache_read_tokens={} cache_write_tokens={} hit_ratio={:.3f}".format(
+    u.get("input_tokens", 0), u.get("cache_read_tokens", 0),
+    u.get("cache_write_tokens", 0), u.get("hit_ratio", 0.0)))
+USAGEPY
+else
+  echo "canary: WARNING - usage for mission ${id} unavailable (non-fatal)" >&2
+fi
 
 # Cleanup only runs once every check above has passed (set -e would
 # have already aborted the script on any failure) — a failed mission is

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -6,4 +6,5 @@ every live instance, then it's removed.
 
 ```sql
 ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS tool_def_tokens_estimate integer;
+ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS cache_write_1h_tokens integer;
 ```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -395,6 +395,11 @@ export interface MissionUsage {
   // cache_read_tokens is input served from the provider's prompt cache
   // (D-093), shown next to input_tokens on the cost card.
   cache_read_tokens?: number
+  // cache_write_tokens is what the mission paid to populate that
+  // cache, and hit_ratio is the derived share of prompt input that
+  // came from it: reads over reads plus fresh input.
+  cache_write_tokens?: number
+  hit_ratio?: number
   // review_input_tokens is the input spent on reviewer turns, shown
   // against review_token_ceiling (the mission_review_token_ceiling
   // setting, 0 = no ceiling) on the cost card (D-097).
@@ -418,6 +423,21 @@ export interface CacheRow {
   cache_read_tokens: number
   input_tokens: number
   hit_ratio: number
+}
+
+// One session's spend and prompt-cache position over a range
+// (GET /v1/admin/usage/sessions). hit_ratio is derived server-side:
+// cache reads over reads plus fresh input.
+export interface SessionUsage {
+  session_id: string
+  currency: string
+  cost: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  hit_ratio: number
+  requests: number
 }
 
 // Budget position per UTC calendar window; limit is null when no

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -195,7 +195,24 @@ describe('MissionDetail spend', () => {
     )
   })
 
-  it('shows cached input reads alongside the token counts when present', async () => {
+  it('shows cached input reads and the hit ratio alongside the token counts', async () => {
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      input_tokens: 120_000,
+      output_tokens: 8_000,
+      cache_read_tokens: 90_000,
+      cache_write_tokens: 30_000,
+      hit_ratio: 0.4286,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    expect(await screen.findByText('120.0k→8.0k tok · 90.0k cached (43%)')).toBeTruthy()
+  })
+
+  it('reads a missing hit ratio as zero rather than blanking the badge', async () => {
     vi.mocked(missionUsage).mockResolvedValue({
       mission_id: 'm1',
       cost_by_currency: { USD: 0.5 },
@@ -207,7 +224,7 @@ describe('MissionDetail spend', () => {
       models: [],
     })
     renderPage()
-    expect(await screen.findByText('120.0k→8.0k tok · 90.0k cached')).toBeTruthy()
+    expect(await screen.findByText('120.0k→8.0k tok · 90.0k cached (0%)')).toBeTruthy()
   })
 
   it('shows review input tokens against the ceiling', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -894,9 +894,14 @@ export function MissionDetail() {
                   </Badge>
                 )}
                 {usage && usage.requests > 0 && (
-                  <Badge variant="secondary" title="input→output tokens; cached = input read from the provider's prompt cache">
+                  <Badge
+                    variant="secondary"
+                    title="input→output tokens; cached = input read from the provider's prompt cache, with that share of total prompt input"
+                  >
                     {compact(usage.input_tokens)}→{compact(usage.output_tokens)} tok
-                    {usage.cache_read_tokens ? ` · ${compact(usage.cache_read_tokens)} cached` : ''}
+                    {usage.cache_read_tokens
+                      ? ` · ${compact(usage.cache_read_tokens)} cached (${Math.round((usage.hit_ratio ?? 0) * 100)}%)`
+                      : ''}
                   </Badge>
                 )}
                 {usage && usage.review_input_tokens ? (


### PR DESCRIPTION
## What

Mission turns now request the one-hour prompt cache tier on the system block; chat turns keep the five-minute default. The one-hour cache write is counted, stored and priced separately from the five-minute write, and analytics gains a cache hit rate per session and per mission.

## Why

A mission idles past five minutes routinely: verify waits, ask_user parks, phase transitions. By the next turn the cached system prefix has expired, so the mission pays full input price to rebuild a prompt that never changed. Chat turns have no such gaps and gain nothing from the longer tier, so they are left alone.

The tier matters for cost, not just for hit rate. A one-hour write bills at 2x base input against 1.25x for the five-minute write, and no price catalog publishes the one-hour rate. Folding both into one token count would make every mission row quietly wrong, so they are separated all the way from the provider response to the ledger column.

## How

- `provider.CompletionRequest` gains a `CacheTTL` hint, documented like `Effort`: "" is the provider default, "1h" the extended tier, and drivers apply it only where the provider has the control. The gateway API sets it when `MissionID` is non-empty. The driver never learns the mission id; `Purpose` is hardcoded "chat" on that path, so `MissionID` is the only honest mission signal there.
- Anthropic: a second cache_control literal, `{"type":"ephemeral","ttl":"1h"}`, on the system block only when the hint is set. The conversation breakpoint stays on the default tier. Longer TTLs must precede shorter ones on the wire, which the existing system-first ordering already satisfies. An unhinted request serialises byte for byte as before.
- Usage split: `stream.Usage` gains `CacheWrite1hTokens`. Anthropic reads `usage.cache_creation.ephemeral_1h_input_tokens` and `ephemeral_5m_input_tokens`; with no breakdown object, the whole `cache_creation_input_tokens` stays in `CacheWriteTokens` as today. Bedrock reads `TokenUsage.CacheDetails` the same way.
- Bedrock: the cache point on the existing `amazon.nova` gate carries `types.CacheTTLOneHour` when the hint is "1h". When the hint is set but the family is not cache-eligible, the request goes out unchanged and a debug log records "cache ttl not applied" with the model.
- Ledger: new nullable `cache_write_1h_tokens` column, added to `migrations/0001_init.sql` in place per the pre-release clean-schema rule, with the matching ALTER in `scripts/pending-alters.md`.
- Cost: `ModelPrices` gains `CacheWrite1hPerMTok`, populated from the `prices_by_model` operator override only (`cache_write_1h_per_mtok`), validated like the other rates. If a request wrote at the one-hour tier and no such rate is declared, `ledger.Cost` returns nil, so the row lands in the existing unpriced views rather than carrying a guessed 2x figure.
- Analytics: `SessionUsage` gains cache read, cache write and a derived `hit_ratio`; `MissionUsage` gains cache write and `hit_ratio`. The ratio is reads over reads plus fresh input, zero when nothing moved, and the existing `/usage/cache` tile reuses the same helper.
- Web: the mission cost badge shows the ratio next to the cached count; types mirror both server shapes.
- Canary: `CANARY_GOAL` pins the goal so two runs can be compared, and the script prints input, cache read, cache write and hit ratio from `/v1/admin/usage/mission` before the mission is deleted.

## Verification

`make build test vet lint` all clean, plus `go vet -tags integration ./...`. Web `npm run build && npm run lint && npm test`: 140 test files, 1847 tests, all passing. One `GraphTab.test.tsx` failure appeared on a first full-suite run; it passes in isolation on a clean tree and is unrelated to this change, and the full suite passed on rerun.

Tests added: anthropic cache marker count and TTL placement (hinted vs unhinted), the usage breakdown parse with and without the object, bedrock cache point TTL set / not applied and the `CacheDetails` split, ledger cost for both the unpriced and the declared one-hour rate, the gateway API deriving the hint from `mission_id` end to end against the real Anthropic driver body, and the session and mission cache fields in the aggregate integration tests.

**Before/after canary was not run.** The local stack is up, but it has no Anthropic-driver provider: the `coding` chain is claude-cli then GLM and OpenAI (both openaicompat), and `default` is OpenAI plus a Bedrock Nova entry. The extended tier is a no-op on every one of those, so a before/after here would measure nothing about this change. On a stack with an Anthropic route the comparison is:

```sh
export CANARY_GOAL="Explain HTTP chunked transfer encoding and when it applies, in a markdown file."
make canary   # before, on main
# rebuild the gateway with this branch, apply the ALTER below
make canary   # after
```

Both runs print the `input_tokens` / `cache_read_tokens` / `cache_write_tokens` / `hit_ratio` line before cleanup.

ALTER to apply on live databases:

```sql
ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS cache_write_1h_tokens integer;
```

## Caveats

- The payback is real only on missions that actually idle. On the last hackathon run the turns were seconds apart, and there the longer tier buys nothing while the write costs 2x base input against 1.25x for the five-minute tier. Missions that park or wait past five minutes are the case this is for.
- Until an operator sets `cache_write_1h_per_mtok` in that provider's `prices_by_model`, any row carrying a one-hour cache write records a NULL cost and shows up as unpriced. That is deliberate: the alternative is inventing a rate no catalog publishes.
- The AC asks for a "Cache hit" column on the sessions table in Analytics. There is no sessions table in the web app: `/v1/admin/usage/sessions` exists server-side but nothing consumes it, and the page shows only the global cache tile. The per-session hit rate is served by the endpoint and typed for the client, but building a whole sessions table was outside this change. Per-mission hit rate is on the mission page.

Closes #644

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791620514&installation_model_id=431401&pr_number=660&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F660&signature=6b16bb0dab57931f993ee7e6838ef8749baef153bc00ed6d47677da156904652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->