### PR TITLE
fix(loop): synchronize test-only timing var overrides

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -73,13 +73,47 @@ const maxStepRetries = 2
 // stepRetryBackoff scales the wait before each step retry (attempt *
 // this duration); a package-level var so tests can shrink it instead
 // of plumbing a config knob through Request/NewAgent for one knob
-// only tests need.
+// only tests need. Guarded by timingVarsMu since tests run in
+// parallel and both write and read it concurrently.
 var stepRetryBackoff = time.Second
 
 // permissionTimeout bounds a chat turn's wait for a parked permission
 // (D-010); an attended mission turn never applies it (see askUser).
 // A package-level var, same reasoning as stepRetryBackoff.
 var permissionTimeout = 10 * time.Minute
+
+// timingVarsMu guards stepRetryBackoff and permissionTimeout: tests
+// override them per-case, but agent_test.go runs its cases with
+// t.Parallel(), so unsynchronized access races under -race.
+var timingVarsMu sync.RWMutex
+
+func getStepRetryBackoff() time.Duration {
+	timingVarsMu.RLock()
+	defer timingVarsMu.RUnlock()
+	return stepRetryBackoff
+}
+
+func setStepRetryBackoff(d time.Duration) time.Duration {
+	timingVarsMu.Lock()
+	defer timingVarsMu.Unlock()
+	old := stepRetryBackoff
+	stepRetryBackoff = d
+	return old
+}
+
+func getPermissionTimeout() time.Duration {
+	timingVarsMu.RLock()
+	defer timingVarsMu.RUnlock()
+	return permissionTimeout
+}
+
+func setPermissionTimeout(d time.Duration) time.Duration {
+	timingVarsMu.Lock()
+	defer timingVarsMu.Unlock()
+	old := permissionTimeout
+	permissionTimeout = d
+	return old
+}
 
 const finalizeWarning = "[system] You have one tool step left before the limit. Finish gathering and produce your final answer on the next step."
 
@@ -796,7 +830,7 @@ func capToolResult(content string, limit int) string {
 // whether the caller should retry; false means ctx ended mid-wait, in
 // which case the caller falls through to its normal failure path.
 func retryStep(ctx context.Context, emit func(stream.StreamEvent), attempt int, reason string) bool {
-	backoff := time.Duration(attempt) * stepRetryBackoff
+	backoff := time.Duration(attempt) * getStepRetryBackoff()
 	emit(stream.StreamEvent{Type: stream.EventRetry, Retry: &stream.RetryInfo{
 		Attempt: attempt, BackoffMs: backoff.Milliseconds(), Reason: reason,
 	}})
@@ -1115,7 +1149,7 @@ func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.R
 				return DecideTimeout
 			}
 		}
-		timer := time.NewTimer(permissionTimeout)
+		timer := time.NewTimer(getPermissionTimeout())
 		defer timer.Stop()
 		select {
 		case d := <-answer:

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2424,9 +2424,8 @@ func TestAskUserEmitsResolvedOnAnswer(t *testing.T) {
 // the model and the event log must not be told the user answered when
 // nobody did.
 func TestAskUserTimeoutWordingDistinctFromDeny(t *testing.T) {
-	old := permissionTimeout
-	permissionTimeout = 20 * time.Millisecond
-	defer func() { permissionTimeout = old }()
+	old := setPermissionTimeout(20 * time.Millisecond)
+	defer func() { setPermissionTimeout(old) }()
 
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
 		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
@@ -2472,9 +2471,8 @@ func TestAskUserTimeoutWordingDistinctFromDeny(t *testing.T) {
 // permissionTimeout to near-zero and letting real time pass well past
 // it proves the attended-mission wait ignored it.
 func TestAskUserAttendedMissionIgnoresLoopTimeout(t *testing.T) {
-	old := permissionTimeout
-	permissionTimeout = 10 * time.Millisecond
-	defer func() { permissionTimeout = old }()
+	old := setPermissionTimeout(10 * time.Millisecond)
+	defer func() { setPermissionTimeout(old) }()
 
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
 		toolCallStep([2]string{"echo", `{"text":"hi"}`}),

--- a/internal/brain/loop/retry_test.go
+++ b/internal/brain/loop/retry_test.go
@@ -56,9 +56,8 @@ func errorAfterChunkStep() []stream.StreamEvent {
 
 func withShortRetryBackoff(t *testing.T) {
 	t.Helper()
-	orig := stepRetryBackoff
-	stepRetryBackoff = time.Millisecond
-	t.Cleanup(func() { stepRetryBackoff = orig })
+	orig := setStepRetryBackoff(time.Millisecond)
+	t.Cleanup(func() { setStepRetryBackoff(orig) })
 }
 
 func TestAgentRetriesStreamErrorBeforeContentThenSucceeds(t *testing.T) {


### PR DESCRIPTION
Closes #681

## Summary
- `stepRetryBackoff` and `permissionTimeout` (internal/brain/loop/agent.go) are package vars tests overwrite directly to shrink retry/timeout waits.
- Nearly every test in agent_test.go runs with `t.Parallel()`, so a test writing one of these races a concurrent test reading it via `retryStep`/`askUser`. Confirmed by CI on PR #677 (`go test -race` reported a data race between `withShortRetryBackoff` and `retryStep`).
- Added a mutex-guarded getter/setter pair for each var; production code and tests now go through them instead of touching the vars directly.

## Test plan
- `go build ./...`
- `go test -race -count=5 ./internal/brain/loop/...` — clean
- `go vet ./internal/brain/loop/...` — clean
- `golangci-lint run ./internal/brain/loop/...` — 0 issues

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791667882&installation_model_id=431401&pr_number=682&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F682&signature=3b06a4a514ec2200a44a1422ab588ba7a9df57333371ef9a27bc6375b0e71d90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->