### PR TITLE
fix(tools): shell guard misreads regex tokens inside quoting

### DIFF
--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -561,21 +561,71 @@ type quotedToken struct {
 }
 
 // commandTokensQuoted is CommandTokens plus per-token quoting info.
+//
+// It scans char-by-char tracking quote nesting rather than splitting
+// on whitespace first, so a space inside a quoted fragment (an awk or
+// grep program like '/R1/{ok=1} END{exit !ok}') does not get cut into
+// two tokens before the quoting is seen. A token is "quoted" if any
+// part of it was produced while inside a quote — nested or not — so
+// the regex/pattern skip in guardSubject still applies to something
+// like "awk '/^###/ ...'" wrapped in an outer sh -c "...".
 func commandTokensQuoted(command string) []quotedToken {
-	// '=' splits too, so --output=/abs/path exposes its path part.
-	fields := strings.Fields(strings.ReplaceAll(command, "=", " "))
-	out := make([]quotedToken, 0, len(fields))
-	for _, f := range fields {
-		// Redirect/fd syntax (>, <, 2>) only ever prefixes a path, never
-		// trails it — trimming from both ends would also strip a
-		// literal "<tag>" down to "/tag", a false absolute-path hit.
-		f = strings.TrimLeft(f, "<>0123456789")
-		trimmed := strings.Trim(f, `'";|&()`)
-		if trimmed == "" {
+	// '=' splits too, so --output=/abs/path exposes its path part —
+	// but not inside quotes, where '=' can be literal program text.
+	var quote rune
+	runes := []rune(command)
+	for i, r := range runes {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
 			continue
 		}
-		quoted := (strings.HasPrefix(f, "'") || strings.HasPrefix(f, `"`)) && trimmed != f
-		out = append(out, quotedToken{text: trimmed, quoted: quoted})
+		switch r {
+		case '\'', '"':
+			quote = r
+		case '=':
+			runes[i] = ' '
+		}
 	}
+	command = string(runes)
+
+	var out []quotedToken
+	var cur strings.Builder
+	curQuoted := false
+	quote = 0
+	flush := func() {
+		trimmed := strings.Trim(cur.String(), `;|&()`)
+		if !curQuoted {
+			// Redirect/fd syntax (>, <, 2>) only ever prefixes a path,
+			// never trails it, and is never quoted literal content.
+			trimmed = strings.TrimLeft(trimmed, "<>0123456789")
+		}
+		cur.Reset()
+		if trimmed == "" {
+			curQuoted = false
+			return
+		}
+		out = append(out, quotedToken{text: trimmed, quoted: curQuoted})
+		curQuoted = false
+	}
+	for _, r := range command {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+				continue
+			}
+			cur.WriteRune(r)
+		case r == '\'' || r == '"':
+			quote = r
+			curQuoted = true
+		case r == ' ' || r == '\t' || r == '\n':
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
 	return out
 }

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
@@ -42,6 +44,8 @@ func TestGuardSubject(t *testing.T) {
 
 		{name: "quoted regex leading slash", command: "awk '/^#{1,6}/ {print}' README.md"},
 		{name: "quoted regex alternation", command: "grep -E '^(foo|bar)$' /workspace/file"},
+		{name: "awk program with spaces and braces", command: "awk '/R1/{ok=1} END{exit !ok}' rules-checklist.md"},
+		{name: "grep pattern with leading space", command: "grep -c '^### ' ideas.md"},
 		{name: "quoted sed pattern", command: "sed 's/^#//' notes.md"},
 		{name: "quoted secret path still denied", command: "cat '/etc/passwd'", blocked: "system dirs"},
 		{name: "quoted plain path still denied", command: "cat '/Users/someone/x'", blocked: "outside the workspace"},
@@ -93,6 +97,49 @@ func TestGuardSubject(t *testing.T) {
 	// The guard only applies to shell.
 	if got := guardSubject(root, "fetch_url", "https://example.com/.env"); got != "" {
 		t.Fatalf("non-shell tool guarded: %q", got)
+	}
+}
+
+// TestGuardedCommandsRunAsIntended is a real /bin/sh round-trip for
+// the two commands issue #653 found the guard misreading as paths:
+// a fake pass here would mean the guard's tokenizer parsed something
+// the shell itself does not, since quoting bugs forgive themselves in
+// mocks (see real-shell-tests-for-composed-commands.md).
+func TestGuardedCommandsRunAsIntended(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	checklist := "R1: ok\nR2: ok\n"
+	ideas := "### one\n### two\nnot a heading\n"
+	if err := os.WriteFile(dir+"/rules-checklist.md", []byte(checklist), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/ideas.md", []byte(ideas), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "awk", command: "awk '/R1/{ok=1} END{exit !ok}' rules-checklist.md; echo $?", want: "0\n"},
+		{name: "grep", command: "grep -c '^### ' ideas.md", want: "2\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := guardSubject("/workspace", "shell", tc.command); got != "" {
+				t.Fatalf("guardSubject(%q) = %q, want allowed", tc.command, got)
+			}
+			cmd := exec.Command("/bin/sh", "-c", tc.command) //nolint:gosec // test-table command, not external input
+			cmd.Dir = dir
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("sh -c %q: %v", tc.command, err)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("sh -c %q output = %q, want %q", tc.command, out, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- commandTokensQuoted tokenized by whitespace before checking quote state, so a space inside a quoted awk/grep program (e.g. `'/R1/{ok=1} END{exit !ok}'`) split into two tokens and each half was refused as an out-of-workspace path
- Rewrote the tokenizer to scan char-by-char tracking quote state, so whitespace inside a quoted fragment no longer splits the token
- Redirect-prefix trimming (`<`, `>`, digits) now only applies to unquoted tokens, so a literal like `"</head>"` isn't mistaken for redirect syntax

Closes #653

## Test plan
- [x] `TestGuardSubject` extended with the two exact commands refused in mission c9c3ec96
- [x] New `TestGuardedCommandsRunAsIntended`: real `/bin/sh -c` round-trip confirming both commands both pass the guard and execute as intended
- [x] `make build test vet lint` all green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791635503&installation_model_id=431401&pr_number=668&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F668&signature=5766dc4927ccf3315d3fddcfc7804e064e93f9fb4488a3f3439372776601e05c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->