### PR TITLE
fix(chat): distinguish a stopped turn from a gateway outage

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -552,6 +552,17 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		for attempt := 0; ; attempt++ {
 			upstream, err := a.gw.Stream(ctx, sreq)
 			if err != nil {
+				// A canceled ctx (issue #622) means the operator stopped
+				// the turn, not that the gateway is unreachable: retrying,
+				// and the gateway_unavailable code, both misrepresent an
+				// intentional stop as a failure.
+				if ctx.Err() != nil {
+					emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+					emitFinal(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+						Code: "stopped", Message: "turn stopped", Retryable: false,
+					}})
+					return
+				}
 				if attempt < maxStepRetries && retryStep(ctx, emit, attempt+1, err.Error()) {
 					continue
 				}
@@ -1025,6 +1036,9 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 
 	out, err := exec.Execute(ctx, call.Name, call.Input)
 	if err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			return "turn stopped before this call finished", "canceled", codeCanceled
+		}
 		if tools.IsViolation(err) {
 			return err.Error(), "error", codePolicyDenied
 		}

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -347,6 +347,125 @@ func TestAgentTerminalSurvivesContextCancel(t *testing.T) {
 	}
 }
 
+// errAfterCancelGateway's Stream call blocks until the caller's ctx is
+// canceled, then returns ctx.Err() — the shape of a stop landing while
+// a step's Stream request is in flight.
+type errAfterCancelGateway struct{}
+
+func (g *errAfterCancelGateway) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
+func (g *errAfterCancelGateway) Stream(ctx context.Context, _ gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestAgentStopVsOutageStreamErrorCode pins issue #622: a canceled ctx
+// must surface as a distinct, non-retryable "stopped" code, never the
+// "gateway_unavailable" code a real outage gets — a stop is not a
+// gateway failure and must not read as one to the model or the UI.
+func TestAgentStopVsOutageStreamErrorCode(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	gw := &errAfterCancelGateway{}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(ctx, Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	evs := collect(t, ch)
+
+	errs := ofType(evs, stream.EventError)
+	if len(errs) != 1 {
+		t.Fatalf("error events = %+v, want exactly 1", errs)
+	}
+	if errs[0].Err.Code != "stopped" {
+		t.Fatalf("code = %q, want stopped", errs[0].Err.Code)
+	}
+	if errs[0].Err.Retryable {
+		t.Fatal("stopped error must not be retryable")
+	}
+}
+
+// TestAgentGatewayOutageKeepsUnavailableCode confirms the #622 fix
+// left the real-outage path untouched: a Stream failure with no
+// context cancellation still reports gateway_unavailable/retryable.
+func TestAgentGatewayOutageKeepsUnavailableCode(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{} // no scripts queued: every Stream call errors
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	errs := ofType(evs, stream.EventError)
+	if len(errs) != 1 {
+		t.Fatalf("error events = %+v, want exactly 1", errs)
+	}
+	if errs[0].Err.Code != "gateway_unavailable" {
+		t.Fatalf("code = %q, want gateway_unavailable", errs[0].Err.Code)
+	}
+	if !errs[0].Err.Retryable {
+		t.Fatal("a real outage must stay retryable")
+	}
+}
+
+// TestAgentToolCallCanceledOnStop pins issue #622's second AC: a tool
+// call in flight when the turn is stopped must persist and report as
+// canceled, not error — the tool did not fail, the operator stopped it.
+func TestAgentToolCallCanceledOnStop(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	slow := &tools.Tool{
+		Name:        "slow",
+		Description: "blocks until its context is canceled",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(ctx context.Context, _ json.RawMessage) (string, error) {
+			close(started)
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"slow", `{}`}),
+	}}
+	a, audit, _, _ := testAgent(t, gw, slow)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ch, err := a.Start(ctx, Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drain concurrently: emit() blocks on the channel send until read,
+	// so the tool_start event ahead of the call must be drained before
+	// the tool itself ever runs and can close started. Once ctx is
+	// canceled, emit()'s own select races ctx.Done() against the send
+	// and may legitimately drop a live event — this only asserts on
+	// audit persistence, which runs on a detached (WithoutCancel)
+	// context and is never subject to that race.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		collect(t, ch)
+	}()
+	<-started
+	cancel()
+	<-done
+
+	audit.mu.Lock()
+	gotAudit := audit.entries
+	audit.mu.Unlock()
+	if len(gotAudit) != 1 || gotAudit[0].Status != "canceled" {
+		t.Fatalf("audit = %+v, want status canceled", gotAudit)
+	}
+}
+
 // TestAgentToolPanicBecomesErrorResult pins the recover in executeOne:
 // a panicking tool must come back to the model as an error result
 // (D-009), not crash the process — executeOne runs inside an errgroup

--- a/internal/brain/loop/toolerror.go
+++ b/internal/brain/loop/toolerror.go
@@ -30,6 +30,10 @@ const (
 	codeNetwork            = "network"
 	codeGatewayUnavailable = "gateway_unavailable"
 	codeToolError          = "tool_error"
+	// codeCanceled marks a call cut short by the turn being stopped
+	// (issue #622), never by the tool itself failing: retrying it means
+	// re-running the same call the operator asked to stop.
+	codeCanceled = "canceled"
 )
 
 // retryableFor reports whether a call that failed with code could
