### PR TITLE
fix(gateway): reset idle watchdog on every byte read

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -460,6 +460,9 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			if res.entry.Status == "" {
 				res.entry.Status = "incomplete"
 			}
+			if strings.HasPrefix(ev.Text, "provider idle for ") {
+				res.entry.ErrorCode = "timeout"
+			}
 			send(ev)
 		case stream.EventChunk, stream.EventReasoningChunk, stream.EventToolStart, stream.EventToolEnd:
 			res.streamed = true

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -377,7 +377,7 @@ func (a *Anthropic) retryEffortStrippedOn400(ctx context.Context, req Completion
 			wire.OutputConfig = nil
 			body, err := json.Marshal(wire)
 			if err != nil {
-				emit(ctx, out, errEvent(fmt.Errorf("anthropic: marshal retry request: %w", err)))
+				emit(ctx, out, errEvent(fmt.Errorf("anthropic: marshal retry request: %w", err), a.cfg.Timeout))
 				return
 			}
 			retry := runStream(ctx, a.client, a.cfg.Timeout, retriesFor(req.FinalAttempt), a.buildFor(body), a.relay)

--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -111,13 +111,18 @@ func (e *permanentError) Error() string { return e.err.Error() }
 func (e *permanentError) Unwrap() error { return e.err }
 
 // errEvent builds the terminal error event for a request failure.
-func errEvent(err error) stream.StreamEvent {
+// idleTimeout is the idle-gap ceiling that was in force, used only to
+// phrase a deadline-exceeded error concretely; it does not change how
+// the error is classified.
+func errEvent(err error, idleTimeout time.Duration) stream.StreamEvent {
 	var perm *permanentError
 	retryable := !errors.As(err, &perm)
 	code := "provider_error"
+	message := err.Error()
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		code = "timeout"
+		message = fmt.Sprintf("provider idle for %s: no stream activity", idleTimeout)
 	case perm != nil && isContextLengthMessage(perm.Error()):
 		code = "context_length"
 	case perm != nil && perm.status != 0:
@@ -125,7 +130,7 @@ func errEvent(err error) stream.StreamEvent {
 	}
 	return stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 		Code:      code,
-		Message:   err.Error(),
+		Message:   message,
 		Retryable: retryable,
 	}}
 }
@@ -208,7 +213,7 @@ func runStream(ctx context.Context, client *http.Client, timeout time.Duration, 
 			// Terminal events gate on the PARENT ctx: the per-call
 			// timeout expiring is exactly when the consumer must still
 			// receive the error.
-			emit(ctx, ch, errEvent(err))
+			emit(ctx, ch, errEvent(err, timeout))
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
@@ -227,7 +232,14 @@ func runStream(ctx context.Context, client *http.Client, timeout time.Duration, 
 				}
 			}
 		}()
-		finished, readErr := relay(callCtx, resp.Body, relayCh)
+		// A driver's relay only calls resetIdle indirectly, by emitting
+		// to relayCh — but several SSE event kinds (e.g. a function-call
+		// argument delta) are accumulated silently and never emitted on
+		// their own. Those bytes are still live stream activity, so the
+		// idle watchdog resets on every read off the wire too, not only
+		// on parsed-and-emitted events; whichever fires more often wins.
+		body := &idleResettingReader{r: resp.Body, reset: resetIdle}
+		finished, readErr := relay(callCtx, body, relayCh)
 		close(relayCh)
 		<-done
 
@@ -238,11 +250,31 @@ func runStream(ctx context.Context, client *http.Client, timeout time.Duration, 
 		if readErr != nil {
 			reason = readErr.Error()
 		}
+		if errors.Is(readErr, context.DeadlineExceeded) || errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+			reason = fmt.Sprintf("provider idle for %s", timeout)
+		}
 		if emit(ctx, ch, stream.StreamEvent{Type: stream.EventIncomplete, Text: reason}) {
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
 		}
 	}()
 	return ch
+}
+
+// idleResettingReader resets the idle watchdog on every read that
+// returns data, so the timeout tracks real gaps in wire activity
+// rather than only the subset of stream events a driver chooses to
+// emit.
+type idleResettingReader struct {
+	r     io.Reader
+	reset func()
+}
+
+func (r *idleResettingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if n > 0 {
+		r.reset()
+	}
+	return n, err
 }
 
 // toolAccumulator assembles streamed tool calls. Providers emit a

--- a/internal/gateway/provider/httpx_test.go
+++ b/internal/gateway/provider/httpx_test.go
@@ -3,10 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
 func TestBackoffGrowsWithJitter(t *testing.T) {
@@ -93,10 +97,98 @@ func TestIsContextLengthMessage(t *testing.T) {
 	}
 }
 
