### PR TITLE
fix(gateway): wire the effort dial into anthropic and bedrock

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -297,6 +297,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 			Route: req.Route, Agent: req.Agent, Purpose: req.Purpose,
 			SessionID: req.SessionID, MissionID: req.MissionID, Local: local,
 			ToolDefTokensEstimate: req.ToolDefTokensEstimate,
+			Effort:                req.Effort,
 		}, prices, send)
 
 		if res.failedOver() {

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -26,11 +26,15 @@ func NewAggregator(db *pgpool.Pool) *Aggregator {
 // SQL and must never come from the caller unchecked.
 var buckets = map[string]string{"hour": "hour", "day": "day", "week": "week"}
 
-// groups whitelists the series group column for the same reason.
+// groups whitelists the series group column for the same reason. The
+// value is the SQL expression, not a bare column name: effort is
+// nullable (NULL means full effort, D-020) and the group label must
+// still be a string, so it coalesces to 'full'.
 var groups = map[string]string{
 	"provider": "provider",
 	"model":    "model",
 	"route":    "route",
+	"effort":   "COALESCE(effort, 'full')",
 }
 
 const notTest = `purpose IS DISTINCT FROM 'test'`

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -76,8 +76,10 @@ func seedAgg(t *testing.T, led *Ledger) (from, to time.Time) {
 			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 20},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.10), ToolDefTokensEstimate: 400},
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", SessionID: "s1",
-			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100},
-			LatencyMS: 300, Status: "ok", Cost: usd(0.20), ToolDefTokensEstimate: 600},
+			Usage: &stream.Usage{InputTokens: 200, OutputTokens: 100},
+			// The one reduced-effort row: D-020 analytics compare output
+			// tokens against the full-effort rows above and below.
+			LatencyMS: 300, Status: "ok", Cost: usd(0.20), ToolDefTokensEstimate: 600, Effort: "low"},
 		{Provider: aggMarker + "b", Model: "m2", Route: "mini", SessionID: "s2",
 			Usage:     &stream.Usage{InputTokens: 10, OutputTokens: 5},
 			LatencyMS: 50, Status: "ok", Cost: usd(0.01)},
@@ -803,5 +805,35 @@ func TestAggregateSeriesRejectsUnknownParams(t *testing.T) {
 	}
 	if _, err := agg.Series(t.Context(), time.Now().Add(-time.Hour), time.Now(), "day", "purpose; DROP TABLE"); err == nil {
 		t.Fatal("unknown group must error")
+	}
+}
+
+// TestAggregateSeriesByEffort asserts the D-020 effort level is stored
+// per row and groups like any other dimension, which is what makes
+// output tokens per effort level answerable without new SQL.
+func TestAggregateSeriesByEffort(t *testing.T) {
+	agg, led := testAggregator(t)
+	from, to := seedAgg(t, led)
+
+	points, err := agg.Series(t.Context(), from, to, "day", "effort")
+	if err != nil {
+		t.Fatalf("Series by effort: %v", err)
+	}
+	byEffort := map[string]int64{}
+	for _, p := range points {
+		byEffort[p.Group] += p.OutputTokens
+	}
+	// The fixture's single low-effort row carries 100 output tokens.
+	// Other rows in a shared DB may add to either bucket, so only the
+	// floor is asserted.
+	if _, ok := byEffort["low"]; !ok {
+		t.Fatal("no low-effort group came back; the effort column is not being stored")
+	}
+	if byEffort["low"] < 100 {
+		t.Fatalf("low-effort output tokens = %d, want at least the fixture's 100", byEffort["low"])
+	}
+	// Full-effort rows store NULL and must still group, under 'full'.
+	if _, ok := byEffort["full"]; !ok {
+		t.Fatal("no full-effort group came back; NULL effort must group as 'full'")
 	}
 }

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -54,6 +54,10 @@ type Entry struct {
 	// the prompt tokens spent on this turn's tool definitions. Recorded
 	// for tool-surface overhead visibility only, never priced.
 	ToolDefTokensEstimate int
+	// Effort is the D-020 dial the request was served at ("low", or
+	// empty for full effort). Stored so output tokens can be compared
+	// per effort level.
+	Effort string
 }
 
 // Recorder is what the API layer depends on; tests supply an in-memory
