### PR TITLE
feat(connectors): defer large mcp tool sets behind a load_tool index

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -226,8 +226,22 @@ func main() {
 	}
 
 	conns, goog, msft, markItDownURL := buildConnectors(app.DB, secrets, app.Log)
+	// recordLoadedTool is set to the chat service's recorder once that
+	// exists (below); connectors are built long before it, and a
+	// connector reload can only fire after the HTTP server is up, so
+	// the indirection is never read while still nil in practice. Left
+	// nil-safe anyway: a load_tool call with no sink just reports the
+	// schema and nothing sticks.
+	var recordLoadedTool func(sessionID string, t *tools.Tool)
 	if conns != nil {
-		conns.RegisterBuilder("mcp", connectors.MCPBuilder(nil))
+		conns.RegisterBuilder("mcp", connectors.MCPBuilder(nil, connectors.MCPDeferral{
+			Threshold: flags.MCPToolIndexThreshold,
+			OnLoad: func(sessionID string, t *tools.Tool) {
+				if recordLoadedTool != nil {
+					recordLoadedTool(sessionID, t)
+				}
+			},
+		}))
 		conns.RegisterBuilder("github", connectors.GitHubBuilder(nil))
 		if goog != nil {
 			conns.RegisterBuilder("google", goog.Builder())
@@ -538,6 +552,10 @@ func main() {
 	// agent loop's own Resolve chain reads from: seeding here is
 	// visible to that exact chain, not a parallel grant store.
 	svc.SetApprovalGrants(chatPerms)
+	// Closes the loop opened where the mcp builder was registered: a
+	// deferred MCP tool the model loads mid-session lands in this
+	// session's turn-scoped ExtraTools from the next turn on.
+	recordLoadedTool = svc.RecordLoadedTool
 	compactor.SetSensitiveTools(sensitiveTools)
 	// extractDeny fetches system-owned values a proposed fact must not
 	// restate (currently just the operator's timezone). Read per-call,

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -172,6 +172,15 @@ type Service struct {
 	seededMu sync.Mutex
 	seeded   map[string]bool
 
+	// loadedTools holds the MCP tools a session pulled in through a
+	// connector's load_tool (issue #643), keyed by session id and
+	// replayed as turn-scoped ExtraTools for the rest of the session.
+	// Process-local by design, same tradeoff as seeded above: a
+	// restart just makes the model load the tool again, which costs
+	// one step and no correctness.
+	loadedMu    sync.Mutex
+	loadedTools map[string][]*tools.Tool
+
 	// turns is the live-turn broadcaster registry (broadcast.go): a
 	// session ID present here means that session has a turn in flight,
 	// full stop. There is no separate turn_active bool anywhere: the
@@ -376,6 +385,44 @@ func (s *Service) seedApprovalGrants(ctx context.Context, sessionID string, prof
 			s.logger.Warn("chat: approval allowlist grant failed", "session_id", sessionID, "tool", tool, "error", err)
 		}
 	}
+}
+
+// RecordLoadedTool remembers a deferred MCP tool a session loaded
+// through a connector's load_tool (issue #643) so every later turn in
+// that session offers it. The tool arrives already namespaced and is
+// wrapped in schema validation here, matching what the eager path
+// gets from tools.Constrained: turn-scoped ExtraTools skip that check
+// otherwise, and a remote server's schema is not this repo's code.
+// Loading grants no permission: the call still walks the whole chain.
+func (s *Service) RecordLoadedTool(sessionID string, t *tools.Tool) {
+	if sessionID == "" || t == nil {
+		return
+	}
+	validated, err := tools.Validated(t)
+	if err != nil {
+		s.logger.Warn("chat: loaded tool schema rejected", "session_id", sessionID, "tool", t.Name, "error", err)
+		return
+	}
+	s.loadedMu.Lock()
+	defer s.loadedMu.Unlock()
+	if s.loadedTools == nil {
+		s.loadedTools = map[string][]*tools.Tool{}
+	}
+	for i, existing := range s.loadedTools[sessionID] {
+		if existing.Name == validated.Name {
+			s.loadedTools[sessionID][i] = validated
+			return
+		}
+	}
+	s.loadedTools[sessionID] = append(s.loadedTools[sessionID], validated)
+}
+
+// LoadedTools returns the tools this session has loaded, in load
+// order.
+func (s *Service) LoadedTools(sessionID string) []*tools.Tool {
+	s.loadedMu.Lock()
+	defer s.loadedMu.Unlock()
+	return slices.Clone(s.loadedTools[sessionID])
 }
 
 // New builds the service. packs are the loaded skill definitions: their
@@ -1371,6 +1418,7 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	}
 
 	var extraTools []*tools.Tool
+	extraTools = append(extraTools, s.LoadedTools(sessionID)...)
 	if t := s.kbSearchTool(boost); t != nil {
 		extraTools = append(extraTools, t)
 	}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
@@ -3383,5 +3384,51 @@ func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {
 	sent := chatRequest(t, gw)
 	if sent.Agent != "general-id" || sent.Route != "default" {
 		t.Fatalf("agent/route = %s/%s, want general-id/default (dispatch fallback on classify error)", sent.Agent, sent.Route)
+	}
+}
+
+// TestLoadedToolsPersistPerSession pins the session-scoped registry a
+// deferred MCP tool lands in (issue #643): the tool sticks for the
+// session, reloading it replaces rather than duplicates, and another
+// session sees nothing.
+func TestLoadedToolsPersistPerSession(t *testing.T) {
+	t.Parallel()
+	s := &Service{logger: discard()}
+	mk := func(name string) *tools.Tool {
+		return &tools.Tool{
+			Name:        name,
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute:     func(context.Context, json.RawMessage) (string, error) { return name, nil },
+		}
+	}
+
+	s.RecordLoadedTool("s1", mk("github_create_issue"))
+	s.RecordLoadedTool("s1", mk("github_list_prs"))
+	s.RecordLoadedTool("s1", mk("github_create_issue")) // reload, not a duplicate
+	s.RecordLoadedTool("", mk("github_ignored"))
+	s.RecordLoadedTool("s1", nil)
+
+	got := s.LoadedTools("s1")
+	if len(got) != 2 || got[0].Name != "github_create_issue" || got[1].Name != "github_list_prs" {
+		t.Fatalf("loaded = %+v", got)
+	}
+	if len(s.LoadedTools("s2")) != 0 {
+		t.Fatalf("session s2 must see nothing")
+	}
+	// The recorded tool is schema-validated, unlike a raw ExtraTool.
+	if _, err := got[0].Execute(t.Context(), json.RawMessage(`[]`)); !tools.IsViolation(err) {
+		t.Fatalf("recorded tool = %v, want a schema violation on bad args", err)
+	}
+}
+
+// TestRecordLoadedToolDropsBrokenSchema keeps a remote server's
+// malformed schema out of the session surface instead of panicking
+// or offering an uncheckable tool.
+func TestRecordLoadedToolDropsBrokenSchema(t *testing.T) {
+	t.Parallel()
+	s := &Service{logger: discard()}
+	s.RecordLoadedTool("s1", &tools.Tool{Name: "bad", InputSchema: json.RawMessage(`{"type":`)})
+	if len(s.LoadedTools("s1")) != 0 {
+		t.Fatalf("a broken schema must not reach the session surface")
 	}
 }

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -218,15 +218,23 @@ func (m *Manager) AccountConnector(toolName string, args json.RawMessage) string
 func namespacedTools(name string, ts []*tools.Tool) []*tools.Tool {
 	out := make([]*tools.Tool, 0, len(ts))
 	for _, t := range ts {
-		full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
-		if len(full) > 128 {
-			full = full[:128]
-		}
 		clone := *t
-		clone.Name = full
+		clone.Name = NamespacedName(name, t.Name)
 		out = append(out, &clone)
 	}
 	return out
+}
+
+// NamespacedName is the "<connector>_<tool>" form namespacedTools
+// gives a split tool: sanitized and length-capped. Exported so a
+// deferred MCP tool loaded mid-session (mcp.go's load_tool) lands on
+// exactly the name the eager path would have produced.
+func NamespacedName(connector, tool string) string {
+	full := toolNameSanitizer.ReplaceAllString(connector+"_"+tool, "_")
+	if len(full) > 128 {
+		full = full[:128]
+	}
+	return full
 }
 
 // accountInfo is the optional Source capability that reports the

--- a/internal/brain/connectors/mcp.go
+++ b/internal/brain/connectors/mcp.go
@@ -31,10 +31,29 @@ type mcpConfig struct {
 	Headers  map[string]string `json:"headers"`
 }
 
+// MCPDeferral is what an mcp source needs to defer tool schemas
+// behind an index (issue #643): the threshold above which a server's
+// tools stop being injected eagerly, and the sink a load_tool call
+// reports the loaded tool to. A zero value (or a nil Threshold) keeps
+// every connector eager, so tests and callers that don't wire it get
+// today's behavior.
+type MCPDeferral struct {
+	// Threshold returns the tool count above which the index replaces
+	// eager schemas; 0 disables deferral. Read per build, not cached,
+	// so a settings change takes effect on the next connector reload.
+	Threshold func(ctx context.Context) int
+	// OnLoad records a tool the model loaded, under its final
+	// namespaced name, for the rest of that session's turns. nil means
+	// nothing records it, so deferral stays off.
+	OnLoad func(sessionID string, t *tools.Tool)
+}
+
 // MCPBuilder returns the Builder for kind='mcp'. The credential ref
 // resolves to a bearer token; an empty or unresolvable ref builds
 // without auth and lets the server's 401 surface at initialize.
-func MCPBuilder(client *http.Client) Builder {
+// deferral is optional: its zero value keeps every server's schemas
+// eager.
+func MCPBuilder(client *http.Client, deferral MCPDeferral) Builder {
 	if client == nil {
 		client = &http.Client{}
 	}
@@ -56,6 +75,12 @@ func MCPBuilder(client *http.Client) Builder {
 		if err := src.connect(ctx); err != nil {
 			return nil, fmt.Errorf("mcp %s: %w", c.Name, err)
 		}
+		if deferral.Threshold != nil && deferral.OnLoad != nil {
+			if n := deferral.Threshold(ctx); n > 0 && len(src.toolList) > n {
+				src.indexed = true
+				src.onLoad = deferral.OnLoad
+			}
+		}
 		return src, nil
 	}
 }
@@ -72,6 +97,13 @@ type mcpSource struct {
 	sessionID string // Mcp-Session-Id, captured at initialize
 	nextID    atomic.Int64
 	toolList  []*tools.Tool
+
+	// indexed defers this server's schemas behind load_tool (issue
+	// #643): Tools() then returns that single entry point instead of
+	// toolList, whose schemas the model pulls in one at a time. The
+	// zero value is eager, today's behavior.
+	indexed bool
+	onLoad  func(sessionID string, t *tools.Tool)
 }
 
 // connect runs the MCP handshake and caches the tool list.
@@ -120,8 +152,114 @@ func (s *mcpSource) connect(ctx context.Context) error {
 }
 
 // Tools returns the server's tools, un-namespaced — the manager
-// prefixes connector names when it aggregates.
-func (s *mcpSource) Tools() []*tools.Tool { return s.toolList }
+// prefixes connector names when it aggregates. An indexed source
+// returns exactly one synthetic load_tool whose description carries
+// the index, so a large server costs one tool def per turn instead of
+// one per remote tool; the manager namespaces it to
+// "<connector>_load_tool", which is what we want, one entry point per
+// connector.
+func (s *mcpSource) Tools() []*tools.Tool {
+	if !s.indexed {
+		return s.toolList
+	}
+	return []*tools.Tool{s.loadTool()}
+}
+
+// IndexText renders the deferred tool index: one line per remote tool,
+// name plus the first line of its description.
+func (s *mcpSource) IndexText() string {
+	var b strings.Builder
+	for _, t := range s.toolList {
+		summary := strings.TrimSpace(firstLine(t.Description))
+		if len(summary) > mcpIndexSummaryMax {
+			summary = summary[:mcpIndexSummaryMax] + "…"
+		}
+		if summary == "" {
+			fmt.Fprintf(&b, "- %s\n", t.Name)
+			continue
+		}
+		fmt.Fprintf(&b, "- %s: %s\n", t.Name, summary)
+	}
+	return b.String()
+}
+
+// mcpIndexSummaryMax caps one index line's description so a server
+// with verbose docs can't undo the saving the index exists for.
+const mcpIndexSummaryMax = 160
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// loadTool is the deferred index's entry point: the model names a
+// tool from the index, and the tool's full schema joins the session's
+// surface from the next step on. The loaded tool carries the SAME
+// namespaced name the eager path would have given it, so grants and
+// the D-036 suffix rule behave identically; it takes no permission
+// exemption from having been loaded this way.
+func (s *mcpSource) loadTool() *tools.Tool {
+	byName := make(map[string]*tools.Tool, len(s.toolList))
+	names := make([]string, 0, len(s.toolList))
+	for _, t := range s.toolList {
+		byName[t.Name] = t
+		names = append(names, t.Name)
+	}
+	return &tools.Tool{
+		Name: "load_tool",
+		Description: `Loads one of this connector's tools so you can call it.
+
+The ` + s.name + ` connector serves too many tools to describe them all
+up front, so their schemas are deferred. Pick one from the index below
+by what you need to do, load it, then call it by its own name on your
+next step.
+
+Arguments:
+- name (string, required): the tool's name exactly as listed below.
+
+Returns the tool's description and argument schema; the tool stays
+callable for the rest of this conversation. Loading a tool does not
+grant permission to use it: the usual approval still applies when you
+call it.
+
+Tools available from ` + s.name + `:
+` + s.IndexText(),
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Tool name from the index in this description"
+				}
+			},
+			"required": ["name"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			t, ok := byName[args.Name]
+			if !ok {
+				return "", fmt.Errorf("unknown tool %q on connector %s — available: %s", args.Name, s.name, strings.Join(names, ", "))
+			}
+			sessionID := tools.SessionIDFromContext(ctx)
+			if sessionID == "" {
+				return "", fmt.Errorf("load_tool: no session in context")
+			}
+			loaded := *t
+			loaded.Name = NamespacedName(s.name, t.Name)
+			s.onLoad(sessionID, &loaded)
+			return fmt.Sprintf("Loaded %s. Call it as %q.\n\nDescription: %s\n\nInput schema: %s",
+				t.Name, loaded.Name, t.Description, string(t.InputSchema)), nil
+		},
+	}
+}
 
 // Test re-lists tools: proves the session, auth, and endpoint are
 // still good without side effects.

