### PR TITLE
feat(loop): structured tool errors with a retryable flag

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -931,7 +931,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 // resolveAndRun walks the permission chain, parks on Ask, and executes
 // on allow. It returns the raw message, a status of ok, denied, or
 // error, and on failure the error code executeOne wraps the message
-// with (D-104) — denials and failures come back as feedback, never as
+// with (D-104): denials and failures come back as feedback, never as
 // a broken turn (D-009). The code is empty on ok.
 //
 // A call whose name is absent from toolNames (a hallucinated tool)

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -3,8 +3,10 @@ package loop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -714,11 +716,11 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			}
 			run = append(run, c)
 		}
-		executed := a.executeAll(ctx, exec, req.SessionID, run, toolNames, req.Unattended, emit)
+		executed := a.executeAll(ctx, exec, req.SessionID, run, toolNames, req.Unattended, req.ToolResultCap, emit)
 		results := make([]provider.ToolResult, 0, len(calls))
 		for i, c := range calls {
 			if refused[i] {
-				results = append(results, provider.ToolResult{ID: c.ID, Content: toolCallCapMessage, IsError: true})
+				results = append(results, provider.ToolResult{ID: c.ID, Content: wrapToolError(codeCallCap, toolCallCapMessage, req.ToolResultCap), IsError: true})
 				continue
 			}
 			results = append(results, executed[0])
@@ -811,13 +813,13 @@ func EffortFor(results []provider.ToolResult) string {
 // returns results in call order. toolNames is the turn's offered
 // surface (see run's toolNames comment); unattended is req.Unattended,
 // threaded down to resolveAndRun's DecisionAsk handling (D-039).
-func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) []provider.ToolResult {
+func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, toolNames map[string]bool, unattended bool, resultCap int, emit func(stream.StreamEvent)) []provider.ToolResult {
 	results := make([]provider.ToolResult, len(calls))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelTools)
 	for i, call := range calls {
 		g.Go(func() error {
-			results[i] = a.executeOne(gctx, exec, sessionID, call, toolNames, unattended, emit)
+			results[i] = a.executeOne(gctx, exec, sessionID, call, toolNames, unattended, resultCap, emit)
 			return nil
 		})
 	}
@@ -825,7 +827,7 @@ func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string,
 	return results
 }
 
-func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) provider.ToolResult {
+func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, resultCap int, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
 	// A fresh collector per call: media a tool emits during THIS
 	// Execute rides on ctx, drained right below, never leaking into a
@@ -836,11 +838,11 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	// never a process crash: executeOne runs inside an errgroup worker,
 	// and an unrecovered panic there takes down the whole brain — every
 	// active turn and mission with it.
-	content, status := func() (content, status string) {
+	content, status, code := func() (content, status, code string) {
 		defer func() {
 			if p := recover(); p != nil {
 				a.logger.Error("tool panicked", "tool", call.Name, "panic", p, "stack", string(debug.Stack()))
-				content, status = fmt.Sprintf("tool %s failed with an internal error: %v", call.Name, p), "error"
+				content, status, code = fmt.Sprintf("tool %s failed with an internal error: %v", call.Name, p), "error", codeToolError
 			}
 		}()
 		return a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
@@ -914,13 +916,23 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 		Media: streamMedia, Content: traceContent,
 	}})
 
+	// D-104: the single boundary where a failure becomes the structured
+	// object. Everything above (digest, audit line, stream event) has
+	// already been taken from the raw prose, so the UI, the mission
+	// events and the audit trail read the same as before; only what the
+	// model sees changes.
+	if isError && !alreadyStructured(content) {
+		content = wrapToolError(code, content, resultCap)
+	}
+
 	return provider.ToolResult{ID: call.ID, Content: content, IsError: isError}
 }
 
 // resolveAndRun walks the permission chain, parks on Ask, and executes
