### PR TITLE
chore(scripts): clear cost_ledger alters applied on both live databases

### DIFF
--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -5,7 +5,5 @@ run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
 ```sql
-ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS tool_def_tokens_estimate integer;
-ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS cache_write_1h_tokens integer;
-ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS effort text;
+(none)
 ```


### PR DESCRIPTION
## What

Resets scripts/pending-alters.md to (none).

## Why

The three additive cost_ledger columns (tool_def_tokens_estimate, cache_write_1h_tokens, effort) from #659, #660 and #661 are applied on the local dev database and on the homelab central Postgres, before the alpha.81 deploy. The file tracks only what is still unapplied.

## Verification

Homelab: information_schema shows all three columns; alpha.81 gateway writes ledger rows without error.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791630810&installation_model_id=431401&pr_number=665&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F665&signature=a251f2d00b7de8d98e7ca52a4fabcf6fcdd2a026bc40cd69e49440a5b49523fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->