--- a/internal/brain/connectors/mcp_test.go
+++ b/internal/brain/connectors/mcp_test.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
 
 // fakeMCP is a minimal streamable-HTTP MCP server: initialize,
@@ -24,6 +26,10 @@ type fakeMCP struct {
 	gotProto  string
 	gotCalls  []string
 	sessionID string
+	// toolsJSON overrides the default two-tool list (the "tools" array
+	// body only), for the deferred-index tests that need a server over
+	// the threshold.
+	toolsJSON string
 }
 
 func (f *fakeMCP) handler() http.HandlerFunc {
@@ -75,6 +81,10 @@ func (f *fakeMCP) handler() http.HandlerFunc {
 				return
 			}
 			// One line: SSE data frames must not contain raw newlines.
+			if f.toolsJSON != "" {
+				respond(`{"tools":` + f.toolsJSON + `}`)
+				return
+			}
 			respond(`{"tools":[{"name":"create_issue","description":"Create a GitHub issue","inputSchema":{"type":"object","properties":{"title":{"type":"string"}}}},{"name":"search code","description":"Search"}]}`)
 		case "tools/call":
 			var p struct {
@@ -96,10 +106,15 @@ func (f *fakeMCP) handler() http.HandlerFunc {
 
 func buildMCP(t *testing.T, f *fakeMCP, token string) Source {
 	t.Helper()
+	return buildMCPWith(t, f, token, MCPDeferral{})
+}
+
+func buildMCPWith(t *testing.T, f *fakeMCP, token string, deferral MCPDeferral) Source {
+	t.Helper()
 	srv := httptest.NewServer(f.handler())
 	t.Cleanup(srv.Close)
 	//nolint:gosec // G101: CredentialRef is a ref NAME, not a credential value.
-	src, err := MCPBuilder(srv.Client())(t.Context(), Connector{
+	src, err := MCPBuilder(srv.Client(), deferral)(t.Context(), Connector{
 		Name: "github", Kind: "mcp",
 		Config:        json.RawMessage(`{"endpoint":"` + srv.URL + `"}`),
 		CredentialRef: "GITHUB_MCP_TOKEN",
@@ -175,7 +190,7 @@ func TestMCPSSEResponses(t *testing.T) {
 
 func TestMCPBuildFailures(t *testing.T) {
 	t.Parallel()
-	builder := MCPBuilder(nil)
+	builder := MCPBuilder(nil, MCPDeferral{})
 	resolve := func(context.Context, string) (string, error) { return "", nil }
 
 	// Endpoint is required.
@@ -186,7 +201,7 @@ func TestMCPBuildFailures(t *testing.T) {
 	f := &fakeMCP{token: "right"}
 	srv := httptest.NewServer(f.handler())
 	t.Cleanup(srv.Close)
-	_, err := MCPBuilder(srv.Client())(t.Context(), Connector{
+	_, err := MCPBuilder(srv.Client(), MCPDeferral{})(t.Context(), Connector{
 		Name: "x", Config: json.RawMessage(`{"endpoint":"` + srv.URL + `"}`),
 	}, func(context.Context, string) (string, error) { return "wrong", nil })
 	if err == nil || !strings.Contains(err.Error(), "401") {
@@ -301,4 +316,197 @@ func TestManagerNamespacesMCPToolReservedByBuiltin(t *testing.T) {
 	if names["search code"] {
 		t.Fatalf("tools = %v, reserved raw name must never be served directly", names)
 	}
+}
+
+// bigToolsJSON builds a tools/list body with n tools named tool_0..n-1.
+func bigToolsJSON(n int) string {
+	var b strings.Builder
+	b.WriteString("[")
+	for i := range n {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"name":"tool_%d","description":"Does thing %d","inputSchema":{"type":"object","properties":{"q":{"type":"string"}},"required":["q"],"additionalProperties":false}}`, i, i)
+	}
+	b.WriteString("]")
+	return b.String()
+}
+
+func indexDeferral(threshold int, loaded *[]*tools.Tool, sessions *[]string) MCPDeferral {
+	return MCPDeferral{
+		Threshold: func(context.Context) int { return threshold },
+		OnLoad: func(sessionID string, t *tools.Tool) {
+			*sessions = append(*sessions, sessionID)
+			*loaded = append(*loaded, t)
+		},
+	}
+}
+
+// TestMCPDefersLargeToolSetBehindIndex pins issue #643's headline
+// behavior: over the threshold, the turn sees one load_tool whose
+// description carries every remote tool's name, not every schema.
+func TestMCPDefersLargeToolSetBehindIndex(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{toolsJSON: bigToolsJSON(9)}
+	var loaded []*tools.Tool
+	var sessions []string
+	src := buildMCPWith(t, f, "", indexDeferral(8, &loaded, &sessions))
+
+	list := src.Tools()
+	if len(list) != 1 || list[0].Name != "load_tool" {
+		t.Fatalf("tools = %+v, want a single load_tool", list)
+	}
+	index := src.(*mcpSource).IndexText()
+	for i := range 9 {
+		name := fmt.Sprintf("tool_%d", i)
+		if !strings.Contains(index, "- "+name+": Does thing") {
+			t.Fatalf("index missing %s:\n%s", name, index)
+		}
+		if !strings.Contains(list[0].Description, name) {
+			t.Fatalf("load_tool description missing %s", name)
+		}
+	}
+	// The index carries names and one-line summaries, never schemas.
+	if strings.Contains(list[0].Description, "additionalProperties") {
+		t.Fatalf("index leaked a schema:\n%s", list[0].Description)
+	}
+}
+
+// TestMCPUnderThresholdStaysEager pins the unchanged case: a small
+// server injects every schema exactly as before, and never grows a
+// load_tool.
+func TestMCPUnderThresholdStaysEager(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{toolsJSON: bigToolsJSON(8)}
+	var loaded []*tools.Tool
+	var sessions []string
+	src := buildMCPWith(t, f, "", indexDeferral(8, &loaded, &sessions))
+
+	list := src.Tools()
+	if len(list) != 8 {
+		t.Fatalf("tools = %d, want all 8 eager", len(list))
+	}
+	for _, tl := range list {
+		if tl.Name == "load_tool" {
+			t.Fatalf("under-threshold server grew a load_tool")
+		}
+	}
+}
+
+// TestMCPThresholdZeroDisablesDeferral pins the off switch: 0 keeps a
+// large server fully eager, and so does an unwired deferral.
+func TestMCPThresholdZeroDisablesDeferral(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		deferral MCPDeferral
+	}{
+		{"threshold zero", MCPDeferral{Threshold: func(context.Context) int { return 0 }, OnLoad: func(string, *tools.Tool) {}}},
+		{"not wired", MCPDeferral{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakeMCP{toolsJSON: bigToolsJSON(20)}
+			src := buildMCPWith(t, f, "", tc.deferral)
+			if len(src.Tools()) != 20 {
+				t.Fatalf("tools = %d, want 20 eager", len(src.Tools()))
+			}
+		})
+	}
+}
+
+// TestMCPLoadToolRoundTrip proves the full path: load a tool by name,
+// get it back under the namespaced name the eager path would have
+// given it, then call it through the source's own RPC.
+func TestMCPLoadToolRoundTrip(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{toolsJSON: bigToolsJSON(9)}
+	var loaded []*tools.Tool
+	var sessions []string
+	src := buildMCPWith(t, f, "", indexDeferral(8, &loaded, &sessions))
+
+	load := src.Tools()[0]
+	ctx := tools.WithSessionID(t.Context(), "sess-abc")
+	out, err := load.Execute(ctx, json.RawMessage(`{"name":"tool_3"}`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !strings.Contains(out, "github_tool_3") {
+		t.Fatalf("load result = %q, want the namespaced name", out)
+	}
+	if len(loaded) != 1 || loaded[0].Name != "github_tool_3" {
+		t.Fatalf("recorded = %+v, want github_tool_3", loaded)
+	}
+	if len(sessions) != 1 || sessions[0] != "sess-abc" {
+		t.Fatalf("sessions = %v, want sess-abc", sessions)
+	}
+	// The recorded tool keeps the remote schema and actually calls.
+	if !strings.Contains(string(loaded[0].InputSchema), `"q"`) {
+		t.Fatalf("schema = %s", loaded[0].InputSchema)
+	}
+	res, err := loaded[0].Execute(t.Context(), json.RawMessage(`{"q":"x"}`))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if res != "issue #42 created" {
+		t.Fatalf("call result = %q", res)
+	}
+	// The remote sees the RAW name, not the namespaced one.
+	if len(f.gotCalls) != 1 || !strings.HasPrefix(f.gotCalls[0], "tool_3 ") {
+		t.Fatalf("remote calls = %v", f.gotCalls)
+	}
+}
+
+func TestMCPLoadToolRejectsUnknownAndSessionless(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{toolsJSON: bigToolsJSON(9)}
+	var loaded []*tools.Tool
+	var sessions []string
+	src := buildMCPWith(t, f, "", indexDeferral(8, &loaded, &sessions))
+	load := src.Tools()[0]
+
+	_, err := load.Execute(tools.WithSessionID(t.Context(), "s1"), json.RawMessage(`{"name":"nope"}`))
+	if err == nil || !strings.Contains(err.Error(), "tool_0") {
+		t.Fatalf("unknown name error = %v, want the available list", err)
+	}
+	if _, err := load.Execute(t.Context(), json.RawMessage(`{"name":"tool_1"}`)); err == nil {
+		t.Fatalf("load with no session in context must fail")
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("nothing should have been recorded, got %+v", loaded)
+	}
+}
+
+// TestMCPIndexTokenCost is the before/after measurement issue #643
+// asks for: the tool-definition tokens a turn pays for a large MCP
+// server, eager versus indexed.
+func TestMCPIndexTokenCost(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{toolsJSON: bigToolsJSON(30)}
+	var loaded []*tools.Tool
+	var sessions []string
+	eager := buildMCPWith(t, f, "", MCPDeferral{})
+	indexed := buildMCPWith(t, &fakeMCP{toolsJSON: bigToolsJSON(30)}, "", indexDeferral(8, &loaded, &sessions))
+
+	before, err := session.EstimateToolTokens(toolDefs(eager.Tools()))
+	if err != nil {
+		t.Fatalf("estimate eager: %v", err)
+	}
+	after, err := session.EstimateToolTokens(toolDefs(indexed.Tools()))
+	if err != nil {
+		t.Fatalf("estimate indexed: %v", err)
+	}
+	t.Logf("tool-definition tokens for a 30-tool MCP server: eager=%d indexed=%d saved=%d (%.0f%%)",
+		before, after, before-after, 100*float64(before-after)/float64(before))
+	if after >= before {
+		t.Fatalf("indexed surface (%d) must cost fewer tokens than eager (%d)", after, before)
+	}
+}
+
+func toolDefs(ts []*tools.Tool) []provider.ToolDef {
+	out := make([]provider.ToolDef, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, provider.ToolDef{Name: t.Name, Description: t.Description, InputSchema: t.InputSchema})
+	}
+	return out
 }

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -832,6 +832,9 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	// concurrent sibling call's result.
 	collector := tools.NewCollector(a.mediaSaver)
 	ctx = tools.WithCollector(ctx, collector)
+	// The session id rides ctx for tools that record per-session state
+	// (connectors' load_tool, issue #643); every other tool ignores it.
+	ctx = tools.WithSessionID(ctx, sessionID)
 	// A panicking tool must become feedback the model can read (D-009),
 	// never a process crash: executeOne runs inside an errgroup worker,
 	// and an unrecovered panic there takes down the whole brain — every

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -119,7 +119,18 @@ const (
 	// from the cost ledger before every review round; "" (the default)
 	// defers to DefaultReviewTokenCeiling, "0" disables the ceiling.
 	ValueReviewTokenCeiling = "mission_review_token_ceiling"
+	// ValueMCPToolIndexThreshold is the tool count above which an MCP
+	// connector stops injecting every remote schema into every turn and
+	// offers a one-line index plus a load_tool entry point instead
+	// (issue #643); "" defers to DefaultMCPToolIndexThreshold, "0"
+	// disables deferral so every connector stays fully eager.
+	ValueMCPToolIndexThreshold = "mcp_tool_index_threshold"
 )
+
+// DefaultMCPToolIndexThreshold is the MCP tool count above which the
+// index replaces eager schemas when ValueMCPToolIndexThreshold is
+// unset.
+const DefaultMCPToolIndexThreshold = 8
 
 // DefaultReviewTokenCeiling is the per-mission review input token cap
 // when ValueReviewTokenCeiling is unset.
@@ -138,6 +149,7 @@ var knownValueKeys = map[string]bool{
 	ValueWebBaseURL: true, ValueTimezone: true,
 	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
 	ValueExecutorRunBudgetMinutes: true, ValueReviewTokenCeiling: true,
+	ValueMCPToolIndexThreshold: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -240,6 +252,18 @@ func (s *Store) AskTimeoutSeconds(ctx context.Context) int {
 		}
 	}
 	return 0
+}
+
+// MCPToolIndexThreshold parses the MCP deferral threshold: unset or
+// unparsable falls back to DefaultMCPToolIndexThreshold, 0 disables
+// deferral entirely.
+func (s *Store) MCPToolIndexThreshold(ctx context.Context) int {
+	if v := s.Value(ctx, ValueMCPToolIndexThreshold); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return DefaultMCPToolIndexThreshold
 }
 
 // ExecutorRunBudget parses the delegated executor wall-clock cap,
@@ -411,7 +435,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}
 	}
-	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling) && value != "" {
+	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling || key == ValueMCPToolIndexThreshold) && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}

--- a/internal/brain/settings/settings_test.go
+++ b/internal/brain/settings/settings_test.go
@@ -61,3 +61,13 @@ func TestAllAppliesKnownKeysOffDefault(t *testing.T) {
 		t.Fatal("All()[KeyKBImageCaptioning] = true, want false by default")
 	}
 }
+
+// TestMCPToolIndexThresholdDefault pins the accessor's fallback: an
+// absent row (or a degraded database) means the built-in threshold,
+// not deferral-off, so a large MCP server is indexed out of the box.
+func TestMCPToolIndexThresholdDefault(t *testing.T) {
+	s := degradedStore(t)
+	if got := s.MCPToolIndexThreshold(context.Background()); got != DefaultMCPToolIndexThreshold {
+		t.Fatalf("MCPToolIndexThreshold = %d, want %d", got, DefaultMCPToolIndexThreshold)
+	}
+}

--- a/internal/brain/tools/constraints.go
+++ b/internal/brain/tools/constraints.go
@@ -299,3 +299,48 @@ func NeedsRetrievalCoercion(category string, toolCalls int, alreadyCoerced bool)
 	}
 	return toolCalls < minCalls
 }
+
+// Validated wraps one tool so its arguments are schema-checked before
+// Execute runs, the same check Constrained applies to registered
+// tools. Turn-scoped ExtraTools bypass Constrained entirely
+// (loop.withExtraTools), which is fine for this repo's own callers but
+// not for a tool whose schema came from a remote MCP server: a
+// deferred tool loaded mid-session must be no less validated than the
+// eager one it stands in for (issue #643). A schema that fails to
+// compile is reported, not silently skipped.
+func Validated(t *Tool) (*Tool, error) {
+	schema := t.InputSchema
+	if len(schema) == 0 {
+		schema = json.RawMessage(`{"type":"object"}`)
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return nil, fmt.Errorf("tools: %s schema: %w", t.Name, err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource(t.Name+".json", doc); err != nil {
+		return nil, fmt.Errorf("tools: %s schema: %w", t.Name, err)
+	}
+	compiled, err := compiler.Compile(t.Name + ".json")
+	if err != nil {
+		return nil, fmt.Errorf("tools: %s schema: %w", t.Name, err)
+	}
+	inner := t.Execute
+	clone := *t
+	clone.Execute = func(ctx context.Context, args json.RawMessage) (string, error) {
+		if len(args) == 0 {
+			args = json.RawMessage(`{}`)
+		}
+		argDoc, uerr := jsonschema.UnmarshalJSON(bytes.NewReader(args))
+		if uerr != nil {
+			return "", &Violation{Msg: fmt.Sprintf(
+				"arguments for %s are not valid JSON: %v — resend the call with corrected arguments", clone.Name, uerr)}
+		}
+		if verr := compiled.Validate(argDoc); verr != nil {
+			return "", &Violation{Msg: fmt.Sprintf(
+				"arguments for %s failed validation: %v — check the tool description for the expected format and resend", clone.Name, verr)}
+		}
+		return inner(ctx, args)
+	}
+	return &clone, nil
+}

--- a/internal/brain/tools/constraints_test.go
+++ b/internal/brain/tools/constraints_test.go
@@ -345,3 +345,48 @@ func TestNeedsRetrievalCoercion(t *testing.T) {
 		})
 	}
 }
+
+// TestValidatedRejectsBadArgs pins the validation parity a deferred
+// MCP tool needs (issue #643): turn-scoped ExtraTools bypass
+// Constrained, so a loaded tool wraps its own schema check and gives
+// the same *Violation feedback rather than handing junk to a remote
+// server.
+func TestValidatedRejectsBadArgs(t *testing.T) {
+	t.Parallel()
+	var got json.RawMessage
+	v, err := Validated(&Tool{
+		Name:        "github_create_issue",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}`),
+		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
+			got = args
+			return "ok", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Validated: %v", err)
+	}
+
+	if _, err := v.Execute(context.Background(), json.RawMessage(`{"title":42}`)); !IsViolation(err) {
+		t.Fatalf("wrong type = %v, want a violation", err)
+	}
+	if _, err := v.Execute(context.Background(), json.RawMessage(`{}`)); !IsViolation(err) {
+		t.Fatalf("missing required = %v, want a violation", err)
+	}
+	if got != nil {
+		t.Fatalf("inner Execute ran on invalid args: %s", got)
+	}
+	out, err := v.Execute(context.Background(), json.RawMessage(`{"title":"hi"}`))
+	if err != nil || out != "ok" {
+		t.Fatalf("valid call = %q, %v", out, err)
+	}
+	if string(got) != `{"title":"hi"}` {
+		t.Fatalf("inner got %s", got)
+	}
+}
+
+func TestValidatedRejectsBrokenSchema(t *testing.T) {
+	t.Parallel()
+	if _, err := Validated(&Tool{Name: "broken", InputSchema: json.RawMessage(`{"type":`)}); err == nil {
+		t.Fatal("a malformed schema must be reported, not silently accepted")
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -113,8 +113,38 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// memory (issue #648): the query is the only argument and
 			// nothing it returns reaches a side effect.
 			"search_memory": true,
+			// A connector's deferred-tool index entry point is exempt
+			// too, but by suffix rather than by name: see
+			// isConnectorLoadTool.
 		},
 	}
+}
+
+// loadToolName is the raw name a connector gives its deferred-tool
+// index entry point; the manager serves it namespaced as
+// "<connector>_load_tool" (connectors.NamespacedName).
+const loadToolName = "load_tool"
+
+// isConnectorLoadTool reports whether tool is a connector's
+// deferred-tool index entry point (issue #643), which is exempt for
+// the same reason load_skill is: its Execute resolves a name against
+// an in-process list and returns that tool's description and schema
+// as text, with no remote call and no side effect the operator could
+// meaningfully approve. Prompting on the lookup would park a turn on
+// the act of reading an index.
+//
+// A suffix check rather than an exempt-map entry because the map is
+// exact-name and the manager namespaces the raw "load_tool" per
+// connector, so the exempt name is not known until a connector is
+// configured. The suffix is deliberately NOT applied to the rest of
+// the exempt map: reusing ToolMatches there would exempt any remote
+// tool that happened to end in "_search_kb" or "_remember", handing a
+// third-party MCP server a way to name its way out of the permission
+// chain. Loading a tool still grants nothing: the loaded tool keeps
+// its own namespaced name, is absent from the exempt map, and walks
+// the whole chain when the model actually calls it.
+func isConnectorLoadTool(tool string) bool {
+	return tool == loadToolName || strings.HasSuffix(tool, "_"+loadToolName)
 }
 
 // Resolve runs the chain for one call.
@@ -129,7 +159,7 @@ func (p *Permissions) Resolve(ctx context.Context, sessionID, tool string, args 
 		}, nil
 	}
 
-	if p.exempt[tool] {
+	if p.exempt[tool] || isConnectorLoadTool(tool) {
 		return Resolution{Decision: DecisionAllow, Subject: subject, Rationale: "exempt tool"}, nil
 	}
 

--- a/internal/brain/tools/permissions_integration_test.go
+++ b/internal/brain/tools/permissions_integration_test.go
@@ -269,3 +269,21 @@ func TestResolveSandboxOpaqueGuardStillDenies(t *testing.T) {
 		t.Fatalf("res = %+v, want hard deny (system dirs guard)", res)
 	}
 }
+
+// TestResolveLoadedMCPToolAsks pins issue #643's safety AC: a
+// deferred MCP tool the model pulled in through load_tool goes
+// through the same chain as an eager one. Its namespaced name has no
+// standing grant and no exemption, so it asks.
+func TestResolveLoadedMCPToolAsks(t *testing.T) {
+	p, sid := integrationPermissions(t)
+
+	for _, name := range []string{"github_load_tool", "github_create_issue"} {
+		res, err := p.Resolve(t.Context(), sid, name, json.RawMessage(`{"q":"x"}`))
+		if err != nil {
+			t.Fatalf("Resolve %s: %v", name, err)
+		}
+		if res.Decision != DecisionAsk {
+			t.Fatalf("%s = %+v, want ask", name, res)
+		}
+	}
+}

--- a/internal/brain/tools/permissions_integration_test.go
+++ b/internal/brain/tools/permissions_integration_test.go
@@ -270,20 +270,27 @@ func TestResolveSandboxOpaqueGuardStillDenies(t *testing.T) {
 	}
 }
 
-// TestResolveLoadedMCPToolAsks pins issue #643's safety AC: a
-// deferred MCP tool the model pulled in through load_tool goes
-// through the same chain as an eager one. Its namespaced name has no
-// standing grant and no exemption, so it asks.
-func TestResolveLoadedMCPToolAsks(t *testing.T) {
+// TestResolveConnectorLoadToolPath pins the deferred-tool permission
+// path end to end against the real chain: the index entry point is
+// allowed without a prompt (exempt, like load_skill), while a tool
+// loaded through it has no grant and no exemption, so it asks exactly
+// as the eager tool it stands in for would.
+func TestResolveConnectorLoadToolPath(t *testing.T) {
 	p, sid := integrationPermissions(t)
 
-	for _, name := range []string{"github_load_tool", "github_create_issue"} {
-		res, err := p.Resolve(t.Context(), sid, name, json.RawMessage(`{"q":"x"}`))
-		if err != nil {
-			t.Fatalf("Resolve %s: %v", name, err)
-		}
-		if res.Decision != DecisionAsk {
-			t.Fatalf("%s = %+v, want ask", name, res)
-		}
+	res, err := p.Resolve(t.Context(), sid, "github_load_tool", json.RawMessage(`{"name":"create_issue"}`))
+	if err != nil {
+		t.Fatalf("Resolve entry point: %v", err)
+	}
+	if res.Decision != DecisionAllow || res.Rationale != "exempt tool" {
+		t.Fatalf("github_load_tool = %+v, want an exempt allow", res)
+	}
+
+	res, err = p.Resolve(t.Context(), sid, "github_create_issue", json.RawMessage(`{"title":"x"}`))
+	if err != nil {
+		t.Fatalf("Resolve loaded tool: %v", err)
+	}
+	if res.Decision != DecisionAsk {
+		t.Fatalf("github_create_issue = %+v, want ask", res)
 	}
 }

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -329,3 +329,17 @@ func TestGuardEmbeddedPath(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadedMCPToolsAreNotExempt guards the loading path against
+// quietly becoming a permission bypass (issue #643): neither the
+// entry point nor a tool loaded through it may appear in the exempt
+// map, unlike load_skill, whose result is inert text.
+func TestLoadedMCPToolsAreNotExempt(t *testing.T) {
+	t.Parallel()
+	p := NewPermissions(nil, "/workspace")
+	for _, name := range []string{"load_tool", "github_load_tool", "github_create_issue"} {
+		if p.exempt[name] {
+			t.Fatalf("%s must not be exempt from the permission chain", name)
+		}
+	}
+}

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -330,16 +330,32 @@ func TestGuardEmbeddedPath(t *testing.T) {
 	}
 }
 
-// TestLoadedMCPToolsAreNotExempt guards the loading path against
-// quietly becoming a permission bypass (issue #643): neither the
-// entry point nor a tool loaded through it may appear in the exempt
-// map, unlike load_skill, whose result is inert text.
-func TestLoadedMCPToolsAreNotExempt(t *testing.T) {
+// TestConnectorLoadToolExemption pins both halves of issue #643's
+// permission story: the deferred-index entry point is exempt under
+// every connector's namespaced form, the way load_skill is, while a
+// tool loaded THROUGH it stays fully inside the chain. The suffix
+// must not leak to the rest of the exempt map either, or a remote
+// server could name its way out by ending a tool in "_search_kb".
+func TestConnectorLoadToolExemption(t *testing.T) {
 	t.Parallel()
+	exempt := []string{"load_tool", "github_load_tool", "some-other-mcp_load_tool"}
+	notExempt := []string{
+		"github_create_issue",
+		"github_load_toolbox",  // suffix must land on a "_" boundary
+		"github_search_kb",     // an exempt raw name must NOT match by suffix
+		"github_remember",      // same
+		"my_load_tool_wrapper", // suffix must be at the end
+	}
+
 	p := NewPermissions(nil, "/workspace")
-	for _, name := range []string{"load_tool", "github_load_tool", "github_create_issue"} {
-		if p.exempt[name] {
-			t.Fatalf("%s must not be exempt from the permission chain", name)
+	for _, name := range exempt {
+		if !isConnectorLoadTool(name) {
+			t.Errorf("%s: want exempt as a connector index entry point", name)
+		}
+	}
+	for _, name := range notExempt {
+		if isConnectorLoadTool(name) || p.exempt[name] {
+			t.Errorf("%s: must stay inside the permission chain", name)
 		}
 	}
 }

--- a/internal/brain/tools/tool.go
+++ b/internal/brain/tools/tool.go
@@ -28,3 +28,22 @@ type Tool struct {
 	// convention or a connector's kind.
 	ReadOnly bool
 }
+
+// sessionIDKey carries the turn's session id to a tool's Execute. Set
+// once by the loop before it runs a step's calls; the permission
+// chain takes the id as an argument instead, so this exists only for
+// tools that must record something per session (connectors' load_tool,
+// issue #643).
+type sessionIDKey struct{}
+
+// WithSessionID attaches the turn's session id to ctx.
+func WithSessionID(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sessionID)
+}
+
+// SessionIDFromContext returns the session id WithSessionID attached,
+// or "" outside a turn.
+func SessionIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(sessionIDKey{}).(string)
+	return id
+}

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -156,6 +156,11 @@ const EXECUTOR_RUN_BUDGET_DEFAULT_MIN = 480
 // for the placeholder; the server applies the real default.
 const REVIEW_TOKEN_CEILING_DEFAULT = 1_500_000
 
+// MCP_TOOL_INDEX_THRESHOLD_DEFAULT mirrors
+// settings.DefaultMCPToolIndexThreshold for the placeholder; the
+// server applies the real default.
+const MCP_TOOL_INDEX_THRESHOLD_DEFAULT = 8
+
 // Descriptor for a plain value card: an Input or Select field, one
 // settings key, and how its committed value maps to the field's
 // working value. save() receives the trimmed working value.
@@ -239,6 +244,24 @@ const valueCardDescriptors: ValueCardDescriptor[] = [
         placeholder={String(REVIEW_TOKEN_CEILING_DEFAULT)}
         className="h-9 w-40"
         aria-label="Review token ceiling"
+      />
+    ),
+    toPatchValue: (v) => v.trim(),
+  },
+  {
+    key: 'mcp_tool_index_threshold',
+    title: 'MCP tool index threshold',
+    description:
+      'An MCP connector with more tools than this offers a one-line index plus a load_tool entry point instead of every schema, so a large server does not tax every turn. Empty uses the default (8), 0 keeps every connector eager.',
+    render: (value, setValue) => (
+      <Input
+        type="number"
+        min={0}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={String(MCP_TOOL_INDEX_THRESHOLD_DEFAULT)}
+        className="h-9 w-40"
+        aria-label="MCP tool index threshold"
       />
     ),
     toPatchValue: (v) => v.trim(),


### PR DESCRIPTION
Closes #643

## What

An MCP connector serving more tools than a configurable threshold (new
`mcp_tool_index_threshold` setting, default 8, `0` disables) stops
injecting every remote schema into every turn. Its `Tools()` returns a
single synthetic `load_tool` instead, which the manager namespaces to
`<connector>_load_tool`, one entry point per connector. That tool's
description carries a compact index: one line per remote tool, name plus
the first line of its description, capped at 160 characters. The model
names a tool from the index, `load_tool` returns its description and
schema, and the tool joins that session's surface for every later turn
under the same namespaced name the eager path would have given it.

Below the threshold nothing changes: all schemas stay eager, and no
`load_tool` appears.

## Why

Skills already solved this shape of problem with a one-line index plus
`load_skill`. MCP had no equivalent, so connecting one large server made
every request in every session pay for schemas the model would mostly
never call. The tool-definition estimate from #642 makes the cost
visible, and the index cuts it by more than half on a realistic server.

## How

- `settings`: `ValueMCPToolIndexThreshold` with a non-negative-integer
  validation case and a `MCPToolIndexThreshold(ctx) int` accessor
  (`DefaultMCPToolIndexThreshold = 8`, `0` = off), plus a row in the
  Features settings panel mirroring the other numeric value keys.
- `connectors/mcp.go`: `mcpSource` keeps the full list and gains
  `indexed`/`onLoad`, decided at build time from a new optional
  `MCPDeferral{Threshold, OnLoad}` argument to `MCPBuilder`. The zero
  value is eager, so struct-literal sources in tests and any caller that
  does not wire it keep today's behaviour. `IndexText()` renders the
  index; `loadTool()` builds the entry point.
- `connectors/manager.go`: `NamespacedName` factored out of
  `namespacedTools`, so a tool loaded mid-session lands on byte-identical
  naming and the D-036 grant suffix rule behaves the same.
- `tools`: `WithSessionID`/`SessionIDFromContext`, set once by the loop
  in `executeOne` next to the existing media collector, so `load_tool`
  knows which session to record into. `Validated(t)` wraps one tool in
  the same JSON-schema check `Constrained` applies to registered tools.
- `chat.Service`: a mutex-protected `loadedTools map[sessionID][]*Tool`
  (process-local, the same tradeoff as the existing `seeded` map),
  appended to the per-turn `ExtraTools` alongside the KB tools.
  `RecordLoadedTool` runs every tool through `tools.Validated` first,
  because turn-scoped `ExtraTools` bypass `Constrained` and a remote
  server's schema is not this repo's code. `cmd/brain/main.go` wires the
  threshold and the recorder into the mcp builder.

On permissions, the two halves are treated differently on purpose. A
**loaded tool** gets no exemption: it keeps its namespaced name, is
absent from the exempt map, and resolves to `DecisionAsk` without a
standing grant, so it walks the policy guard, danger classifier and
interactive prompt exactly like an eager one. The **entry point** is
exempt, for the same reason `load_skill` is: its Execute resolves a name
against an in-process list and returns that tool's description and schema
as text, with no remote call and no side effect an operator could
meaningfully approve. Prompting on the index lookup would park a turn on
the act of reading an index.

The exempt map is exact-name and the manager namespaces the raw
`load_tool` per connector, so the exempt name is not known until a
connector is configured. `isConnectorLoadTool` therefore does a
`"_load_tool"` suffix check beside the map lookup in `Resolve`,
deliberately scoped to this one name. Reusing the D-036 `ToolMatches`
suffix rule across the whole exempt map would have been the broader fix
and is the wrong one: it would exempt any remote tool that happened to
end in `_search_kb` or `_remember`, handing a third-party MCP server a
way to name its way out of the permission chain.

Missions were left alone and needed no change: `Manager.ReadOnlyTools`
excludes MCP sources unconditionally, so a mission turn never sees an
MCP tool, eager or deferred. Nothing to defer there.

## Verification

`make build test vet lint` green, `go vet -tags integration ./...` green,
and the web suite (`npm run build && npm run lint && npm test`, 1848
tests) green, all re-run after merging `origin/main` with #662.

New tests: deferral above the threshold, unchanged eager behaviour at and
below it, both off switches (`0` and an unwired deferral), a load-then-call
round trip proving the remote sees the raw name while the session gets the
namespaced one, unknown-name and missing-session rejection, the settings
accessor default, the schema-validation wrapper, the session-scoped
registry (replace not duplicate, isolated per session, broken schema
dropped), and permission tests pinning both halves of the exemption:
`load_tool` and `<any connector>_load_tool` are exempt, while
`github_create_issue`, `github_load_toolbox` (suffix must land on a `_`
boundary), `my_load_tool_wrapper` (suffix must be at the end) and
`github_search_kb` / `github_remember` (an exempt raw name must not match
by suffix) all stay inside the chain. An integration test resolves the
real chain end to end: the entry point comes back as an exempt allow, the
loaded tool as an ask.

### Before and after

`TestMCPIndexTokenCost` measures `session.EstimateToolTokens` over the
tool defs a turn would offer for a 30-tool MCP server:

```
eager   1202 tokens
indexed  491 tokens
saved    711 tokens (59%)
```

Not run against a live stack: the local compose stack was left down, so
there is no before/after `turn assembled` log line to compare.