-// on allow. It returns the content the model sees plus a status of
-// ok, denied, or error — denials and failures come back as feedback
-// text, never as a broken turn (D-009).
+// on allow. It returns the raw message, a status of ok, denied, or
+// error, and on failure the error code executeOne wraps the message
+// with (D-104) — denials and failures come back as feedback, never as
+// a broken turn (D-009). The code is empty on ok.
 //
 // A call whose name is absent from toolNames (a hallucinated tool)
 // never reaches a.perms.Resolve at all — it is rejected here, before
@@ -928,26 +940,26 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 // feedback tools.Constrained.Execute would eventually give (D-039):
 // an unattended mission can't afford to wait out a 10-minute prompt
 // timeout just to learn the name never existed.
-func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) (content, status string) {
+func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) (content, status, code string) {
 	if !toolNames[call.Name] {
-		return fmt.Sprintf("unknown tool %q — use one of the tools you were given", call.Name), "error"
+		return fmt.Sprintf("unknown tool %q — use one of the tools you were given", call.Name), "error", codeUnknownTool
 	}
 
 	res, err := a.perms.Resolve(ctx, sessionID, call.Name, call.Input)
 	if err != nil {
-		return "permission check failed: " + err.Error(), "error"
+		return "permission check failed: " + err.Error(), "error", codeGatewayUnavailable
 	}
 
 	switch res.Decision {
 	case tools.DecisionDeny:
-		return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied"
+		return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied", codePolicyDenied
 	case tools.DecisionAsk:
 		if unattended {
 			// No human is watching a schedule-fired mission's turn — parking
 			// on askUser would strand it for the full permissionTimeout with
 			// nobody to answer (D-039). Fail fast with feedback that steers
 			// the model toward calls the allowlist actually grants.
-			return fmt.Sprintf("permission denied automatically (unattended mission): %s. No human is available to approve. Rewrite the call to avoid the flagged pattern — create files with write_file instead of shell redirects, avoid command substitution — or use only tools the agent's allowlist grants.", res.Rationale), "denied"
+			return fmt.Sprintf("permission denied automatically (unattended mission): %s. No human is available to approve. Rewrite the call to avoid the flagged pattern — create files with write_file instead of shell redirects, avoid command substitution — or use only tools the agent's allowlist grants.", res.Rationale), "denied", codePolicyDenied
 		}
 
 		// A step's parallel same-tool calls (executeAll) all land here
@@ -960,7 +972,7 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 		key := sessionID + "\x00" + call.Name + "\x00" + res.Subject
 		release, ok := a.askGate.lock(ctx, key)
 		if !ok {
-			return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied"
+			return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied", codeUserDenied
 		}
 
 		// Re-resolve under the gate: a parallel sibling's session grant
@@ -968,14 +980,14 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 		res, err = a.perms.Resolve(ctx, sessionID, call.Name, call.Input)
 		if err != nil {
 			release()
-			return "permission check failed: " + err.Error(), "error"
+			return "permission check failed: " + err.Error(), "error", codeGatewayUnavailable
 		}
 		switch res.Decision {
 		case tools.DecisionAllow:
 			// fall through to execution below.
 		case tools.DecisionDeny:
 			release()
-			return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied"
+			return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied", codePolicyDenied
 		default: // still DecisionAsk
 			decision := a.askUser(ctx, call, res, emit)
 			switch decision {
@@ -987,7 +999,9 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 				// proceed
 			default: // deny or timeout
 				release()
-				return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied"
+				// Issue #650 will split the timeout case out with its own
+				// wording; both share user_denied until then.
+				return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied", codeUserDenied
 			}
 		}
 		// Execution runs outside the gate: only the ask/re-resolve/grant
@@ -999,15 +1013,42 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 	out, err := exec.Execute(ctx, call.Name, call.Input)
 	if err != nil {
 		if tools.IsViolation(err) {
-			return err.Error(), "error"
+			return err.Error(), "error", codePolicyDenied
+		}
+		// A tool that emits its own structured error hands it back as
+		// the error message; relay it verbatim so executeOne's
+		// passthrough guard sees an object rather than prefixed prose.
+		if alreadyStructured(err.Error()) {
+			return err.Error(), "error", ""
 		}
 		if out != "" {
-			// e.g. shell timeout with partial output.
-			return err.Error() + "\n" + out, "error"
+			// e.g. shell timeout with partial output: the output is the
+			// useful half of the message and must survive the wrap.
+			return err.Error() + "\n" + out, "error", classifyToolError(err)
 		}
-		return "tool failed: " + err.Error(), "error"
+		return "tool failed: " + err.Error(), "error", classifyToolError(err)
 	}
-	return out, "ok"
+	return out, "ok", ""
+}
+
+// classifyToolError maps a tool's own failure to a retryable code:
+// timeout for a deadline (the tools.ErrTimeout sentinel or a net
+// timeout), network for any other net.Error or dial failure, and the
+// generic tool_error otherwise. It never inspects message text.
+func classifyToolError(err error) string {
+	if errors.Is(err, tools.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+		return codeTimeout
+	}
+	// net.Error covers dial, DNS and read/write failures alike
+	// (*net.OpError and *net.DNSError both satisfy it).
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return codeTimeout
+		}
+		return codeNetwork
+	}
+	return codeToolError
 }
 
 // askUser parks the call: emits a permission_request and blocks for

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2483,7 +2483,8 @@ func TestAgentEndTurnToolsErrorContinues(t *testing.T) {
 
 // TestAgentRequestMaxToolCallsRefusesPastCap pins D-097: with
 // MaxToolCalls 2, the third tool call of a turn is not executed and
-// comes back as an error result carrying toolCallCapMessage, while an
+// comes back as an error result carrying toolCallCapMessage inside the
+// D-104 structured error, while an
 // end-turn (sentinel) call past the cap still runs and ends the turn.
 // 0 leaves the count unbounded.
 func TestAgentRequestMaxToolCallsRefusesPastCap(t *testing.T) {
@@ -2499,9 +2500,10 @@ func TestAgentRequestMaxToolCallsRefusesPastCap(t *testing.T) {
 		maxCalls      int
 		wantExecuted  int
 		wantThirdText string
+		wantCode      string
 	}{
-		{"cap of 2 refuses the third", 2, 3, toolCallCapMessage}, // 2 echo + sentinel
-		{"zero runs every call", 0, 4, "echo: call 3"},
+		{"cap of 2 refuses the third", 2, 3, toolCallCapMessage, codeCallCap}, // 2 echo + sentinel
+		{"zero runs every call", 0, 4, "echo: call 3", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2533,8 +2535,21 @@ func TestAgentRequestMaxToolCallsRefusesPastCap(t *testing.T) {
 			}
 			msgs := gw.requests[3].Messages
 			third := msgs[len(msgs)-1].ToolResult
-			if third == nil || third.Content != tc.wantThirdText {
-				t.Fatalf("third call's result = %+v, want content %q", third, tc.wantThirdText)
+			if third == nil {
+				t.Fatal("third call has no tool result")
+			}
+			if tc.wantCode == "" {
+				if third.Content != tc.wantThirdText {
+					t.Fatalf("third call's result = %+v, want content %q", third, tc.wantThirdText)
+				}
+			} else {
+				var te toolError
+				if err := json.Unmarshal([]byte(third.Content), &te); err != nil {
+					t.Fatalf("third call's result is not structured: %q", third.Content)
+				}
+				if te.Error != tc.wantCode || te.Message != tc.wantThirdText || te.Retryable {
+					t.Fatalf("third call's structured error = %+v, want code %q message %q retryable false", te, tc.wantCode, tc.wantThirdText)
+				}
 			}
 			if tc.maxCalls > 0 && !third.IsError {
 				t.Fatal("refused call's result must be an error so the model keeps full effort")

--- a/internal/brain/loop/toolerror.go
+++ b/internal/brain/loop/toolerror.go
@@ -1,0 +1,88 @@
+package loop
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// D-104: a failed tool call reaches the model as a small JSON object
+// instead of prose, so the retry decision is a field rather than
+// something the model has to infer from wording. Codes name the class
+// of failure; retryable says whether re-issuing the same call could
+// ever succeed. The wrap happens at one boundary (executeOne), and
+// only for the model-facing content: the digest, the audit line, the
+// stream event and the mission event all keep the raw prose.
+type toolError struct {
+	Error     string `json:"error"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+// Tool error codes. The first group cannot succeed on a retry: the
+// call is refused by policy, names nothing, or was turned down by a
+// human. The second group can: the failure is transient or external.
+const (
+	codePolicyDenied       = "policy_denied"
+	codeUnknownTool        = "unknown_tool"
+	codeCallCap            = "call_cap"
+	codeUserDenied         = "user_denied"
+	codeTimeout            = "timeout"
+	codeNetwork            = "network"
+	codeGatewayUnavailable = "gateway_unavailable"
+	codeToolError          = "tool_error"
+)
+
+// retryableFor reports whether a call that failed with code could
+// succeed if the model issued it again unchanged. An unknown code is
+// treated as retryable: a new failure class is more often transient
+// than permanent, and a wrong "do not retry" costs the model a
+// recovery it could have made.
+func retryableFor(code string) bool {
+	switch code {
+	case codePolicyDenied, codeUnknownTool, codeCallCap, codeUserDenied:
+		return false
+	default:
+		return true
+	}
+}
+
+// toolErrorEnvelopeBytes is the room wrapToolError reserves for the
+// JSON scaffolding around the message: the field names, the code, the
+// retryable flag, and worst-case escaping of the message itself.
+const toolErrorEnvelopeBytes = 256
+
+// wrapToolError renders a failed call's message as the structured
+// object. capBytes is the turn's tool-result cap: the message is
+// trimmed to fit inside it BEFORE marshaling, because capToolResult
+// runs on the finished content and would otherwise cut the object
+// mid-JSON. A marshal failure falls back to the raw message so a
+// failure never becomes an empty result.
+func wrapToolError(code, msg string, capBytes int) string {
+	if capBytes > toolErrorEnvelopeBytes {
+		if budget := capBytes - toolErrorEnvelopeBytes; len(msg) > budget {
+			msg = msg[:budget] + "\n[truncated]"
+		}
+	}
+	b, err := json.Marshal(toolError{Error: code, Message: msg, Retryable: retryableFor(code)})
+	if err != nil {
+		return msg
+	}
+	return string(b)
+}
+
+// alreadyStructured reports whether s is already a JSON object with an
+// "error" key, in which case the loop passes it through unwrapped
+// rather than nesting one error object inside another. See the result
+// convention on tools.Tool.
+func alreadyStructured(s string) bool {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") {
+		return false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		return false
+	}
+	_, ok := obj["error"]
+	return ok
+}

--- a/internal/brain/loop/toolerror_test.go
+++ b/internal/brain/loop/toolerror_test.go
@@ -1,0 +1,354 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// TestRetryableFor pins the retry classification per code (D-104): a
+// refusal the model cannot talk its way past is not retryable, a
+// transient or external failure is, and an unrecognised code defaults
+// to retryable.
+func TestRetryableFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		code string
+		want bool
+	}{
+		{codePolicyDenied, false},
+		{codeUnknownTool, false},
+		{codeCallCap, false},
+		{codeUserDenied, false},
+		{codeTimeout, true},
+		{codeNetwork, true},
+		{codeGatewayUnavailable, true},
+		{codeToolError, true},
+		{"something_new", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			if got := retryableFor(tc.code); got != tc.want {
+				t.Fatalf("retryableFor(%q) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapToolErrorShape proves the wrapped result is a valid object
+// carrying the code, the untouched message and the flag.
+func TestWrapToolErrorShape(t *testing.T) {
+	t.Parallel()
+	got := wrapToolError(codePolicyDenied, "denied: no shell redirects. This is a hard policy; do not retry the same call.", 0)
+	var te toolError
+	if err := json.Unmarshal([]byte(got), &te); err != nil {
+		t.Fatalf("unmarshal %q: %v", got, err)
+	}
+	if te.Error != codePolicyDenied {
+		t.Fatalf("error = %q, want %q", te.Error, codePolicyDenied)
+	}
+	if te.Retryable {
+		t.Fatal("policy_denied must not be retryable")
+	}
+	if !strings.Contains(te.Message, "do not retry the same call") {
+		t.Fatalf("message lost the remediation prose: %q", te.Message)
+	}
+}
+
+// TestWrapToolErrorKeepsPartialOutput pins the shell-timeout path: the
+// partial output the command produced before the deadline stays in
+// message, so the model can still use it.
+func TestWrapToolErrorKeepsPartialOutput(t *testing.T) {
+	t.Parallel()
+	raw := "command timed out after 30s\nline one\nline two"
+	var te toolError
+	if err := json.Unmarshal([]byte(wrapToolError(codeTimeout, raw, 0)), &te); err != nil {
+		t.Fatal(err)
+	}
+	if te.Message != raw {
+		t.Fatalf("message = %q, want %q", te.Message, raw)
+	}
+	if !te.Retryable {
+		t.Fatal("timeout must be retryable")
+	}
+}
+
+// TestWrapToolErrorCapKeepsValidJSON proves the message is trimmed
+// before marshaling, so capToolResult never has to cut the object
+// itself and the model always receives parseable JSON.
+func TestWrapToolErrorCapKeepsValidJSON(t *testing.T) {
+	t.Parallel()
+	const capBytes = 512
+	got := wrapToolError(codeToolError, strings.Repeat("x", 4000), capBytes)
+	if len(got) > capBytes {
+		t.Fatalf("wrapped length = %d, want <= %d", len(got), capBytes)
+	}
+	var te toolError
+	if err := json.Unmarshal([]byte(got), &te); err != nil {
+		t.Fatalf("capped result is not valid JSON: %v", err)
+	}
+	if !strings.HasSuffix(te.Message, "[truncated]") {
+		t.Fatalf("capped message lost its marker: %q", te.Message)
+	}
+	if got := capToolResult(got, capBytes); !json.Valid([]byte(got)) {
+		t.Fatal("capToolResult cut the wrapped object")
+	}
+}
+
+// TestWrapToolErrorNoCap leaves a long message intact when the turn
+// sets no cap.
+func TestWrapToolErrorNoCap(t *testing.T) {
+	t.Parallel()
+	msg := strings.Repeat("y", 4000)
+	var te toolError
+	if err := json.Unmarshal([]byte(wrapToolError(codeToolError, msg, 0)), &te); err != nil {
+		t.Fatal(err)
+	}
+	if te.Message != msg {
+		t.Fatalf("message length = %d, want %d", len(te.Message), len(msg))
+	}
+}
+
+// TestAlreadyStructured pins the passthrough guard: a tool that emits
+// its own object with an "error" key is not wrapped again, everything
+// else is.
+func TestAlreadyStructured(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"own error object", `{"error":"quota","message":"over limit"}`, true},
+		{"leading whitespace", "\n  {\"error\":\"quota\"}", true},
+		{"object without error key", `{"result":"fine"}`, false},
+		{"plain prose", "tool failed: dial tcp: refused", false},
+		{"json array", `[{"error":"quota"}]`, false},
+		{"broken json", `{"error":`, false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := alreadyStructured(tc.in); got != tc.want {
+				t.Fatalf("alreadyStructured(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyToolError pins the mapping from a tool's own error to a
+// code, all by errors.Is/As and never by message text.
+func TestClassifyToolError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"shell timeout sentinel", fmt.Errorf("command timed out after 30s: %w", tools.ErrTimeout), codeTimeout},
+		{"context deadline", fmt.Errorf("call: %w", context.DeadlineExceeded), codeTimeout},
+		{"net timeout", &net.DNSError{Err: "i/o timeout", IsTimeout: true}, codeTimeout},
+		{"dial failure", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, codeNetwork},
+		{"plain failure", errors.New("bad request"), codeToolError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyToolError(tc.err); got != tc.want {
+				t.Fatalf("classifyToolError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAgentWrapsToolErrorForModel walks a failing call through the
+// loop and proves the D-104 boundary: the model gets the structured
+// object with the right code and flag, the stream digest and the
+// audit line keep the raw prose, and IsError stays true so the turn
+// continues at full effort.
+func TestAgentWrapsToolErrorForModel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		err           error
+		out           string
+		wantCode      string
+		wantRetryable bool
+		wantInMessage string
+		wantDigest    string
+	}{
+		{
+			name: "shell timeout keeps partial output", err: fmt.Errorf("command timed out after 1s: %w", tools.ErrTimeout),
+			out: "half a line", wantCode: codeTimeout, wantRetryable: true,
+			wantInMessage: "half a line", wantDigest: "command timed out after 1s",
+		},
+		{
+			name: "constraint violation is not retryable", err: &tools.Violation{Msg: "destructive command refused"},
+			wantCode: codePolicyDenied, wantRetryable: false,
+			wantInMessage: "destructive command refused", wantDigest: "destructive command refused",
+		},
+		{
+			name: "generic failure is retryable", err: errors.New("upstream said no"),
+			wantCode: codeToolError, wantRetryable: true,
+			wantInMessage: "upstream said no", wantDigest: "tool failed: upstream said no",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			failing := &tools.Tool{
+				Name:        "flaky",
+				Description: "fails on purpose",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+				Execute: func(context.Context, json.RawMessage) (string, error) {
+					return tc.out, tc.err
+				},
+			}
+			gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+				toolCallStep([2]string{"flaky", `{}`}),
+				finalStep("done"),
+			}}
+			a, audit, _, _ := testAgent(t, gw, failing)
+			ch, err := a.Start(t.Context(), Request{
+				SessionID: "s1", Route: "coding",
+				Messages: []provider.Message{{Role: "user", Content: "go"}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evs := collect(t, ch)
+
+			results := ofType(evs, stream.EventToolResult)
+			if len(results) != 1 {
+				t.Fatalf("tool results = %d, want 1", len(results))
+			}
+			if !strings.Contains(results[0].ToolResult.Digest, tc.wantDigest) {
+				t.Fatalf("stream digest = %q, want the raw prose %q", results[0].ToolResult.Digest, tc.wantDigest)
+			}
+			if len(audit.entries) != 1 || !strings.Contains(audit.entries[0].Error, tc.wantDigest) {
+				t.Fatalf("audit entries = %+v, want the raw prose", audit.entries)
+			}
+
+			var got *provider.ToolResult
+			for _, m := range gw.requests[1].Messages {
+				if m.ToolResult != nil {
+					got = m.ToolResult
+				}
+			}
+			if got == nil {
+				t.Fatal("no tool result reached the model")
+			}
+			if !got.IsError {
+				t.Fatal("wrapped failure must keep IsError true")
+			}
+			var te toolError
+			if err := json.Unmarshal([]byte(got.Content), &te); err != nil {
+				t.Fatalf("model content is not structured: %q", got.Content)
+			}
+			if te.Error != tc.wantCode || te.Retryable != tc.wantRetryable {
+				t.Fatalf("structured error = %+v, want code %q retryable %v", te, tc.wantCode, tc.wantRetryable)
+			}
+			if !strings.Contains(te.Message, tc.wantInMessage) {
+				t.Fatalf("message = %q, want it to contain %q", te.Message, tc.wantInMessage)
+			}
+			// D-020: an error result keeps full effort.
+			if gw.requests[1].Effort != "" {
+				t.Fatalf("effort after error = %q, want normal", gw.requests[1].Effort)
+			}
+		})
+	}
+}
+
+// TestAgentUnknownToolIsNotRetryable proves a hallucinated tool name
+// is tagged unknown_tool with retryable false.
+func TestAgentUnknownToolIsNotRetryable(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"nothing_real", `{}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "coding",
+		Messages: []provider.Message{{Role: "user", Content: "go"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	var got *provider.ToolResult
+	for _, m := range gw.requests[1].Messages {
+		if m.ToolResult != nil {
+			got = m.ToolResult
+		}
+	}
+	if got == nil {
+		t.Fatal("no tool result reached the model")
+	}
+	var te toolError
+	if err := json.Unmarshal([]byte(got.Content), &te); err != nil {
+		t.Fatalf("model content is not structured: %q", got.Content)
+	}
+	if te.Error != codeUnknownTool || te.Retryable {
+		t.Fatalf("structured error = %+v, want unknown_tool and retryable false", te)
+	}
+	if !strings.Contains(te.Message, "unknown tool") {
+		t.Fatalf("message = %q, want the original guidance", te.Message)
+	}
+}
+
+// TestAgentPassesThroughToolOwnStructuredError proves a tool that
+// already emits an object with an "error" key is relayed unwrapped.
+func TestAgentPassesThroughToolOwnStructuredError(t *testing.T) {
+	t.Parallel()
+	const own = `{"error":"quota_exhausted","message":"daily limit","retryable":false}`
+	structured := &tools.Tool{
+		Name:        "quota",
+		Description: "returns its own structured error",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "", errors.New(own)
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"quota", `{}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw, structured)
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "coding",
+		Messages: []provider.Message{{Role: "user", Content: "go"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	var got *provider.ToolResult
+	for _, m := range gw.requests[1].Messages {
+		if m.ToolResult != nil {
+			got = m.ToolResult
+		}
+	}
+	if got == nil {
+		t.Fatal("no tool result reached the model")
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got.Content), &obj); err != nil {
+		t.Fatalf("content is not an object: %q", got.Content)
+	}
+	if _, nested := obj["message"]; !nested {
+		t.Fatalf("content lost its shape: %q", got.Content)
+	}
+	var code string
+	if err := json.Unmarshal(obj["error"], &code); err != nil || code != "quota_exhausted" {
+		t.Fatalf("content = %q, want the tool's own error code passed through", got.Content)
+	}
+}

--- a/internal/brain/tools/builtin/shell.go
+++ b/internal/brain/tools/builtin/shell.go
@@ -189,7 +189,7 @@ func runShell(ctx context.Context, dir string, timeout time.Duration, command st
 
 	switch {
 	case ctx.Err() == context.DeadlineExceeded:
-		return out, fmt.Errorf("command timed out after %s", timeout)
+		return out, fmt.Errorf("command timed out after %s: %w", timeout, tools.ErrTimeout)
 	case err != nil:
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/internal/brain/tools/tool.go
+++ b/internal/brain/tools/tool.go
@@ -8,13 +8,29 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 )
+
+// ErrTimeout marks a tool failure caused by the tool's own deadline
+// expiring, so the loop can classify it as retryable without matching
+// on message text. Wrap it with %w from any tool that enforces a
+// timeout (see builtin.newShell).
+var ErrTimeout = errors.New("tool: timed out")
 
 // Tool is one capability the model can invoke. Description is the
 // model's only manual for the tool — it must say what the tool does,
 // when to use it, argument formats, and edge cases. InputSchema is a
 // JSON Schema object; arguments are validated against it before
 // Execute runs.
+//
+// Result convention: on success Execute returns prose (or whatever
+// text the model should read) and a nil error. On failure it returns
+// a Go error; the loop wraps that error into the structured tool
+// error the model sees, so a tool must not format its own "error:"
+// prose. A tool that genuinely needs to emit a machine-readable
+// failure of its own returns an error whose message is a top-level
+// JSON object carrying an "error" key, and the loop relays that
+// object unwrapped instead of nesting one error inside another.
 type Tool struct {
 	Name        string
 	Description string


### PR DESCRIPTION
## What

A failed tool call now enters the conversation as a small JSON object instead of prose:

```json
{"error": "policy_denied", "message": "denied: ... do not retry the same call.", "retryable": false}
```

`IsError` stays true, so the D-020 effort dial still restores full effort after any failure.

Codes and their retryability:

| code | retryable | raised by |
| --- | --- | --- |
| `policy_denied` | false | hard deny, unattended auto-deny (D-039), constraint violation |
| `unknown_tool` | false | a name absent from the turn's tool surface |
| `call_cap` | false | a call past `MaxToolCalls` (D-097) |
| `user_denied` | false | the user turning down an interactive prompt, or the ask gate losing its context |
| `timeout` | true | `tools.ErrTimeout`, `context.DeadlineExceeded`, a net timeout |
| `network` | true | any other `net.Error` |
| `gateway_unavailable` | true | the permission resolve itself failing |
| `tool_error` | true | a tool's own failure, and a panic folded into feedback |

## Why

Retryability was prose only. The model had to infer from wording whether a second attempt could work, so it re-issued calls a hard policy would refuse again, and abandoned failures a retry would have cleared. A flag it can read directly makes both cheaper.

## How

- New `internal/brain/loop/toolerror.go`: the `toolError` struct, the code constants, `retryableFor`, `wrapToolError` and `alreadyStructured` (D-104).
- `resolveAndRun` returns the code alongside content and status; every failure site is tagged.
- The wrap happens at exactly one place, in `executeOne`, after the digest, the audit line and the stream event have been derived from the raw prose. The UI, mission events (`mission.permission_denied` detail) and the audit trail read exactly as before; only `ToolResult.Content` changes, so no TypeScript change was needed.
- The message is capped **before** marshaling, leaving room for the envelope, because `capToolResult` runs on the finished content and would otherwise cut the object mid-JSON. A shell timeout with partial output keeps that output inside `message`.
- The call-cap refusal wraps its content with `call_cap`; the stream event's digest stays the plain sentence.
- Classification uses `errors.Is`/`errors.As`, never message text. `builtin.newShell`'s timeout now wraps a new `tools.ErrTimeout` sentinel with `%w`. The sentinel lives in `internal/brain/tools` rather than `builtin`: `loop` already imports `tools`, while importing `builtin` would pull pgpool, migrations and pdfgen into the loop package for one variable.
- Passthrough guard: a tool that returns an error whose message is a top-level JSON object with an `"error"` key is relayed unwrapped, so one error object is never nested in another. The convention is documented on `tools.Tool`.

## Deviations from the plan

- The scoping suggested the guard match on the tool's *output* string. A tool signalling failure returns a Go error, and the output string is either empty or partial data, so the guard matches on the error message and `resolveAndRun` relays it verbatim instead of prefixing `tool failed: `.
- `*net.OpError` already satisfies `net.Error`, so a single `errors.As` on `net.Error` covers dial, DNS and read/write failures; the separate `*net.OpError` branch was dropped as dead.
- Issue #650 (timeout vs deny wording) is out of scope here. Both the explicit deny and the 10 minute prompt timeout keep their current wording and share `user_denied` for now; #650 will split them.

## Verification

- `make build test vet lint` green, plus `go vet -tags integration ./...`.
- New `toolerror_test.go`: per-code retryability, wrap shape, partial output surviving in `message`, the cap keeping valid JSON through `capToolResult`, `alreadyStructured` table, `classifyToolError` table, and three end-to-end agent tests proving the model gets the structured object while the digest and audit line keep the raw prose, that an unknown tool is not retryable, and that a tool's own structured error passes through.
- `TestAgentRequestMaxToolCallsRefusesPastCap` now decodes the JSON for the capped case; the uncapped case still asserts plain content.
- `make canary`: **PASS** (6 model turns, 139s, `mission.done`).
- `make canary-impossible`: **PASS: harness failed honestly, no fabrication** (`mission.plan_infeasible`, and a `mission.permission_denied` along the way, so the denial prose still steers the model through the wrap).

Closes #646

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791624472&installation_model_id=431401&pr_number=662&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F662&signature=9a5e67311c8da5af9ec1e915d0d1f913a1c93dc9486c89505d2b03f7247b3c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->