+// TestRunStreamIdleResetsOnReadNotOnlyEmit pins issue #653... issue
+// #654's fix: a driver's relay reads several silent SSE events (e.g.
+// function-call argument deltas) that are never forwarded to relayCh,
+// so resetIdle is never called from inside relay itself — only the
+// raw byte reads off the wire keep the idle watchdog from firing. A
+// server that trickles bytes slower than the idle window but never
+// stops must not be cut off.
+func TestRunStreamIdleResetsOnReadNotOnlyEmit(t *testing.T) {
+	t.Parallel()
+	const idle = 80 * time.Millisecond
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher := w.(http.Flusher)
+		for range 5 {
+			_, _ = w.Write([]byte("x"))
+			flusher.Flush()
+			time.Sleep(idle / 2)
+		}
+	}))
+	defer srv.Close()
+
+	build := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	}
+	// relay never emits to ch — every byte read is silent stream
+	// activity, the way an unforwarded SSE event kind is.
+	relay := func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+		buf := make([]byte, 1)
+		for {
+			_, err := body.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					return true, nil
+				}
+				return false, err
+			}
+		}
+	}
+
+	ch := runStream(context.Background(), http.DefaultClient, idle, 1, build, relay)
+	for ev := range ch {
+		if ev.Type == stream.EventError || ev.Type == stream.EventIncomplete {
+			t.Fatalf("stream cut short despite continuous read activity: %+v", ev.Err)
+		}
+	}
+}
+
+// TestRunStreamIdleTimeoutMessage pins the AC in #654: a genuinely
+// stalled stream (one read, then nothing) is cancelled with a message
+// naming the cause, not a bare "context canceled".
+func TestRunStreamIdleTimeoutMessage(t *testing.T) {
+	t.Parallel()
+	const idle = 30 * time.Millisecond
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, _, _ := w.(http.Hijacker).Hijack()
+		defer func() { _ = hj.Close() }()
+		_, _ = hj.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 999999\r\n\r\nx"))
+		time.Sleep(time.Second)
+	}))
+	defer srv.Close()
+
+	build := func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	}
+	relay := func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+		buf := make([]byte, 1)
+		if _, err := body.Read(buf); err != nil {
+			return false, err
+		}
+		_, err := body.Read(buf) // blocks until the idle watchdog cancels ctx
+		return false, err
+	}
+
+	ch := runStream(context.Background(), http.DefaultClient, idle, 1, build, relay)
+	var got *stream.StreamEvent
+	for ev := range ch {
+		if ev.Type == stream.EventIncomplete {
+			e := ev
+			got = &e
+		}
+	}
+	if got == nil {
+		t.Fatal("want an incomplete event, got none")
+	}
+	if !strings.Contains(got.Text, "idle for") {
+		t.Fatalf("incomplete text = %q, want it to name the idle cause", got.Text)
+	}
+}
+
 func TestErrEventContextLengthCode(t *testing.T) {
 	t.Parallel()
 	err := &permanentError{status: 400, err: fmt.Errorf("http 400: Your input exceeds the context window of this model")}
-	ev := errEvent(err)
+	ev := errEvent(err, defaultTimeout)
 	if ev.Err.Code != "context_length" {
 		t.Fatalf("code = %q, want context_length", ev.Err.Code)
 	}
@@ -108,7 +200,7 @@ func TestErrEventContextLengthCode(t *testing.T) {
 func TestErrEventHTTPStatusCode(t *testing.T) {
 	t.Parallel()
 	err := &permanentError{status: 401, err: fmt.Errorf("http 401: invalid api key")}
-	ev := errEvent(err)
+	ev := errEvent(err, defaultTimeout)
 	if ev.Err.Code != "http_401" {
 		t.Fatalf("code = %q, want http_401", ev.Err.Code)
 	}

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -324,7 +324,7 @@ func retryMaxCompletionTokens(ctx context.Context, o *OpenAICompat, req Completi
 	wire.MaxTokens = 0
 	body, err := json.Marshal(wire)
 	if err != nil {
-		emit(ctx, out, errEvent(fmt.Errorf("openaicompat: marshal retry request: %w", err)))
+		emit(ctx, out, errEvent(fmt.Errorf("openaicompat: marshal retry request: %w", err), o.cfg.Timeout))
 		return
 	}
 	retry := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)
@@ -341,7 +341,7 @@ func retryReasoningEffortStripped(ctx context.Context, o *OpenAICompat, req Comp
 	wire.ReasoningEffort = ""
 	body, err := json.Marshal(wire)
 	if err != nil {
-		emit(ctx, out, errEvent(fmt.Errorf("openaicompat: marshal retry request: %w", err)))
+		emit(ctx, out, errEvent(fmt.Errorf("openaicompat: marshal retry request: %w", err), o.cfg.Timeout))
 		return
 	}
 	retry := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)

--- a/internal/gateway/provider/openairesponses.go
+++ b/internal/gateway/provider/openairesponses.go
@@ -406,7 +406,7 @@ func retryStaleState(ctx context.Context, o *OpenAIResponses, req CompletionRequ
 			wire := o.buildRequest(req, nil)
 			body, err := json.Marshal(wire)
 			if err != nil {
-				emit(ctx, out, errEvent(fmt.Errorf("openairesponses: marshal retry request: %w", err)))
+				emit(ctx, out, errEvent(fmt.Errorf("openairesponses: marshal retry request: %w", err), o.cfg.Timeout))
 				return
 			}
 			retry := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)


### PR DESCRIPTION
## Summary
- `runStream`'s idle timeout only reset when a driver's relay emitted a parsed event — several SSE event kinds (function-call argument deltas, unhandled output-item events) are accumulated silently and never emitted, so a long tool-call argument stream could go minutes without resetting the watchdog despite continuous byte activity, tripping the flat 5-minute timeout mid-stream
- Idle watchdog now also resets on every read that returns data off the wire, independent of what the driver's relay does with the parsed event
- Terminal error/incomplete text now names the cause (`provider idle for 5m0s: no stream activity`) instead of the driver's raw `context canceled`
- Ledger entry gets `error_code=timeout` when an idle cutoff ends a stream that had already produced output (previously left blank)

Closes #654

## Test plan
- [x] New `TestRunStreamIdleResetsOnReadNotOnlyEmit`: a relay that never emits to its channel but reads continuously does not get cut off
- [x] New `TestRunStreamIdleTimeoutMessage`: a genuinely stalled read still cancels, with a message naming the idle cause
- [x] Existing `runStream` idle/retry/incomplete tests all still pass unchanged
- [x] `make build test vet lint` all green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636018&installation_model_id=431401&pr_number=669&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F669&signature=dd0d837b7ee4705464d2491738e9fce33afc7d34244d3ccce21171a2990b6346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->