@@ -39,7 +43,7 @@ const (
 // recovery it could have made.
 func retryableFor(code string) bool {
 	switch code {
-	case codePolicyDenied, codeUnknownTool, codeCallCap, codeUserDenied:
+	case codePolicyDenied, codeUnknownTool, codeCallCap, codeUserDenied, codeCanceled:
 		return false
 	default:
 		return true

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -49,7 +49,8 @@ type StreamEvent struct {
 }
 
 // ToolResultEvent reports a finished tool execution to the client:
-// status ok|error|denied, a digest (never the raw result), and timing.
+// status ok|error|denied|canceled, a digest (never the raw result), and
+// timing.
 type ToolResultEvent struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -566,6 +566,13 @@ export function AssistantMessage({
           {n}
         </Badge>
       ))}
+      {msg.stopped && (
+        <div className="mt-3 flex items-center gap-2">
+          <Badge variant="neutral" data-testid="stopped">
+            Stopped
+          </Badge>
+        </div>
+      )}
       {msg.error && (
         <div className="mt-3 flex items-center gap-2">
           <Badge variant="destructive" data-testid="error">

--- a/web/src/components/chat/ToolCallCard.tsx
+++ b/web/src/components/chat/ToolCallCard.tsx
@@ -68,7 +68,12 @@ export function ToolCallCard({
   const args = parseArgs(run.args)
   const isError = run.status === 'error'
 
-  const hasDetail = args !== undefined || run.digest !== undefined || run.status === 'denied' || children !== undefined
+  const hasDetail =
+    args !== undefined ||
+    run.digest !== undefined ||
+    run.status === 'denied' ||
+    run.status === 'canceled' ||
+    children !== undefined
   if (!hasDetail) {
     return (
       <div className="min-w-0 w-full" data-density={density}>
@@ -85,6 +90,7 @@ export function ToolCallCard({
           <p className="font-mono text-trace text-muted-foreground">{run.name}</p>
           {args !== undefined && <JsonBlock value={args} density="trace" label="Arguments" maxLines={20} />}
           {run.status === 'denied' && <p className="text-sm text-muted-foreground">Denied by you</p>}
+          {run.status === 'canceled' && <p className="text-sm text-muted-foreground">Stopped</p>}
           {run.digest !== undefined && <DigestBlock digest={run.digest} isError={isError} />}
           {children}
         </div>

--- a/web/src/components/timothy/status.tsx
+++ b/web/src/components/timothy/status.tsx
@@ -61,9 +61,9 @@ export function missionStatus(input: { phase?: string; status: string }): Status
 }
 
 // toolCallStatus implements the tool-call row of the same mapping table.
-export function toolCallStatus(s: 'running' | 'ok' | 'denied' | 'error' | 'blocked'): Status {
+export function toolCallStatus(s: 'running' | 'ok' | 'denied' | 'error' | 'blocked' | 'canceled'): Status {
   if (s === 'running') return 'working'
   if (s === 'ok') return 'success'
-  if (s === 'denied') return 'neutral'
+  if (s === 'denied' || s === 'canceled') return 'neutral'
   return 'error'
 }

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -5,7 +5,7 @@ export interface ToolRun {
   id: string
   name: string
   args?: string
-  status: 'running' | 'ok' | 'error' | 'denied'
+  status: 'running' | 'ok' | 'error' | 'denied' | 'canceled'
   digest?: string
   durationMs?: number
   // The permission prompt (if any) this call parked on, so its result
@@ -23,6 +23,7 @@ export interface AssistantState {
   // call-result order.
   media: MediaRef[]
   error?: string
+  stopped?: boolean
   meta?: {
     provider?: string
     model?: string
@@ -104,6 +105,7 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
     case 'incomplete':
       return { ...msg, notices: [...msg.notices, `incomplete: ${ev.text || 'stream cut off'}`] }
     case 'error':
+      if (ev.error?.code === 'stopped') return { ...msg, stopped: true }
       return { ...msg, error: `${ev.error?.code}: ${ev.error?.message}` }
     case 'meta':
       return {

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -18,7 +18,10 @@ function toToolRun(tool: NonNullable<TranscriptItem['tool']>): ToolRun {
     id: tool.call_id,
     name: tool.name,
     args: tool.args,
-    status: status === 'ok' || status === 'error' || status === 'denied' ? status : 'ok',
+    status:
+      status === 'ok' || status === 'error' || status === 'denied' || status === 'canceled'
+        ? status
+        : 'ok',
     digest: tool.result_digest,
     durationMs: tool.duration_ms,
   }


### PR DESCRIPTION
## Summary
- `agent.go`: a canceled ctx (operator stop) now emits a distinct, non-retryable `stopped` terminal code instead of `gateway_unavailable`; a real outage is unaffected
- `resolveAndRun`: a tool call cut off by ctx cancellation returns status `canceled` (new `codeCanceled`, non-retryable), not `error`
- web: the `stopped` code renders a neutral "Stopped" badge instead of the destructive error banner + retry button; canceled tool calls get the same neutral treatment as denied ones

Closes #622

## Test plan
- [x] `TestAgentStopVsOutageStreamErrorCode` — canceled ctx → `stopped`/non-retryable
- [x] `TestAgentGatewayOutageKeepsUnavailableCode` — real Stream failure → `gateway_unavailable`/retryable, unchanged
- [x] `TestAgentToolCallCanceledOnStop` — tool cut off by stop persists/audits as `canceled`, not `error`
- [x] `make build test vet lint`
- [x] full web build/lint/test suite

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791660161&installation_model_id=431401&pr_number=678&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F678&signature=c69901c8ffc1d8420017b6c2c69ec8bd696e82c7a42245cd40e7a10e09f33ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->