@@ -107,12 +111,12 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 		(id, provider, model, route, agent, purpose, session_id, mission_id,
 		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens,
 		 latency_ms, status, error_code, cost, currency, unbilled, provider_request_id,
-		 tool_def_tokens_estimate)
+		 tool_def_tokens_estimate, effort)
 		VALUES (COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
-		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''), $17, $18, $19, NULLIF($20, ''), $21)`,
+		 $2, $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''), $9, $10, $11, $12, $13, $14, $15, NULLIF($16, ''), $17, $18, $19, NULLIF($20, ''), $21, NULLIF($22, ''))`,
 		e.ID, e.Provider, e.Model, e.Route, e.Agent, e.Purpose, e.SessionID, e.MissionID,
 		in, out, cr, cw, rt, e.LatencyMS, e.Status, e.ErrorCode, e.Cost, currency, e.Unbilled, e.ProviderRequestID,
-		e.ToolDefTokensEstimate)
+		e.ToolDefTokensEstimate, e.Effort)
 	if err != nil {
 		l.log.Warn("ledger write failed", "error", err, "provider", e.Provider, "status", e.Status)
 	}

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -77,6 +79,59 @@ type anthropicRequest struct {
 	Tools     []anthropicTool      `json:"tools,omitempty"`
 	// ToolChoice forces a specific tool call (D-063: CompletionRequest.ForceTool).
 	ToolChoice any `json:"tool_choice,omitempty"`
+	// OutputConfig carries the D-020 dial as the Messages API's effort
+	// parameter. Omitted at full effort: the API default is "high",
+	// which is exactly equivalent to not sending the field, so the wire
+	// stays byte-identical to what the driver sent before.
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+}
+
+// anthropicOutputConfig is the Messages API output_config object. Only
+// effort is ever set.
+type anthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
+}
+
+// anthropicEffortModels lists the model-family substrings whose models
+// accept output_config.effort. Taken from the effort parameter's
+// supported-model list (platform.claude.com/docs/en/build-with-claude/
+// effort): the Fable, Mythos, Opus 4.6 and later, and Sonnet 4.6 and
+// later families. Claude 3.x, Haiku, and Opus 4.5 and earlier reject
+// or ignore it, so they never get the field. Substring matching
+// mirrors converseSupportsToolChoice: model IDs are configuration, and
+// vendor prefixes (bedrock's "anthropic.", regional "us." variants)
+// must still match.
+var anthropicEffortModels = []string{
+	"claude-fable-", "claude-mythos-",
+	"claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-opus-5",
+	"claude-sonnet-4-6", "claude-sonnet-5",
+}
+
+// anthropicSupportsEffort reports whether output_config.effort is
+// honored for this model.
+func anthropicSupportsEffort(model string) bool {
+	for _, m := range anthropicEffortModels {
+		if strings.Contains(model, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// effortFor maps the D-020 dial onto an output_config value: only the
+// "low" hint produces a field, and only on a model that takes it.
+// Anything else returns nil, leaving the request as it was before this
+// driver learned the dial.
+func effortFor(req CompletionRequest) *anthropicOutputConfig {
+	if req.Effort != "low" {
+		return nil
+	}
+	if !anthropicSupportsEffort(req.Model) {
+		slog.Default().Debug("anthropic: model has no effort control, ignoring the D-020 hint",
+			"model", req.Model)
+		return nil
+	}
+	return &anthropicOutputConfig{Effort: "low"}
 }
 
 // anthropicMessage carries either a plain string or content blocks
@@ -241,12 +296,21 @@ func (a *Anthropic) Stream(ctx context.Context, req CompletionRequest) (<-chan s
 	if req.Model == "" {
 		return nil, fmt.Errorf("anthropic: model is required")
 	}
-	body, err := json.Marshal(a.buildRequest(req))
+	wire := a.buildRequest(req)
+	body, err := json.Marshal(wire)
 	if err != nil {
 		return nil, fmt.Errorf("anthropic: marshal request: %w", err)
 	}
 
-	build := func(ctx context.Context) (*http.Request, error) {
+	first := runStream(ctx, a.client, a.cfg.Timeout, retriesFor(req.FinalAttempt), a.buildFor(body), a.relay)
+	if wire.OutputConfig == nil {
+		return first, nil
+	}
+	return a.retryEffortStrippedOn400(ctx, req, wire, first), nil
+}
+
+func (a *Anthropic) buildFor(body []byte) func(context.Context) (*http.Request, error) {
+	return func(ctx context.Context) (*http.Request, error) {
 		r, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.BaseURL+"/v1/messages", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
@@ -259,7 +323,52 @@ func (a *Anthropic) Stream(ctx context.Context, req CompletionRequest) (<-chan s
 		}
 		return r, nil
 	}
-	return runStream(ctx, a.client, a.cfg.Timeout, retriesFor(req.FinalAttempt), build, a.relay), nil
+}
+
+// retryEffortStrippedOn400 mirrors openaicompat's retryOn400: peek the
+// first event, and if it is a bare http_400 then output_config was
+// rejected before any stream activity (per the runStream contract a
+// request-level permanent failure emits exactly one error event and
+// closes), so retry once without the field. Any other first event
+// means relay already ran, so pass everything through event by event
+// and keep the success path streaming live. A proxy or an older
+// gateway in front of the Messages API is the case this covers: the
+// field is GA on api.anthropic.com.
+func (a *Anthropic) retryEffortStrippedOn400(ctx context.Context, req CompletionRequest, wire anthropicRequest, first <-chan stream.StreamEvent) <-chan stream.StreamEvent {
+	out := make(chan stream.StreamEvent)
+	go func() {
+		defer close(out)
+		ev, ok := <-first
+		if !ok {
+			return
+		}
+		if isHTTP400(ev) {
+			slog.Default().Debug("anthropic: output_config rejected, retrying without the effort field",
+				"model", req.Model)
+			wire.OutputConfig = nil
+			body, err := json.Marshal(wire)
+			if err != nil {
+				emit(ctx, out, errEvent(fmt.Errorf("anthropic: marshal retry request: %w", err)))
+				return
+			}
+			retry := runStream(ctx, a.client, a.cfg.Timeout, retriesFor(req.FinalAttempt), a.buildFor(body), a.relay)
+			for ev := range retry {
+				if !emit(ctx, out, ev) {
+					return
+				}
+			}
+			return
+		}
+		if !emit(ctx, out, ev) {
+			return
+		}
+		for ev := range first {
+			if !emit(ctx, out, ev) {
+				return
+			}
+		}
+	}()
+	return out
 }
 
 func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
@@ -274,8 +383,10 @@ func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
 		Messages:  anthropicMessages(req.Messages),
 	}
 	markLastBlockCached(out.Messages)
-	// req.Effort: no thinking control is wired for this driver yet, so
-	// the hint is ignored per D-020.
+	// D-020: the dial rides output_config.effort. "low" is the reduced
+	// setting; full effort sends nothing, because the API default is
+	// "high" and omitting the field means exactly that.
+	out.OutputConfig = effortFor(req)
 	if req.System != "" {
 		// cache_control on the system block enables prompt caching for
 		// the stable prefix (D-018); the conversation breakpoint above

--- a/internal/gateway/provider/anthropic_test.go
+++ b/internal/gateway/provider/anthropic_test.go
@@ -354,3 +354,129 @@ func TestAnthropicMissingModel(t *testing.T) {
 		t.Fatal("Stream() with empty model: want error")
 	}
 }
+
+// TestAnthropicEffort covers the D-020 dial: "low" sends
+// output_config.effort on a model that supports it, full effort and
+// unsupported models send nothing at all.
+func TestAnthropicEffort(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		model  string
+		effort string
+		want   string // JSON of output_config, "" for absent
+	}{
+		{"low on supported model", "claude-opus-5", "low", `{"effort":"low"}`},
+		{"low on bedrock-style id", "anthropic.claude-sonnet-5", "low", `{"effort":"low"}`},
+		{"full effort omits", "claude-opus-5", "", ""},
+		{"normal omits", "claude-opus-5", "normal", ""},
+		{"unsupported model omits", "claude-3-5-haiku-20241022", "low", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var body map[string]json.RawMessage
+			p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+			})
+			ch, err := p.Stream(t.Context(), CompletionRequest{
+				Model: tc.model, Effort: tc.effort,
+				Messages: []Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			collect(t, ch)
+
+			got, present := body["output_config"]
+			if tc.want == "" {
+				if present {
+					t.Fatalf("output_config sent = %s, want absent", got)
+				}
+				return
+			}
+			if !present {
+				t.Fatal("output_config absent, want it sent")
+			}
+			if string(got) != tc.want {
+				t.Fatalf("output_config = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnthropicEffortStrippedOn400 asserts the compatibility fallback:
+// an HTTP 400 as the very first event retries exactly once without
+// output_config, and the retried stream reaches the caller.
+func TestAnthropicEffortStrippedOn400(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	var secondHadEffort atomic.Bool
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]json.RawMessage
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"output_config: unsupported"}}`))
+			return
+		}
+		_, present := body["output_config"]
+		secondHadEffort.Store(present)
+		w.Header().Set("Content-Type", "text/event-stream")
+		sseWrite(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"retried"}}`)
+		sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{
+		Model: "claude-opus-5", Effort: "low", FinalAttempt: true,
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 2 {
+		t.Fatalf("requests = %d, want exactly 2 (one retry)", calls.Load())
+	}
+	if secondHadEffort.Load() {
+		t.Fatal("retry still carried output_config")
+	}
+	if got := textOf(events, stream.EventChunk); got != "retried" {
+		t.Fatalf("chunks = %q, want retried", got)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last event = %v, want done", lastType(t, events))
+	}
+}
+
+// TestAnthropicHTTP400NoEffortNoRetry: without the field there is
+// nothing to strip, so the 400 surfaces as-is on a single request.
+func TestAnthropicHTTP400NoEffortNoRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := anthropicServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad"}}`))
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{
+		Model: "claude-opus-5", FinalAttempt: true,
+		Messages: []Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", calls.Load())
+	}
+	if lastType(t, events) != stream.EventError {
+		t.Fatalf("last event = %v, want error", lastType(t, events))
+	}
+}

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -143,15 +145,17 @@ func (b *Bedrock) lazyClient(ctx context.Context) (*bedrockruntime.Client, error
 }
 
 // Stream implements the normalized streaming contract using Bedrock
-// ConverseStream. req.Effort is ignored: Converse exposes no
-// reasoning-effort dial for Nova/Titan models.
+// ConverseStream. The D-020 effort dial reaches Anthropic models
+// through AdditionalModelRequestFields (see buildConverseStreamInput);
+// Nova and Titan have no equivalent control, so the hint is ignored
+// there.
 func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan stream.StreamEvent, error) {
 	client, err := b.lazyClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	input := buildConverseStreamInput(req)
+	input, extraFields := buildConverseStreamInput(req)
 
 	outCh := make(chan stream.StreamEvent, 64)
 
@@ -163,6 +167,15 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 		defer cancel()
 
 		resp, err := client.ConverseStream(sctx, input)
+		if err != nil && rejectsOutputConfig(err, extraFields) {
+			// The effort field was rejected before the stream opened, so
+			// nothing has been emitted yet: drop it and retry once inline,
+			// mirroring the OpenAI-compatible strip-and-retry fallback.
+			slog.Default().Debug("bedrock: output_config rejected, retrying without the effort field",
+				"model", req.Model)
+			input.AdditionalModelRequestFields = withoutOutputConfig(extraFields)
+			resp, err = client.ConverseStream(sctx, input)
+		}
 		if err != nil {
 			emit(sctx, outCh, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 				Code:      "bedrock_error",
@@ -297,7 +310,11 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 // sequence. topK has no field on InferenceConfiguration; Nova reads it
 // from AdditionalModelRequestFields instead. Titan has no such
 // failure mode and no topK field, so the workaround is gated to Nova.
-func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStreamInput {
+// The returned map is the same model-native field set that was placed
+// on AdditionalModelRequestFields, handed back so the caller can strip
+// a rejected field without reading the document back (a LazyDocument
+// does not round-trip cleanly).
+func buildConverseStreamInput(req CompletionRequest) (*bedrockruntime.ConverseStreamInput, map[string]any) {
 	toolConfig := converseTools(req.Tools)
 	input := &bedrockruntime.ConverseStreamInput{
 		ModelId: aws.String(req.Model),
@@ -318,21 +335,63 @@ func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStr
 			MaxTokens: aws.Int32(int32(req.MaxTokens)), //nolint:gosec // token caps are far below int32 max
 		}
 	}
+	extra := map[string]any{}
 	if len(req.Tools) > 0 && strings.Contains(req.Model, "amazon.nova") {
 		if input.InferenceConfig == nil {
 			input.InferenceConfig = &types.InferenceConfiguration{}
 		}
 		input.InferenceConfig.Temperature = aws.Float32(0)
-		input.AdditionalModelRequestFields = document.NewLazyDocument(map[string]any{
-			"inferenceConfig": map[string]any{"topK": 1},
-		})
+		extra["inferenceConfig"] = map[string]any{"topK": 1}
+	}
+	// D-020: Converse has no effort field of its own, but it forwards
+	// model-native request fields verbatim through
+	// AdditionalModelRequestFields (AWS documents that path with
+	// Anthropic's own top_k). Anthropic models on Bedrock therefore take
+	// the same output_config.effort object the native driver sends.
+	if req.Effort == "low" {
+		if effort := effortFor(req); effort != nil {
+			extra["output_config"] = map[string]any{"effort": effort.Effort}
+		}
+	}
+	if len(extra) > 0 {
+		input.AdditionalModelRequestFields = document.NewLazyDocument(extra)
 	}
 	if req.ForceTool != "" && input.ToolConfig != nil && converseSupportsToolChoice(req.Model) {
 		input.ToolConfig.ToolChoice = &types.ToolChoiceMemberTool{
 			Value: types.SpecificToolChoice{Name: aws.String(req.ForceTool)},
 		}
 	}
-	return input
+	return input, extra
+}
+
+// rejectsOutputConfig reports whether err is Bedrock refusing the
+// output_config field this request carried. Converse validates
+// AdditionalModelRequestFields against the target model, so a model
+// that does not know the field answers with a ValidationException
+// naming it; every other error (throttling, access denied, a genuine
+// bad request) must surface unchanged.
+func rejectsOutputConfig(err error, extra map[string]any) bool {
+	if _, ok := extra["output_config"]; !ok {
+		return false
+	}
+	var ve *types.ValidationException
+	if !errors.As(err, &ve) {
+		return false
+	}
+	return strings.Contains(aws.ToString(ve.Message), "output_config")
+}
+
+// withoutOutputConfig rebuilds AdditionalModelRequestFields with the
+// effort field removed, keeping any other model-native field (the Nova
+// topK workaround) intact. Nil when nothing else is left, so the retry
+// sends no field at all. It mutates extra, which the caller drops
+// straight after.
+func withoutOutputConfig(extra map[string]any) document.Interface {
+	delete(extra, "output_config")
+	if len(extra) == 0 {
+		return nil
+	}
+	return document.NewLazyDocument(extra)
 }
 
 // converseSupportsToolChoice reports whether Converse's ToolChoice

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 )
 
@@ -328,7 +329,7 @@ func TestBuildConverseStreamInput(t *testing.T) {
 		Tools:     []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
 		MaxTokens: 512,
 	}
-	input := buildConverseStreamInput(novaTools)
+	input, _ := buildConverseStreamInput(novaTools)
 	if input.InferenceConfig == nil || input.InferenceConfig.Temperature == nil || *input.InferenceConfig.Temperature != 0 {
 		t.Fatalf("nova+tools: InferenceConfig = %#v, want Temperature 0", input.InferenceConfig)
 	}
@@ -340,7 +341,7 @@ func TestBuildConverseStreamInput(t *testing.T) {
 	}
 
 	novaNoTools := CompletionRequest{Model: "us.amazon.nova-pro-v1:0", MaxTokens: 512}
-	input = buildConverseStreamInput(novaNoTools)
+	input, _ = buildConverseStreamInput(novaNoTools)
 	if input.InferenceConfig == nil || input.InferenceConfig.Temperature != nil {
 		t.Fatalf("nova without tools: Temperature must stay unset, got %#v", input.InferenceConfig)
 	}
@@ -356,7 +357,7 @@ func TestBuildConverseStreamInput(t *testing.T) {
 		Tools:     []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
 		MaxTokens: 256,
 	}
-	input = buildConverseStreamInput(titanTools)
+	input, _ = buildConverseStreamInput(titanTools)
 	if input.InferenceConfig == nil || input.InferenceConfig.Temperature != nil {
 		t.Fatalf("titan+tools: Temperature must stay unset, got %#v", input.InferenceConfig)
 	}
@@ -388,7 +389,7 @@ func TestBuildConverseStreamInputForceTool(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			input := buildConverseStreamInput(CompletionRequest{
+			input, _ := buildConverseStreamInput(CompletionRequest{
 				Model: tc.model, Tools: tools, ForceTool: "submit_plan",
 			})
 			if !tc.wantSet {
@@ -565,5 +566,129 @@ func TestParseTitanEmbedding(t *testing.T) {
 	}
 	if _, _, err := parseTitanEmbedding([]byte(`not json`)); err == nil {
 		t.Fatal("garbage must error")
+	}
+}
+
+// TestBuildConverseStreamInputEffort covers the D-020 dial on
+// Converse: Anthropic models get output_config through
+// AdditionalModelRequestFields, Nova ignores it, and the Nova topK
+// workaround survives alongside it.
+func TestBuildConverseStreamInputEffort(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		req        CompletionRequest
+		wantEffort string // "" means no output_config
+		wantTopK   bool
+	}{
+		{
+			name:       "claude low effort",
+			req:        CompletionRequest{Model: "us.anthropic.claude-sonnet-5", Effort: "low"},
+			wantEffort: "low",
+		},
+		{
+			name: "claude full effort",
+			req:  CompletionRequest{Model: "us.anthropic.claude-sonnet-5"},
+		},
+		{
+			name: "claude model without the control",
+			req:  CompletionRequest{Model: "anthropic.claude-3-5-haiku-20241022-v1:0", Effort: "low"},
+		},
+		{
+			name: "nova ignores effort",
+			req:  CompletionRequest{Model: "us.amazon.nova-pro-v1:0", Effort: "low"},
+		},
+		{
+			name: "nova keeps topK with effort set",
+			req: CompletionRequest{
+				Model:  "us.amazon.nova-pro-v1:0",
+				Effort: "low",
+				Tools:  []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+			},
+			wantTopK: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input, fields := buildConverseStreamInput(tc.req)
+
+			oc, present := fields["output_config"]
+			if tc.wantEffort == "" {
+				if present {
+					t.Fatalf("output_config = %v, want absent", oc)
+				}
+			} else {
+				m, ok := oc.(map[string]any)
+				if !ok {
+					t.Fatalf("output_config = %#v, want a map", oc)
+				}
+				if m["effort"] != tc.wantEffort {
+					t.Fatalf("effort = %v, want %q", m["effort"], tc.wantEffort)
+				}
+			}
+
+			if _, ok := fields["inferenceConfig"]; ok != tc.wantTopK {
+				t.Fatalf("inferenceConfig present = %v, want %v", ok, tc.wantTopK)
+			}
+			if tc.wantEffort == "" && !tc.wantTopK && input.AdditionalModelRequestFields != nil {
+				t.Fatal("AdditionalModelRequestFields set with nothing to send")
+			}
+		})
+	}
+}
+
+// TestBedrockOutputConfigRetry covers the strip-and-retry gate: only a
+// ValidationException naming the field, on a request that actually
+// sent it, triggers the retry, and stripping keeps the Nova topK
+// field intact.
+func TestBedrockOutputConfigRetry(t *testing.T) {
+	t.Parallel()
+
+	_, claude := buildConverseStreamInput(CompletionRequest{
+		Model: "us.anthropic.claude-sonnet-5", Effort: "low",
+	})
+	rejection := &types.ValidationException{
+		Message: aws.String("The model returned the following errors: output_config: extra fields not permitted"),
+	}
+	if !rejectsOutputConfig(rejection, claude) {
+		t.Fatal("a ValidationException naming output_config must trigger the retry")
+	}
+	if rejectsOutputConfig(&types.ThrottlingException{Message: aws.String("output_config")}, claude) {
+		t.Fatal("a throttling error must never trigger the retry")
+	}
+	if rejectsOutputConfig(&types.ValidationException{Message: aws.String("toolConfig required")}, claude) {
+		t.Fatal("an unrelated ValidationException must not trigger the retry")
+	}
+
+	_, nova := buildConverseStreamInput(CompletionRequest{
+		Model: "us.amazon.nova-pro-v1:0",
+		Tools: []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	})
+	if rejectsOutputConfig(rejection, nova) {
+		t.Fatal("a request that never sent output_config must not retry")
+	}
+
+	// Stripping the claude request leaves nothing, so the retry sends
+	// no model-native fields at all.
+	if got := withoutOutputConfig(claude); got != nil {
+		t.Fatalf("stripped claude fields = %#v, want nil", got)
+	}
+
+	// Stripping a request that also carries topK keeps topK.
+	_, bothFields := buildConverseStreamInput(CompletionRequest{
+		Model:  "us.amazon.nova-pro-v1:0",
+		Effort: "low",
+		Tools:  []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+	})
+	bothFields["output_config"] = map[string]any{"effort": "low"} // as if Nova took it
+	if stripped := withoutOutputConfig(bothFields); stripped == nil {
+		t.Fatal("stripping must keep the topK field")
+	}
+	if _, ok := bothFields["output_config"]; ok {
+		t.Fatal("output_config survived stripping")
+	}
+	if _, ok := bothFields["inferenceConfig"]; !ok {
+		t.Fatal("inferenceConfig lost during stripping")
 	}
 }

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -96,7 +96,11 @@ CREATE TABLE IF NOT EXISTS cost_ledger (
     -- definitions cost in prompt tokens: measurement only, so the
     -- operator can see the tool surface's share of prompt spend.
     -- Never billed, cost stays on provider-reported usage.
-    tool_def_tokens_estimate integer
+    tool_def_tokens_estimate integer,
+    -- D-020 effort level the request was served at: 'low' on routine
+    -- post-tool continuations, NULL at full effort. Lets analytics
+    -- compare output tokens per effort level.
+    effort             text
 );
 
 CREATE INDEX IF NOT EXISTS cost_ledger_ts_idx ON cost_ledger (ts);

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -6,4 +6,5 @@ every live instance, then it's removed.
 
 ```sql
 ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS tool_def_tokens_estimate integer;
+ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS effort text;
 ```


### PR DESCRIPTION
## What

The D-020 effort dial now reaches the Anthropic and Bedrock drivers, and the level lands on the ledger row so its effect is measurable.

- Anthropic driver: `Effort == "low"` sends `output_config: {"effort": "low"}` on models that support the parameter. Full effort sends nothing at all, so the wire is byte-identical to before.
- Bedrock: Anthropic models get the same object through `AdditionalModelRequestFields`. Nova and Titan ignore the hint with a debug log.
- Both drivers strip the field and retry once when a backend rejects it, mirroring the OpenAI-compatible fallback.
- New nullable `cost_ledger.effort` column, `ledger.Entry.Effort`, seeded from the gateway request, plus `effort` in the aggregate group whitelist.

## Why

`EffortFor` in the loop already classifies every step and asks for reduced effort after a step where every tool result succeeded. Only the OpenAI-compatible driver acted on that. The Anthropic driver dropped the hint (`no thinking control is wired for this driver yet`) and Bedrock ignored the field, so on the two drivers that serve Claude the dial saved nothing.

It was also unfalsifiable: the ledger recorded no effort level, so output tokens per level could not be compared even where the dial did work. The column is what turns the saving into something the analytics endpoints can show.

## How

**Wire shape.** `output_config.effort` on the Messages API, top level, no beta header, verified against https://platform.claude.com/docs/en/build-with-claude/effort. The exact body added is:

```json
{"output_config": {"effort": "low"}}
```

The API default is `high`, and the docs state that `high` is exactly equivalent to omitting the parameter, which is why full effort keeps sending nothing: the request stays byte-identical to today and the cached prefix is untouched. The docs also warn that changing top-level effort between requests invalidates the prompt cache. That is inherent to D-020 dialling per step and is not made worse here, since full-effort turns are unchanged.

**Model support.** `anthropicSupportsEffort` matches the model-family substrings the docs list as supported: the Fable and Mythos families, Opus 4.6 and later, and Sonnet 4.6 and later. Substring matching follows the existing `converseSupportsToolChoice` idiom so vendor prefixes (`anthropic.`, regional `us.`) still match. Anything else, Claude 3.x and Haiku included, skips the field with one debug log.

**Bedrock.** Converse has no effort field of its own but forwards model-native fields verbatim through `AdditionalModelRequestFields`, which AWS documents using Anthropic's own `top_k` as the example, so the same `output_config` object applies. `buildConverseStreamInput` now builds the extra-fields map and merges into it rather than assigning, so the Nova topK workaround (D-037) survives, and it returns the map alongside the input: a `LazyDocument` does not round-trip cleanly, so reading the field back off the document was not a safe way to strip it.

**Strip and retry.** The Anthropic driver wraps the stream exactly like `openaicompat.retryOn400`: peek the first event, and a bare `http_400` there means the request was rejected before any stream activity, so rebuild without the field and relay the retried stream. One shot, and only when the field was actually sent. Bedrock retries inline on a `ValidationException` whose message names `output_config`, before any event is emitted. This is a compatibility path, not an expected one, since the parameter is GA on the first-party API; it covers a proxy or an older gateway sitting in front.

**Ledger.** `effort text` nullable, written with `NULLIF($23,'')`. It is the first nullable group column, so the aggregate whitelist maps it to `COALESCE(effort, 'full')` rather than a bare column name; without that, grouping fails with `cannot scan NULL into *string`. `/v1/admin/usage/totals?group=effort` and `series?group=effort` then answer output tokens per level with no new SQL.

Schema follows the pre-release convention: `migrations/0001_init.sql` edited in place, with the alter recorded for live databases.

```sql
ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS effort text;
```

## Verification

`make build test vet lint` clean (0 lint issues) and `go vet -tags integration ./...` clean, both before and after merging `origin/main`.

`make test-integration` for `./internal/gateway/...` passes against the live stack, including a new `TestAggregateSeriesByEffort` that asserts the column is stored and that NULL rows group as `full`.

New unit tests: the Anthropic dial across supported, unsupported, bedrock-prefixed, full-effort and `normal` models; the 400 fallback asserting exactly two requests with no `output_config` on the second; a 400 without the field asserting no retry. On Bedrock: the field set for Claude, absent for Nova and for Claude models without the control, topK preserved alongside it, plus the retry gate (a matching `ValidationException` triggers it; a `ThrottlingException` or an unrelated validation error does not) and stripping keeping topK.

`make canary` passes, before and after the merge with `origin/main` (4 model turns, PASS).

Merged `origin/main` at `da9805d` (#660). Conflicts resolved in the ledger INSERT column list (both `cache_write_1h_tokens` and `effort`, parameters renumbered to `\$23`), `pending-alters.md` (both lines kept) and `anthropic_test.go` (both test sets appended; verified both branches were pure appends on an identical prefix, so nothing was dropped).

### Effort A/B not measured here

The AC asks for an observed output-token difference on an Anthropic route. This environment has no Anthropic-driver provider: coding is claude-cli then GLM then OpenAI, default is OpenAI plus Bedrock Nova, and the only Bedrock provider is Nova, which correctly ignores the field. Rather than quote numbers that no request here produced, the commands to collect them on an instance that has an Anthropic route:

```sh
# 1. Point the canary route at the anthropic provider.
curl -X PATCH "\$BASE/v1/admin/routes/coding" -H "Authorization: Bearer \$TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"chain":[{"provider":"<anthropic-provider>","model":"claude-sonnet-5"}]}'

# 2. Two runs with a unique goal each, so no cache or leftover flatters the result.
CANARY_GOAL="<unique goal, run tag A>" make canary
CANARY_GOAL="<unique goal, run tag B>" make canary

# 3. Output tokens per effort level, now that the column exists.
curl "\$BASE/v1/admin/usage/totals?group=effort&from=<iso>&to=<iso>" \
  -H "Authorization: Bearer \$TOKEN"
```

Step 3 is the point of the ledger column: `low` versus `full` output tokens come back as two rows.

Closes #647

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791622644&installation_model_id=431401&pr_number=661&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F661&signature=35e4e11bd826bd1d817415924a21cd5b92d800c08871c6ed8b68bae382c8027a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->