### PR TITLE
fix(loop): distinguish permission timeout from denial

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -50,10 +50,9 @@ type EventAppender interface {
 }
 
 const (
-	permissionTimeout = 10 * time.Minute
-	maxParallelTools  = 4
-	persistTimeout    = 10 * time.Second
-	sessionGrantTTL   = 12 * time.Hour
+	maxParallelTools = 4
+	persistTimeout   = 10 * time.Second
+	sessionGrantTTL  = 12 * time.Hour
 	// retrieveInlineCap bounds what retrieve_output returns inline;
 	// re-offloading a retrieval would chase its own tail, so it
 	// truncates with an honest note instead.
@@ -76,6 +75,11 @@ const maxStepRetries = 2
 // of plumbing a config knob through Request/NewAgent for one knob
 // only tests need.
 var stepRetryBackoff = time.Second
+
+// permissionTimeout bounds a chat turn's wait for a parked permission
+// (D-010); an attended mission turn never applies it (see askUser).
+// A package-level var, same reasoning as stepRetryBackoff.
+var permissionTimeout = 10 * time.Minute
 
 const finalizeWarning = "[system] You have one tool step left before the limit. Finish gathering and produce your final answer on the next step."
 
@@ -716,7 +720,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			}
 			run = append(run, c)
 		}
-		executed := a.executeAll(ctx, exec, req.SessionID, run, toolNames, req.Unattended, req.ToolResultCap, emit)
+		attendedMission := req.MissionID != "" && !req.Unattended
+		executed := a.executeAll(ctx, exec, req.SessionID, run, toolNames, req.Unattended, attendedMission, req.ToolResultCap, emit)
 		results := make([]provider.ToolResult, 0, len(calls))
 		for i, c := range calls {
 			if refused[i] {
@@ -813,13 +818,17 @@ func EffortFor(results []provider.ToolResult) string {
 // returns results in call order. toolNames is the turn's offered
 // surface (see run's toolNames comment); unattended is req.Unattended,
 // threaded down to resolveAndRun's DecisionAsk handling (D-039).
-func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, toolNames map[string]bool, unattended bool, resultCap int, emit func(stream.StreamEvent)) []provider.ToolResult {
+// attendedMission (issue #650) is req.MissionID != "" && !req.Unattended
+// — a mission turn with an operator watching it, threaded down to
+// askUser so a parked permission there waits for the mission's own
+// pause/resume instead of racing a loop-level timer.
+func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, toolNames map[string]bool, unattended, attendedMission bool, resultCap int, emit func(stream.StreamEvent)) []provider.ToolResult {
 	results := make([]provider.ToolResult, len(calls))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelTools)
 	for i, call := range calls {
 		g.Go(func() error {
-			results[i] = a.executeOne(gctx, exec, sessionID, call, toolNames, unattended, resultCap, emit)
+			results[i] = a.executeOne(gctx, exec, sessionID, call, toolNames, unattended, attendedMission, resultCap, emit)
 			return nil
 		})
 	}
@@ -827,7 +836,7 @@ func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string,
 	return results
 }
 
-func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, resultCap int, emit func(stream.StreamEvent)) provider.ToolResult {
+func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended, attendedMission bool, resultCap int, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
 	// A fresh collector per call: media a tool emits during THIS
 	// Execute rides on ctx, drained right below, never leaking into a
@@ -848,7 +857,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 				content, status, code = fmt.Sprintf("tool %s failed with an internal error: %v", call.Name, p), "error", codeToolError
 			}
 		}()
-		return a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
+		return a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, attendedMission, emit)
 	}()
 	isError := status != "ok"
 	media := collector.Drain()
@@ -943,7 +952,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 // feedback tools.Constrained.Execute would eventually give (D-039):
 // an unattended mission can't afford to wait out a 10-minute prompt
 // timeout just to learn the name never existed.
-func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) (content, status, code string) {
+func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended, attendedMission bool, emit func(stream.StreamEvent)) (content, status, code string) {
 	if !toolNames[call.Name] {
 		return fmt.Sprintf("unknown tool %q — use one of the tools you were given", call.Name), "error", codeUnknownTool
 	}
@@ -992,7 +1001,7 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 			release()
 			return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied", codePolicyDenied
 		default: // still DecisionAsk
-			decision := a.askUser(ctx, call, res, emit)
+			decision := a.askUser(ctx, call, res, attendedMission, emit)
 			switch decision {
 			case DecideSession:
 				if err := a.perms.Grant(ctx, sessionID, call.Name, res.Subject, sessionGrantTTL); err != nil {
@@ -1000,10 +1009,11 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 				}
 			case DecideOnce:
 				// proceed
-			default: // deny or timeout
+			case DecideTimeout:
 				release()
-				// Issue #650 will split the timeout case out with its own
-				// wording; both share user_denied until then.
+				return "no decision arrived within the time allowed; the call was not run. This is not a denial — nobody answered. Retry later or ask the user directly.", "denied", codeTimeout
+			default: // deny
+				release()
 				return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied", codeUserDenied
 			}
 		}
