### PR TITLE
test: harden three load-sensitive test flakes

### DIFF
--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -739,6 +739,9 @@ func TestChatTitlesUntitledSessionWithCompletedTurns(t *testing.T) {
 		defer log.mu.Unlock()
 		return log.titles["s1"] != ""
 	})
+	// The stream closes before turnDone frees the slot (D-042): wait for
+	// the slot itself, not the earlier close, before starting turn 2.
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
 
 	// Simulate the title call having timed out: the turn completed but
 	// no title landed.

--- a/web/src/components/memory/GraphTab.test.tsx
+++ b/web/src/components/memory/GraphTab.test.tsx
@@ -128,6 +128,7 @@ describe('GraphTab', () => {
   it('rings the selected node by its index in the kind-filtered series', async () => {
     renderTab()
     await screen.findByTestId('entity-graph')
+    await waitFor(() => expect(clickHandler).not.toBeNull())
     clickHandler!({ dataType: 'node', data: { id: 'e2' } })
     await screen.findByTestId('entity-detail')
     expect(dispatchAction).toHaveBeenLastCalledWith({ type: 'select', seriesId: 'entities', dataIndex: 1 })

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1951,7 +1951,7 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
 
     expect(await screen.findByText('Proposed from the goal')).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'GitHub' })).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByRole('button', { name: 'octocat/hello-world' })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'octocat/hello-world' })).toBeInTheDocument()
   })
 
   it('labels a fuzzy match as a guess', async () => {


### PR DESCRIPTION
## Summary
- chat: wait on `TurnActive` going false before starting the second turn, since `turnDone` frees the slot after the stream closes (D-042 ordering, unchanged)
- GraphTab: wait for the mocked chart's click handler to be registered before invoking it
- MissionForm: await the debounced repo-proposal button instead of asserting on it synchronously

Closes #612

## Test plan
- [x] `go test -race -count=5 -run TestChatTitlesUntitledSessionWithCompletedTurns ./internal/brain/chat/`
- [x] web test: GraphTab "rings the selected node by its index in the kind-filtered series"
- [x] web test: MissionForm "proposes the connector + repo named in the goal and shows a note"
- [x] `make build test vet lint`
- [x] full web build/lint/test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791640902&installation_model_id=431401&pr_number=671&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F671&signature=e61ecb21e50b1b3acd052c021590a7e5d1e8c17a49ca1c11f343d2651ed9b589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->