@@ -1055,15 +1065,23 @@ func classifyToolError(err error) string {
 }
 
 // askUser parks the call: emits a permission_request and blocks for
-// the decision (timeout = deny, D-010). Turn durability while parked
-// comes from the relay's periodic pending_state flushes; the prompt
-// itself is in-memory only — a restart drops it, which resolves as a
-// deny. Whatever the outcome — an explicit answer, a timeout, or ctx
+// the decision (D-010). Turn durability while parked comes from the
+// relay's periodic pending_state flushes; the prompt itself is
+// in-memory only — a restart drops it, which resolves as a timeout.
+// Whatever the outcome — an explicit answer, a timeout, or ctx
 // cancellation — a permission_resolved event follows so anything
 // tracking the request (persistence, a replay client) learns the
 // outcome too; the live web client already clears its prompt off
 // tool_result, so this is additive, not a behavior change for it.
-func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.Resolution, emit func(stream.StreamEvent)) string {
+//
+// attendedMission (issue #650) is a mission turn with a human
+// operator and no schedule behind it: the parked permission IS that
+// turn's pause point (StorePermissionParker records it, the mission
+// UI offers approve/deny), so no loop-level timer competes with it —
+// only the turn's own context ending can end the wait. A chat turn
+// (attendedMission false) keeps the 10-minute timer, since chat has
+// no equivalent pause state to sit in.
+func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.Resolution, attendedMission bool, emit func(stream.StreamEvent)) string {
 	id, answer := a.broker.Create()
 	defer a.broker.Forget(id)
 
@@ -1075,15 +1093,23 @@ func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.R
 	}})
 
 	decision := func() string {
+		if attendedMission {
+			select {
+			case d := <-answer:
+				return d
+			case <-ctx.Done():
+				return DecideTimeout
+			}
+		}
 		timer := time.NewTimer(permissionTimeout)
 		defer timer.Stop()
 		select {
 		case d := <-answer:
 			return d
 		case <-timer.C:
-			return DecideDeny
+			return DecideTimeout
 		case <-ctx.Done():
-			return DecideDeny
+			return DecideTimeout
 		}
 	}()
 	emit(stream.StreamEvent{Type: stream.EventPermissionResolved, Resolved: &stream.PermissionResolvedEvent{

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2372,14 +2372,20 @@ func TestAskUserAttendedMissionIgnoresLoopTimeout(t *testing.T) {
 	var requestID string
 	deadline := time.After(5 * time.Second)
 	sawRequest := make(chan struct{})
+	resolvedEarly := make(chan stream.PermissionResolvedEvent, 1)
+	drained := make(chan struct{})
 	go func() {
+		defer close(drained)
 		for ev := range ch {
 			if ev.Type == stream.EventPermissionRequest {
 				requestID = ev.Permission.ID
 				close(sawRequest)
 			}
 			if ev.Type == stream.EventPermissionResolved {
-				t.Errorf("resolved before the answer arrived: %+v (loop timeout leaked into an attended mission turn)", ev.Resolved)
+				select {
+				case resolvedEarly <- *ev.Resolved:
+				default:
+				}
 			}
 		}
 	}()
@@ -2392,9 +2398,15 @@ func TestAskUserAttendedMissionIgnoresLoopTimeout(t *testing.T) {
 	// Outlive the shrunk permissionTimeout several times over: an
 	// attended mission turn must still be waiting.
 	time.Sleep(20 * permissionTimeout)
+	select {
+	case ev := <-resolvedEarly:
+		t.Fatalf("resolved before the answer arrived: %+v (loop timeout leaked into an attended mission turn)", ev)
+	default:
+	}
 	if !a.broker.Resolve(requestID, DecideOnce) {
 		t.Fatal("broker no longer knows the prompt id — it must have resolved on its own")
 	}
+	<-drained
 }
 
 // TestWaitToolsReadyNilIsNoOp confirms the default (before main.go

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2300,6 +2300,103 @@ func TestAskUserEmitsResolvedOnAnswer(t *testing.T) {
 	}
 }
 
+// TestAskUserTimeoutWordingDistinctFromDeny pins issue #650: a chat
+// turn's unanswered permission ask reports a timeout, not a denial —
+// the model and the event log must not be told the user answered when
+// nobody did.
+func TestAskUserTimeoutWordingDistinctFromDeny(t *testing.T) {
+	old := permissionTimeout
+	permissionTimeout = 20 * time.Millisecond
+	defer func() { permissionTimeout = old }()
+
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("adapted"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = askPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	resolved := ofType(evs, stream.EventPermissionResolved)
+	if len(resolved) != 1 || resolved[0].Resolved.Decision != DecideTimeout {
+		t.Fatalf("resolved = %+v, want one DecideTimeout", resolved)
+	}
+	results := ofType(evs, stream.EventToolResult)
+	if len(results) != 1 || results[0].ToolResult.Status != "denied" {
+		t.Fatalf("tool result = %+v, want denied status", results)
+	}
+	second := gw.requests[1]
+	var content string
+	for _, m := range second.Messages {
+		if m.ToolResult != nil {
+			content = m.ToolResult.Content
+		}
+	}
+	if strings.Contains(content, "the user denied") {
+		t.Fatalf("model feedback wrongly says the user denied: %q", content)
+	}
+	if !strings.Contains(content, "no decision") {
+		t.Fatalf("model feedback = %q, want it to name the timeout", content)
+	}
+}
+
+// TestAskUserAttendedMissionIgnoresLoopTimeout pins issue #650's other
+// half: an attended mission turn (MissionID set, Unattended false) is
+// not subject to the loop's own permissionTimeout at all — the parked
+// call is the mission's pause point, and only the turn's own context
+// ending (or an explicit answer) resolves it. Shrinking
+// permissionTimeout to near-zero and letting real time pass well past
+// it proves the attended-mission wait ignored it.
+func TestAskUserAttendedMissionIgnoresLoopTimeout(t *testing.T) {
+	old := permissionTimeout
+	permissionTimeout = 10 * time.Millisecond
+	defer func() { permissionTimeout = old }()
+
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("after decision"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = askPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", MissionID: "m1", Unattended: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var requestID string
+	deadline := time.After(5 * time.Second)
+	sawRequest := make(chan struct{})
+	go func() {
+		for ev := range ch {
+			if ev.Type == stream.EventPermissionRequest {
+				requestID = ev.Permission.ID
+				close(sawRequest)
+			}
+			if ev.Type == stream.EventPermissionResolved {
+				t.Errorf("resolved before the answer arrived: %+v (loop timeout leaked into an attended mission turn)", ev.Resolved)
+			}
+		}
+	}()
+	select {
+	case <-sawRequest:
+	case <-deadline:
+		t.Fatal("never saw the permission request")
+	}
+
+	// Outlive the shrunk permissionTimeout several times over: an
+	// attended mission turn must still be waiting.
+	time.Sleep(20 * permissionTimeout)
+	if !a.broker.Resolve(requestID, DecideOnce) {
+		t.Fatal("broker no longer knows the prompt id — it must have resolved on its own")
+	}
+}
+
 // TestWaitToolsReadyNilIsNoOp confirms the default (before main.go
 // wires SetWaitToolsReady) behaves exactly as before D-043 — no hook,
 // no wait.

--- a/internal/brain/loop/permbroker.go
+++ b/internal/brain/loop/permbroker.go
@@ -11,6 +11,12 @@ const (
 	DecideOnce    = "once"
 	DecideSession = "session"
 	DecideDeny    = "deny"
+	// DecideTimeout is never a user answer: askUser returns it when its
+	// wait ends without one (the 10-minute chat timer, or the turn's own
+	// context ending) — issue #650 split this out of DecideDeny so the
+	// event log and the model stop being told the user denied a call
+	// nobody was ever asked to decide.
+	DecideTimeout = "timeout"
 )
 
 // PermBroker connects parked tool calls to their answers: the loop


### PR DESCRIPTION
## Summary
- `askUser`'s wait returned `DecideDeny` on both an explicit operator denial and an unanswered timeout, so the event log and the model's own tool feedback both said "the user denied permission" when nobody was ever asked
- New `DecideTimeout` outcome carries its own wording ("no decision within the time allowed... this is not a denial") and its own `permission_resolved` decision value, distinct from an explicit deny
- An attended mission turn (`MissionID` set, `Unattended` false) no longer applies the loop's own 10-minute timer at all — the parked call is the mission's own pause point (`StorePermissionParker`/`pending_permission`), and the operator-configured permission-timeout sweep (default: never) already owns denying a genuinely stale park on its own schedule
- Chat keeps the 10-minute timer, since it has no equivalent pause state to sit in

Closes #650

## Test plan
- [x] New `TestAskUserTimeoutWordingDistinctFromDeny`: a chat turn's unanswered ask reports timeout wording, never "the user denied"
- [x] New `TestAskUserAttendedMissionIgnoresLoopTimeout`: an attended mission turn's parked call outlives a shrunk `permissionTimeout` by 20x with no resolution, then resolves normally on an explicit answer
- [x] Existing permission/mission park/sweep tests all still pass unchanged
- [x] `make build test vet lint` all green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636525&installation_model_id=431401&pr_number=670&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F670&signature=f20ba8530153456103ff449842f32648181614d348ca702a20ec7f4bad371bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->