### PR TITLE
feat(settings): owner writing style rules and samples collection

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -518,6 +518,7 @@ func main() {
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
 		flags.Location, agentReg.ResolveByID, app.Log)
+	svc.SetWriting(writingSettings(flags))
 	svc.SetAgentResolverByName(agentReg.Resolve)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
@@ -869,6 +870,14 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 	return mgr, goog, msft, markItDownURL
 }
 
+// writingSettings curries the operator's writing-style settings into
+// the one closure chat and the mission harness both take.
+func writingSettings(flags *settings.Store) func(context.Context) (string, string) {
+	return func(ctx context.Context) (string, string) {
+		return flags.WritingStyle(ctx), flags.WritingSamplesCollection(ctx)
+	}
+}
+
 // buildDestinations wires the destinations control plane (store +
 // adapters + Deliverer). missionStore nil (WORKSPACES unset) disables
 // it entirely: delivery has no meaning without missions. conns/goog
@@ -1174,6 +1183,10 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		return skills.Index(skills.Allowed(packs, a.Skills))
 	}
 	driver.SetSkillsIndex(missionSkillsIndex)
+	// Same operator writing-style settings chat turns get: the style
+	// text rides worker packets, the samples collection boosts search_kb.
+	driver.SetWriting(writingSettings(flags))
+	nativeRunner.SetWriting(writingSettings(flags))
 	// Issue #628: discover and plan get the same index, so a skill that
 	// defines the mission's output shape is loadable before the plan is
 	// committed rather than first seen in build.

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -146,6 +146,7 @@ type Service struct {
 	packs          []skills.Skill
 	skillAllow     func(context.Context, string) bool   // nil: all packs allowed
 	location       func(context.Context) *time.Location // nil: date line renders in UTC
+	writing        func(context.Context) (style, samplesCollection string) // nil: both empty, no writing-style block
 	skillBodies    map[string]string                    // name -> full pack body, for skill_hint
 	flushEvery     time.Duration                        // pending-state flush cadence mid-stream
 	turnTimeout    time.Duration                        // detached-turn ceiling; defaults to the turnTimeout const, overridable in tests
@@ -283,6 +284,13 @@ type KBSearch func(ctx context.Context, query string, boostCollections []string,
 // agent's Knowledge list (same "the dependency's absence turns the
 // feature off entirely" contract as SetMemoryRetrieve/SetAttachments).
 func (s *Service) SetKBSearch(fn KBSearch) { s.kbSearch = fn }
+
+// SetWriting wires the operator's writing-style settings: the free-text
+// rules and the name of the kb collection holding their own writing.
+// Optional: nil means both read empty.
+func (s *Service) SetWriting(fn func(ctx context.Context) (style, samplesCollection string)) {
+	s.writing = fn
+}
 
 // kbSearchTool builds this turn's search_kb ExtraTool, or nil when no
 // backing search call is wired (KB feature off entirely). boost (the
@@ -1374,7 +1382,11 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	if s.location != nil {
 		loc = s.location(turnCtx)
 	}
-	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), time.Now(), loc)
+	var style, samplesCollection string
+	if s.writing != nil {
+		style, samplesCollection = s.writing(turnCtx)
+	}
+	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), style, samplesCollection != "", time.Now(), loc)
 	// The agent overlay is stable for a given agent, so it sits ahead
 	// of the per-turn tail and stays inside the cacheable prefix.
 	if profile.PromptOverlay != "" {
@@ -1407,6 +1419,12 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 				boost = append(boost, name)
 			}
 		}
+	}
+
+	// The writing-samples collection joins the boost so the model's
+	// search_kb calls surface the owner's own writing first.
+	if samplesCollection != "" && !slices.Contains(boost, samplesCollection) {
+		boost = append(boost, samplesCollection)
 	}
 
 	// A pinned collection is an explicit user signal to search it, not

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
@@ -1114,6 +1115,55 @@ func TestKBToolsUnionDedupesAgentAndSessionCollections(t *testing.T) {
 	}
 }
 
+// TestKBToolsUnionIncludesWritingSamplesCollection pins that the
+// operator's configured writing-samples collection joins the boost and
+// dedupes against the agent's and session's own names.
+func TestKBToolsUnionIncludesWritingSamplesCollection(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("ok")}
+	log := newFakeLog()
+	log.knowledge["s1"] = []string{"b"}
+	resolver := func(context.Context, string) (agents.Agent, bool) {
+		return agents.Agent{Memory: true, Knowledge: []string{"a"}}, true
+	}
+	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
+	s.SetWriting(func(context.Context) (string, string) { return "Short sentences.", "b" })
+
+	var gotBoost []string
+	s.SetKBSearch(func(_ context.Context, _ string, boost []string, _ string, _ int) ([]builtin.KBSearchHit, error) {
+		gotBoost = boost
+		return nil, nil
+	})
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	var tool *tools.Tool
+	for _, et := range chatRequest(t, gw).ExtraTools {
+		if et.Name == "search_kb" {
+			tool = et
+		}
+	}
+	if tool == nil {
+		t.Fatalf("search_kb not offered, extra tools = %v", extraToolNames(chatRequest(t, gw)))
+	}
+	if _, err := tool.Execute(t.Context(), []byte(`{"query":"x"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	sort.Strings(gotBoost)
+	if !slices.Equal(gotBoost, []string{"a", "b"}) {
+		t.Fatalf("bound boost collections = %v, want [a b] (settings name deduped)", gotBoost)
+	}
+
+	sys := chatRequest(t, gw).System
+	if !strings.Contains(sys, "Short sentences.") || !strings.Contains(sys, missions.WritingSamplesNote) {
+		t.Fatalf("writing-style block missing from system prompt:\n%s", sys)
+	}
+}
+
 // TestKBToolsFallBackOnSessionKnowledgeLookupFailure pins the
 // best-effort contract: s.log.Knowledge erroring must not kill the
 // turn. search_kb still gets offered from the agent's own Knowledge
@@ -1663,7 +1713,7 @@ func TestMemoryRetrieveEmptyLeavesSystemUntouched(t *testing.T) {
 	drain(t, ch)
 
 	got := chatRequest(t, gw).System
-	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})), time.Now(), nil)
+	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})), "", false, time.Now(), nil)
 	if got != want {
 		t.Fatalf("system modified on empty recall:\n%q\nvs\n%q", got, want)
 	}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -1,9 +1,13 @@
 package chat
 
-import "time"
+import (
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
 
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 7
+const systemPromptVersion = 8
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the
@@ -33,8 +37,11 @@ const systemPromptClose = `Be concise; do not restate context or repeat the ques
 const timezoneSteer = " Present all dates and times in this timezone unless the user asks otherwise."
 
 // assembleSystem builds the full system prompt: identity, then the
-// optional per-deploy skills index, then a current-date line, then the
-// closing steer. now must be evaluated at request time (never cached
+// optional operator writing-style block, then the optional per-deploy
+// skills index, then a current-date line, then the closing steer. The
+// writing-style block is operator-edited and stable between edits, so
+// it belongs in the cacheable prefix (D-018). now must be evaluated at
+// request time (never cached
 // at construction) so the date line is fresh every turn — a model
 // with no other way to know "today" otherwise anchors on training
 // data and mangles date-bounded tool calls (e.g. Gmail after:/before:
@@ -42,13 +49,17 @@ const timezoneSteer = " Present all dates and times in this timezone unless the 
 // provider prompt cache's tail every single request, where a date
 // busts it once per day (D-018), acceptable. loc is the operator's
 // configured timezone; nil renders in UTC.
-func assembleSystem(skillsIndex string, now time.Time, loc *time.Location) string {
+func assembleSystem(skillsIndex, style string, samples bool, now time.Time, loc *time.Location) string {
 	if loc == nil {
 		loc = time.UTC
 	}
 	dateLine := "Today is " + now.In(loc).Format("Monday, 2006-01-02 (MST).") + timezoneSteer
-	if skillsIndex == "" {
-		return systemPrompt + "\n\n" + dateLine + "\n\n" + systemPromptClose
+	out := systemPrompt
+	if block := missions.WritingStyleBlock(style, samples); block != "" {
+		out += "\n\n" + block
 	}
-	return systemPrompt + "\n\n" + skillsIndex + "\n\n" + dateLine + "\n\n" + systemPromptClose
+	if skillsIndex != "" {
+		out += "\n\n" + skillsIndex
+	}
+	return out + "\n\n" + dateLine + "\n\n" + systemPromptClose
 }

--- a/internal/brain/chat/systemprompt_test.go
+++ b/internal/brain/chat/systemprompt_test.go
@@ -4,12 +4,14 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 )
 
 func TestAssembleSystemDateLine(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 28, 15, 4, 5, 0, time.UTC)
-	got := assembleSystem("", now, nil)
+	got := assembleSystem("", "", false, now, nil)
 
 	want := "Today is Tuesday, 2026-07-28 (UTC)."
 	if !strings.Contains(got, want) {
@@ -25,7 +27,7 @@ func TestAssembleSystemDateLineNilLocationIsUTC(t *testing.T) {
 	loc := time.FixedZone("UTC-5", -5*60*60)
 	// 2026-07-28 23:30 UTC-5 == 2026-07-29 04:30 UTC.
 	now := time.Date(2026, time.July, 28, 23, 30, 0, 0, loc)
-	got := assembleSystem("", now, nil)
+	got := assembleSystem("", "", false, now, nil)
 
 	if !strings.Contains(got, "Today is Wednesday, 2026-07-29 (UTC).") {
 		t.Fatalf("date line not normalized to UTC:\n%s", got)
@@ -40,7 +42,7 @@ func TestAssembleSystemDateLineOperatorLocation(t *testing.T) {
 	}
 	// 2026-07-28 23:30 UTC == 2026-07-29 01:30 CEST.
 	now := time.Date(2026, time.July, 28, 23, 30, 0, 0, time.UTC)
-	got := assembleSystem("", now, loc)
+	got := assembleSystem("", "", false, now, loc)
 
 	if !strings.Contains(got, "Today is Wednesday, 2026-07-29 (CEST).") {
 		t.Fatalf("date line not rendered in operator location:\n%s", got)
@@ -58,7 +60,7 @@ func TestAssembleSystemDateLineIncludesTimezoneSteer(t *testing.T) {
 	want := "Present all dates and times in this timezone"
 
 	t.Run("nil location (UTC)", func(t *testing.T) {
-		got := assembleSystem("", now, nil)
+		got := assembleSystem("", "", false, now, nil)
 		if !strings.Contains(got, want) {
 			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", got, want)
 		}
@@ -69,7 +71,7 @@ func TestAssembleSystemDateLineIncludesTimezoneSteer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("load location: %v", err)
 		}
-		got := assembleSystem("", now, loc)
+		got := assembleSystem("", "", false, now, loc)
 		if !strings.Contains(got, want) {
 			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", got, want)
 		}
@@ -83,7 +85,7 @@ func TestAssembleSystemDateLineIncludesTimezoneSteer(t *testing.T) {
 func TestAssembleSystemIncludesKBNudge(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
-	got := assembleSystem("", now, nil)
+	got := assembleSystem("", "", false, now, nil)
 
 	want := "curated knowledge base of their own notes and reference material, reachable via search_kb"
 	if !strings.Contains(got, want) {
@@ -96,9 +98,13 @@ func TestAssembleSystemCloseStaysLast(t *testing.T) {
 	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
 
 	for _, skillsIndex := range []string{"", "# Skills\n\n- foo: does foo"} {
-		got := assembleSystem(skillsIndex, now, nil)
-		if !strings.HasSuffix(got, systemPromptClose) {
-			t.Fatalf("close steer not last line (skillsIndex=%q):\n%s", skillsIndex, got)
+		for _, style := range []string{"", "Short sentences."} {
+			for _, samples := range []bool{false, true} {
+				got := assembleSystem(skillsIndex, style, samples, now, nil)
+				if !strings.HasSuffix(got, systemPromptClose) {
+					t.Fatalf("close steer not last line (skillsIndex=%q style=%q samples=%v):\n%s", skillsIndex, style, samples, got)
+				}
+			}
 		}
 	}
 }
@@ -106,8 +112,8 @@ func TestAssembleSystemCloseStaysLast(t *testing.T) {
 func TestAssembleSystemStablePrefixUnchangedByDate(t *testing.T) {
 	t.Parallel()
 	skillsIndex := "# Skills\n\n- foo: does foo"
-	day1 := assembleSystem(skillsIndex, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC), nil)
-	day2 := assembleSystem(skillsIndex, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC), nil)
+	day1 := assembleSystem(skillsIndex, "", false, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC), nil)
+	day2 := assembleSystem(skillsIndex, "", false, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC), nil)
 
 	prefix := systemPrompt + "\n\n" + skillsIndex
 	if !strings.HasPrefix(day1, prefix) || !strings.HasPrefix(day2, prefix) {
@@ -116,4 +122,53 @@ func TestAssembleSystemStablePrefixUnchangedByDate(t *testing.T) {
 	if day1 == day2 {
 		t.Fatalf("expected date line to differ across days, got identical output")
 	}
+
+	// The writing-style block joins that same cacheable prefix.
+	style := "Short sentences. No em dashes."
+	styled1 := assembleSystem(skillsIndex, style, true, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC), nil)
+	styled2 := assembleSystem(skillsIndex, style, true, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC), nil)
+	styledPrefix := systemPrompt + "\n\n" + missions.WritingStyleBlock(style, true) + "\n\n" + skillsIndex
+	if !strings.HasPrefix(styled1, styledPrefix) || !strings.HasPrefix(styled2, styledPrefix) {
+		t.Fatalf("writing-style prefix not stable across days:\n%s", styled1)
+	}
+}
+
+// TestAssembleSystemWritingStyleBlock pins the operator writing-style
+// block: style alone, samples alone, both, and absent when neither is
+// configured.
+func TestAssembleSystemWritingStyleBlock(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
+	style := "Short sentences. No em dashes."
+
+	t.Run("style only", func(t *testing.T) {
+		got := assembleSystem("", style, false, now, nil)
+		if !strings.Contains(got, missions.WritingStyleHeading) || !strings.Contains(got, style) {
+			t.Fatalf("writing-style block missing:\n%s", got)
+		}
+		if strings.Contains(got, missions.WritingSamplesNote) {
+			t.Fatalf("samples note present with no samples collection:\n%s", got)
+		}
+	})
+
+	t.Run("samples only", func(t *testing.T) {
+		got := assembleSystem("", "", true, now, nil)
+		if !strings.Contains(got, missions.WritingStyleHeading) || !strings.Contains(got, missions.WritingSamplesNote) {
+			t.Fatalf("samples-only block missing:\n%s", got)
+		}
+	})
+
+	t.Run("both", func(t *testing.T) {
+		got := assembleSystem("", style, true, now, nil)
+		if !strings.Contains(got, style) || !strings.Contains(got, missions.WritingSamplesNote) {
+			t.Fatalf("combined block missing a half:\n%s", got)
+		}
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		got := assembleSystem("", "", false, now, nil)
+		if strings.Contains(got, missions.WritingStyleHeading) {
+			t.Fatalf("writing-style block rendered with nothing configured:\n%s", got)
+		}
+	})
 }

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -127,6 +127,10 @@ type Driver struct {
 	// prompts (SetSkillsIndex) — nil means workers get no index.
 	skillsIndex func(ctx context.Context, agentID string) string
 
+	// writing resolves the operator's writing-style settings for worker
+	// packets (SetWriting); nil means no writing-style block.
+	writing func(ctx context.Context) (style, samplesCollection string)
+
 	// provision holds the mission-provisioning slice split out into its
 	// own type (D-074): ensureProvisioned, grantSessionDefaults,
 	// followUpBaseRef and their resolver deps. Driver's Set* setters
@@ -335,6 +339,13 @@ func (d *Driver) agentName(ctx context.Context, agentID string) string {
 // optional dependency.
 func (d *Driver) SetSkillsIndex(fn func(ctx context.Context, agentID string) string) {
 	d.skillsIndex = fn
+}
+
+// SetWriting wires the operator's writing-style settings into worker
+// packets; a setter for the same construction-order reason
+// SetSkillsIndex is. nil means no writing-style block.
+func (d *Driver) SetWriting(fn func(ctx context.Context) (style, samplesCollection string)) {
+	d.writing = fn
 }
 
 // SetFXRates wires the stored USD-base rate table the budget brake
@@ -2076,6 +2087,10 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	}
 	if d.skillsIndex != nil && m.AgentID != "" {
 		p.SkillsIndex = d.skillsIndex(ctx, m.AgentID)
+	}
+	if d.writing != nil {
+		style, samples := d.writing(ctx)
+		p.WritingStyle, p.WritingSamples = style, samples != ""
 	}
 	return p, nil
 }

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1200,6 +1200,33 @@ func TestDriverPacketOmitsDiscoverNotesForNonPlanlessFlow(t *testing.T) {
 	}
 }
 
+// TestDriverPacketCarriesWritingSettings confirms the operator's
+// writing-style settings reach a worker packet, and that an unwired
+// resolver leaves both fields zero.
+func TestDriverPacketCarriesWritingSettings(t *testing.T) {
+	store := newFakeStore()
+	m := Mission{ID: "m1", Kind: "general", Flow: FlowFull, Phase: PhaseBuild, Status: StatusWorking}
+	store.put("m1", m)
+
+	d := testDriver(store, &scriptedRunner{})
+	p, err := d.packet(context.Background(), m)
+	if err != nil {
+		t.Fatalf("packet: %v", err)
+	}
+	if p.WritingStyle != "" || p.WritingSamples {
+		t.Fatalf("unwired writing resolver gave %q/%v, want empty/false", p.WritingStyle, p.WritingSamples)
+	}
+
+	d.SetWriting(func(context.Context) (string, string) { return "Short sentences.", "my-writing" })
+	p, err = d.packet(context.Background(), m)
+	if err != nil {
+		t.Fatalf("packet: %v", err)
+	}
+	if p.WritingStyle != "Short sentences." || !p.WritingSamples {
+		t.Fatalf("packet writing settings = %q/%v, want \"Short sentences.\"/true", p.WritingStyle, p.WritingSamples)
+	}
+}
+
 // TestDriverNonLightDoneStillGoesThroughReview confirms the light
 // short-circuit is gated on m.RunsPlanless() (Flow == FlowLight): an
 // ordinary general mission with a unit that has no declared artifacts

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -84,6 +84,40 @@ type WorkPacket struct {
 	Findings    []Finding
 	ReworkRound int
 	MaxRounds   int
+	// WritingStyle is the operator's configured writing rules
+	// (settings writing_style), rendered after PromptOverlay.
+	WritingStyle string
+	// WritingSamples marks that a writing-samples kb collection is
+	// configured, adding WritingSamplesNote to the same block.
+	WritingSamples bool
+}
+
+// WritingStyleHeading and WritingSamplesNote are the operator
+// writing-style block's shared text. Chat (internal/brain/chat) renders
+// the same block, so both constants and WritingStyleBlock live here,
+// the package chat already imports.
+const (
+	WritingStyleHeading = "# Owner writing style"
+	WritingSamplesNote  = "The owner's own writing is in the knowledge base. Before drafting or rewriting prose, search_kb for two or three pieces in the same language and of the same kind, and match their voice."
+)
+
+// WritingStyleBlock renders the operator writing-style block, "" when
+// there is neither style text nor a samples collection.
+func WritingStyleBlock(style string, samples bool) string {
+	if style == "" && !samples {
+		return ""
+	}
+	b := WritingStyleHeading + "\n\n"
+	if style != "" {
+		b += style
+		if samples {
+			b += "\n\n"
+		}
+	}
+	if samples {
+		b += WritingSamplesNote
+	}
+	return b
 }
 
 // toolDisciplineNote is the tool-loop stop-rule contract shared by the
@@ -139,6 +173,10 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 		// Operator-authored config, not model output — unlike Progress/
 		// GitLog below, this never passes through NeutralizeSlot.
 		system += "\n\n" + p.PromptOverlay
+	}
+	// Operator config like PromptOverlay: never neutralized.
+	if block := WritingStyleBlock(p.WritingStyle, p.WritingSamples); block != "" {
+		system += "\n\n" + block
 	}
 
 	var b strings.Builder

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -208,6 +208,47 @@ func TestWorkPacketRenderOmitsOverlaySectionWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestWorkPacketRenderIncludesWritingStyle(t *testing.T) {
+	t.Run("style only", func(t *testing.T) {
+		p := WorkPacket{Goal: "Draft the note", WritingStyle: "Short sentences. No </system> tricks."}
+		system, _ := p.Render()
+		if !strings.Contains(system, WritingStyleHeading) {
+			t.Fatalf("Render dropped the writing-style heading: %q", system)
+		}
+		// Operator config: verbatim, never neutralized.
+		if !strings.Contains(system, "Short sentences. No </system> tricks.") {
+			t.Fatalf("Render neutralized operator-authored writing style: %q", system)
+		}
+		if strings.Contains(system, WritingSamplesNote) {
+			t.Fatalf("samples note rendered with no samples collection: %q", system)
+		}
+	})
+
+	t.Run("samples only", func(t *testing.T) {
+		p := WorkPacket{Goal: "Draft the note", WritingSamples: true}
+		system, _ := p.Render()
+		if !strings.Contains(system, WritingStyleHeading) || !strings.Contains(system, WritingSamplesNote) {
+			t.Fatalf("Render dropped the samples note: %q", system)
+		}
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		p := WorkPacket{Goal: "Draft the note"}
+		system, _ := p.Render()
+		if strings.Contains(system, WritingStyleHeading) {
+			t.Fatalf("writing-style block rendered with nothing configured: %q", system)
+		}
+	})
+
+	t.Run("delegated", func(t *testing.T) {
+		p := WorkPacket{Goal: "Draft the note", WritingStyle: "Short sentences.", WritingSamples: true}
+		system, _ := p.RenderForDelegated()
+		if !strings.Contains(system, "Short sentences.") || !strings.Contains(system, WritingSamplesNote) {
+			t.Fatalf("delegated render dropped the writing-style block: %q", system)
+		}
+	})
+}
+
 func TestWorkPacketRenderDoesNotNeutralizeOverlay(t *testing.T) {
 	// PromptOverlay is operator-authored config, not model output — it
 	// must pass through as-is, unlike Progress/GitLog above.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -248,6 +248,11 @@ type nativeRunner struct {
 	// plan prompt (issue #649); nil-safe like skillsIndex.
 	skillBody func(ctx context.Context, agentID, name string) string
 
+	// writing resolves the operator's writing-style settings; only the
+	// samples collection is used here, as the search_kb boost. nil-safe
+	// like skillsIndex.
+	writing func(ctx context.Context) (style, samplesCollection string)
+
 	// askParker backs ask_user's park (D-088): nil means ask_user is
 	// never offered on any mission turn, same nil-safe contract as
 	// kbSearch/kbRead: a store wiring bug degrades to "no ask_user"
@@ -332,6 +337,13 @@ func (r *nativeRunner) SetSkillsIndex(fn func(ctx context.Context, agentID strin
 // means the plan prompt carries the index alone, as before.
 func (r *nativeRunner) SetSkillBody(fn func(ctx context.Context, agentID, name string) string) {
 	r.skillBody = fn
+}
+
+// SetWriting wires the operator's writing-style settings; the runner
+// uses the samples collection as the search_kb boost. Unset means an
+// unboosted search, the behavior before this existed.
+func (r *nativeRunner) SetWriting(fn func(ctx context.Context) (style, samplesCollection string)) {
+	r.writing = fn
 }
 
 // loadedSkillsPrefix opens the first line of discover notes when the
@@ -506,11 +518,10 @@ func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
 
 // KBSearchFunc runs one search_kb call over the whole KB: main curries
 // memclient.Client.KBSearch in, same shape as chat.go's KBSearch type.
-// boostCollections is always nil for a mission turn (issue #482 dropped
-// the mission's own Knowledge snapshot, and search_kb was never scoped
-// by it to begin with, D-078/issue #368) -- kept as a parameter only
-// because memclient.Client.KBSearch's signature is shared with chat's
-// live-agent-boosted calls.
+// boostCollections carries the operator's writing-samples collection
+// when one is configured, nil otherwise (issue #482 dropped the
+// mission's own Knowledge snapshot, and search_kb was never scoped by
+// it to begin with, D-078/issue #368) -- a boost only, never a filter.
 type KBSearchFunc func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
 // SearchMemoryFunc runs one search_memory recall over long-term
@@ -559,12 +570,25 @@ func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
 		return nil
 	}
 	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
-		hits, err := r.kbSearch(ctx, query, nil, mode, k)
+		hits, err := r.kbSearch(ctx, query, r.boostCollections(ctx), mode, k)
 		if err == nil && sink != nil {
 			sink.record(hits)
 		}
 		return hits, err
 	})
+}
+
+// boostCollections is the search_kb ranking boost for a mission turn:
+// the operator's writing-samples collection when configured, nil
+// otherwise.
+func (r *nativeRunner) boostCollections(ctx context.Context) []string {
+	if r.writing == nil {
+		return nil
+	}
+	if _, samples := r.writing(ctx); samples != "" {
+		return []string{samples}
+	}
+	return nil
 }
 
 // kbReadTool builds this turn's read_kb ExtraTool, gated exactly like

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -2964,6 +2964,50 @@ func TestRunWorkerOffersKBSearch(t *testing.T) {
 	})
 }
 
+// TestRunnerKBSearchBoostsWritingSamplesCollection pins the mission
+// search_kb boost: nil with no writing resolver wired, the operator's
+// writing-samples collection when one is configured.
+func TestRunnerKBSearchBoostsWritingSamplesCollection(t *testing.T) {
+	run := func(t *testing.T, writing func(context.Context) (string, string)) []string {
+		t.Helper()
+		var gotBoost []string
+		r := newTestRunner(&scriptedAgent{})
+		r.kbSearch = func(_ context.Context, _ string, boost []string, _ string, _ int) ([]builtin.KBSearchHit, error) {
+			gotBoost = boost
+			return nil, nil
+		}
+		r.writing = writing
+		tool := r.kbSearchTool(Mission{ID: "m1"}, nil)
+		if tool == nil {
+			t.Fatal("kbSearchTool returned nil with a backend wired")
+		}
+		if _, err := tool.Execute(context.Background(), []byte(`{"query":"x"}`)); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		return gotBoost
+	}
+
+	t.Run("unwired", func(t *testing.T) {
+		if got := run(t, nil); got != nil {
+			t.Fatalf("boost = %v, want nil", got)
+		}
+	})
+
+	t.Run("no collection configured", func(t *testing.T) {
+		got := run(t, func(context.Context) (string, string) { return "Short sentences.", "" })
+		if got != nil {
+			t.Fatalf("boost = %v, want nil", got)
+		}
+	})
+
+	t.Run("collection configured", func(t *testing.T) {
+		got := run(t, func(context.Context) (string, string) { return "", "my-writing" })
+		if !slices.Equal(got, []string{"my-writing"}) {
+			t.Fatalf("boost = %v, want [my-writing]", got)
+		}
+	})
+}
+
 // fakeProgressReader is a ProgressReader backed by an in-memory slice,
 // mutable between polls so tests can simulate a note posted mid-turn.
 type fakeProgressReader struct {

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -125,7 +125,23 @@ const (
 	// (issue #643); "" defers to DefaultMCPToolIndexThreshold, "0"
 	// disables deferral so every connector stays fully eager.
 	ValueMCPToolIndexThreshold = "mcp_tool_index_threshold"
+	// ValueWritingStyle is the operator's own writing rules as free
+	// text, injected verbatim into chat and mission prompts when
+	// non-empty; "" (the default) adds no block at all.
+	ValueWritingStyle = "writing_style"
+	// ValueWritingSamplesCollection is the NAME of a kb collection
+	// holding the operator's own writing, added to the search_kb
+	// ranking boost when non-empty. A name, not an id: the boost
+	// matches col.name (internal/memory/store/kb.go) and
+	// agents.Agent.Knowledge already stores names, so a deleted or
+	// renamed collection simply stops boosting.
+	ValueWritingSamplesCollection = "writing_samples_collection"
 )
+
+// writingStyleCap bounds the free-text writing-style setting; it rides
+// every prompt, so an unbounded value would be an unbounded per-turn
+// cost.
+const writingStyleCap = 4000
 
 // DefaultMCPToolIndexThreshold is the MCP tool count above which the
 // index replaces eager schemas when ValueMCPToolIndexThreshold is
@@ -150,6 +166,7 @@ var knownValueKeys = map[string]bool{
 	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
 	ValueExecutorRunBudgetMinutes: true, ValueReviewTokenCeiling: true,
 	ValueMCPToolIndexThreshold: true,
+	ValueWritingStyle:          true, ValueWritingSamplesCollection: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -323,6 +340,18 @@ func (s *Store) WebBaseURL(ctx context.Context) string {
 	return s.Value(ctx, ValueWebBaseURL)
 }
 
+// WritingStyle returns the operator's configured writing rules, ""
+// when unset (no writing-style block in prompts).
+func (s *Store) WritingStyle(ctx context.Context) string {
+	return s.Value(ctx, ValueWritingStyle)
+}
+
+// WritingSamplesCollection returns the name of the kb collection
+// holding the operator's own writing, "" when unset (no extra boost).
+func (s *Store) WritingSamplesCollection(ctx context.Context) string {
+	return s.Value(ctx, ValueWritingSamplesCollection)
+}
+
 // Location returns the operator's configured timezone, time.UTC when
 // unset or when the stored value fails to load (SetValue already
 // rejects a non-IANA value at write time, so a load failure here means
@@ -462,6 +491,9 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 		if err := missions.ValidateCommitStyle(value); err != nil {
 			return fmt.Errorf("%s: %w", key, err)
 		}
+	}
+	if key == ValueWritingStyle && len([]rune(value)) > writingStyleCap {
+		return fmt.Errorf("%s exceeds %d characters", key, writingStyleCap)
 	}
 	if key == ValueTimezone && value != "" {
 		if _, err := time.LoadLocation(value); err != nil {

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -188,6 +189,42 @@ func TestRuntimeValueSettings(t *testing.T) {
 	}
 	if err := s.SetValue(ctx, ValueReviewTokenCeiling, ""); err != nil {
 		t.Fatalf("clear review token ceiling: %v", err)
+	}
+
+	// Writing settings: free text with a length cap, and a collection
+	// name with no validation at all.
+	if got := s.WritingStyle(ctx); got != "" {
+		t.Fatalf("WritingStyle default = %q, want empty", got)
+	}
+	if got := s.WritingSamplesCollection(ctx); got != "" {
+		t.Fatalf("WritingSamplesCollection default = %q, want empty", got)
+	}
+	if err := s.SetValue(ctx, ValueWritingStyle, strings.Repeat("x", writingStyleCap+1)); err == nil {
+		t.Fatal("over-cap writing style accepted")
+	}
+	if err := s.SetValue(ctx, ValueWritingStyle, "Short sentences. No em dashes."); err != nil {
+		t.Fatalf("SetValue writing style: %v", err)
+	}
+	if got := s.WritingStyle(ctx); got != "Short sentences. No em dashes." {
+		t.Fatalf("WritingStyle = %q", got)
+	}
+	if err := s.SetValue(ctx, ValueWritingStyle, ""); err != nil {
+		t.Fatalf("clear writing style: %v", err)
+	}
+	if got := s.WritingStyle(ctx); got != "" {
+		t.Fatalf("WritingStyle after clear = %q, want empty", got)
+	}
+	if err := s.SetValue(ctx, ValueWritingSamplesCollection, "my writing"); err != nil {
+		t.Fatalf("SetValue writing samples collection: %v", err)
+	}
+	if got := s.WritingSamplesCollection(ctx); got != "my writing" {
+		t.Fatalf("WritingSamplesCollection = %q", got)
+	}
+	if err := s.SetValue(ctx, ValueWritingSamplesCollection, ""); err != nil {
+		t.Fatalf("clear writing samples collection: %v", err)
+	}
+	if got := s.WritingSamplesCollection(ctx); got != "" {
+		t.Fatalf("WritingSamplesCollection after clear = %q, want empty", got)
 	}
 
 	if err := s.SetValue(ctx, ValueTokenBudget, "120000"); err != nil {

--- a/internal/brain/settings/settings_test.go
+++ b/internal/brain/settings/settings_test.go
@@ -71,3 +71,16 @@ func TestMCPToolIndexThresholdDefault(t *testing.T) {
 		t.Fatalf("MCPToolIndexThreshold = %d, want %d", got, DefaultMCPToolIndexThreshold)
 	}
 }
+
+// TestWritingSettingsDefaultEmpty pins both writing settings as
+// opt-in: an absent row (or a degraded database) means no writing-style
+// block and no extra search_kb boost.
+func TestWritingSettingsDefaultEmpty(t *testing.T) {
+	s := degradedStore(t)
+	if got := s.WritingStyle(context.Background()); got != "" {
+		t.Fatalf("WritingStyle = %q, want empty", got)
+	}
+	if got := s.WritingSamplesCollection(context.Background()); got != "" {
+		t.Fatalf("WritingSamplesCollection = %q, want empty", got)
+	}
+}

--- a/web/src/components/settings/FeaturesTab.test.tsx
+++ b/web/src/components/settings/FeaturesTab.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FeaturesTab } from './FeaturesTab'
+import type { KbCollection } from '../../api/types'
 
 // FeaturesTab now renders PageHeader's breadcrumb links, which need a
 // Router context, so every render is wrapped in MemoryRouter.
@@ -15,13 +16,14 @@ function renderTab() {
 
 vi.mock('../../api/client', () => ({
   getSettings: vi.fn(),
+  listKbCollections: vi.fn(),
   listRoutes: vi.fn(),
   patchSettings: vi.fn(),
   patchSettingValues: vi.fn(),
 }))
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
-import { getSettings, listRoutes, patchSettings, patchSettingValues } from '../../api/client'
+import { getSettings, listKbCollections, listRoutes, patchSettings, patchSettingValues } from '../../api/client'
 import { toast } from 'sonner'
 
 afterEach(cleanup)
@@ -30,8 +32,23 @@ beforeEach(() => {
   vi.clearAllMocks()
   localStorage.clear()
   vi.mocked(listRoutes).mockResolvedValue([])
+  vi.mocked(listKbCollections).mockResolvedValue([])
   vi.mocked(patchSettingValues).mockResolvedValue(undefined)
 })
+
+function kbCollection(name: string): KbCollection {
+  return {
+    id: name,
+    name,
+    description: '',
+    doc_count: 0,
+    chunk_count: 0,
+    failed_count: 0,
+    retrieval_weight: 1,
+    created_at: '2026-09-11T00:00:00Z',
+    updated_at: '2026-09-11T00:00:00Z',
+  }
+}
 
 describe('FeaturesTab review token ceiling', () => {
   it('shows the stored ceiling beside the run budget and saves an edit', async () => {
@@ -168,6 +185,77 @@ describe('FeaturesTab plain value cards', () => {
     await waitFor(() =>
       expect(patchSettingValues).toHaveBeenCalledWith({ git_branch_pattern: '{type}/{slug}' }),
     )
+  })
+
+  it('saves an edited writing style, trimmed', async () => {
+    vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+    renderTab()
+
+    const textarea = await screen.findByRole('textbox', { name: 'Writing style' })
+    expect(textarea).toHaveAttribute('maxlength', '4000')
+    fireEvent.change(textarea, { target: { value: '  Short sentences. British spelling.  ' } })
+    const region = screen.getByRole('region', { name: 'Writing style' })
+    fireEvent.click(within(region).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({ writing_style: 'Short sentences. British spelling.' }),
+    )
+  })
+})
+
+describe('FeaturesTab writing samples collection', () => {
+  it('picks a collection from the loaded list and saves its name', async () => {
+    vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+    vi.mocked(listKbCollections).mockResolvedValue([kbCollection('my-writing')])
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('combobox', { name: 'Writing samples collection' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'my-writing' }))
+    const region = screen.getByRole('region', { name: 'Writing samples' })
+    fireEvent.click(within(region).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({ writing_samples_collection: 'my-writing' }),
+    )
+  })
+
+  it('falls back to a plain text input when the collection list fails to load', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: {},
+      values: { writing_samples_collection: 'my-writing' },
+    })
+    vi.mocked(listKbCollections).mockRejectedValue(new Error('down'))
+    renderTab()
+
+    const input = await screen.findByRole('textbox', { name: 'Writing samples collection' })
+    expect((input as HTMLInputElement).value).toBe('my-writing')
+  })
+
+  it('keeps a stored name missing from the list selectable, marked missing', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: {},
+      values: { writing_samples_collection: 'renamed-away' },
+    })
+    vi.mocked(listKbCollections).mockResolvedValue([kbCollection('my-writing')])
+    renderTab()
+
+    const trigger = await screen.findByRole('combobox', { name: 'Writing samples collection' })
+    await waitFor(() => expect(trigger).toHaveTextContent('renamed-away (missing)'))
+  })
+
+  it('shows a retryable alert when saving the collection fails', async () => {
+    vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+    vi.mocked(listKbCollections).mockResolvedValue([kbCollection('my-writing')])
+    vi.mocked(patchSettingValues).mockRejectedValueOnce(new Error('network down'))
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('combobox', { name: 'Writing samples collection' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'my-writing' }))
+    const region = screen.getByRole('region', { name: 'Writing samples' })
+    fireEvent.click(within(region).getByRole('button', { name: 'Save' }))
+
+    const alert = await within(region).findByRole('alert')
+    expect(alert).toHaveTextContent('network down')
   })
 })
 

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { ChevronDownIcon } from 'lucide-react'
 import { toast } from 'sonner'
-import { getSettings, listRoutes, patchSettings, patchSettingValues } from '../../api/client'
-import type { AdminRoute } from '../../api/types'
+import { getSettings, listKbCollections, listRoutes, patchSettings, patchSettingValues } from '../../api/client'
+import type { AdminRoute, KbCollection } from '../../api/types'
 import { CURRENCIES } from '../../lib/currencies'
 import { getNotificationSoundEnabled, setNotificationSoundEnabled } from '../../lib/sound'
 import { Button } from '../ui/button'
@@ -10,6 +10,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { Input } from '../ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Textarea } from '../ui/textarea'
 import { Alert, AlertDescription } from '../ui/alert'
 import { PageHeader } from '../timothy/page-header'
 import { PageShell } from '../timothy/page-shell'
@@ -121,6 +122,7 @@ export function FeaturesTab() {
         {values && <SensitiveRouteCard values={values} onSaved={refresh} />}
         {values && <TimezoneCard values={values} onSaved={refresh} />}
         {values && <PlainValueCards values={values} onSaved={refresh} />}
+        {values && <WritingSamplesCard values={values} onSaved={refresh} />}
         <NotificationSoundCard />
       </div>
     </PageShell>
@@ -160,6 +162,9 @@ const REVIEW_TOKEN_CEILING_DEFAULT = 1_500_000
 // settings.DefaultMCPToolIndexThreshold for the placeholder; the
 // server applies the real default.
 const MCP_TOOL_INDEX_THRESHOLD_DEFAULT = 8
+
+// WRITING_STYLE_MAX_LEN mirrors the server's cap on writing_style.
+const WRITING_STYLE_MAX_LEN = 4000
 
 // Descriptor for a plain value card: an Input or Select field, one
 // settings key, and how its committed value maps to the field's
@@ -298,6 +303,23 @@ const valueCardDescriptors: ValueCardDescriptor[] = [
       </Select>
     ),
   },
+  {
+    key: 'writing_style',
+    title: 'Writing style',
+    description:
+      'Your writing rules. Timothy follows them whenever it drafts or rewrites text for you, in chat and in missions. Leave empty for the built-in defaults.',
+    render: (value, setValue) => (
+      <Textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Short sentences. British spelling. No em dashes. Bangla in চলিত register."
+        maxLength={WRITING_STYLE_MAX_LEN}
+        className="w-full"
+        aria-label="Writing style"
+      />
+    ),
+    toPatchValue: (v) => v.trim(),
+  },
 ]
 
 // PlainValueCards renders every value card whose control is an Input
@@ -422,6 +444,79 @@ function SensitiveRouteCard({ values, onSaved }: { values: Record<string, string
           placeholder="empty = off"
           className="h-9 w-56"
           aria-label="Sensitive tool route"
+        />
+      )}
+    </SettingValueCard>
+  )
+}
+
+// WritingSamplesCard picks the knowledge-base collection holding the
+// operator's own writing, stored by name. Fetches the collection list
+// on mount; if that fetch fails, falls back to a plain text input like
+// SensitiveRouteCard. A stored name missing from the list (collection
+// deleted or renamed) still shows as an item so the Select is never
+// blank.
+function WritingSamplesCard({ values, onSaved }: { values: Record<string, string>; onSaved: () => void }) {
+  const baseline = values.writing_samples_collection ?? ''
+  const [collection, setCollection] = useState(baseline)
+  const [collections, setCollections] = useState<KbCollection[] | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const dirty = collection !== baseline
+
+  useEffect(() => {
+    listKbCollections().then(setCollections, () => setCollections(null))
+  }, [])
+
+  const save = () => {
+    setSaving(true)
+    setError(null)
+    patchSettingValues({ writing_samples_collection: collection.trim() })
+      .then(() => {
+        setSaving(false)
+        toast.success('Saved')
+        onSaved()
+      })
+      .catch((err: unknown) => {
+        setSaving(false)
+        setError(errText(err))
+      })
+  }
+
+  const missing = collection !== '' && collections !== null && !collections.some((c) => c.name === collection)
+
+  return (
+    <SettingValueCard
+      title="Writing samples"
+      description="Knowledge-base collection holding your own writing. Timothy searches it for voice and register before drafting."
+      dirty={dirty}
+      saving={saving}
+      error={error}
+      onRetry={save}
+      onSave={save}
+    >
+      {collections ? (
+        <Select value={collection || UNSET} onValueChange={(v) => setCollection(v === UNSET ? '' : v)}>
+          <SelectTrigger className="h-9 w-56" aria-label="Writing samples collection">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={UNSET}>Off (default)</SelectItem>
+            {missing && <SelectItem value={collection}>{`${collection} (missing)`}</SelectItem>}
+            {collections.map((c) => (
+              <SelectItem key={c.id} value={c.name}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Input
+          value={collection}
+          onChange={(e) => setCollection(e.target.value)}
+          placeholder="empty = off"
+          className="h-9 w-56"
+          aria-label="Writing samples collection"
         />
       )}
     </SettingValueCard>


### PR DESCRIPTION
Closes #686. Follows #685 (writing skill pack).

## What

Two operator settings, empty by default, on Settings > Features:

- `writing_style`: free-text rules (textarea, capped at 4000 characters server-side). When set, rendered as an "Owner writing style" block after the identity text in the chat system prompt and after `PromptOverlay` in every mission work packet, native and delegated.
- `writing_samples_collection`: the name of a knowledge-base collection holding the owner's own writing (dropdown of existing collections, stale name shown as "(missing)"). When set, it joins the `search_kb` ranking boost in chat turns and mission turns, and the prompt block gains one fixed sentence telling the model to search it before drafting.

Empty settings produce byte-identical prompts to before, apart from the `systemPromptVersion` bump to 8.

## Why

The writing pack tells the model to look for the owner's voice on the instance; this carries it there. Rules and samples stay in the database, never in the repo, so other deployments are unaffected.

Stored by name, not id: the boost matches `col.name` and `agents.Agent.Knowledge` already stores names. No lookup, no new dependency; a deleted collection just stops boosting.

## Design notes

- Block sits in the cacheable prefix (D-018): operator-edited, stable between edits, same cadence as the skills index. `systemPromptClose` stays last.
- Shared block text lives in `missions` (`WritingStyleBlock`), which `chat` already imports; `settings` imports `missions`, so the reverse would cycle.
- Runner's `kbSearchTool` boost replaces the literal `nil` left after #482; still a boost, never a filter (D-078).

## Verification

- `make build test vet lint`: all packages pass, lint 0 issues.
- `go vet -tags integration` on settings, chat, missions: clean.
- Web: build ok, lint 0 errors, 140 files / 1854 tests pass.
- `make canary` against the rebuilt brain: PASS, done/done in 214s, 5 model turns.
- Live API smoke through the brain container: PATCH both values 204, GET reads them back, 4100-char style rejected 400, clear 204.

## Operator steps after deploy

1. Enable the `writing` skill pack on the agent.
2. Create a KB collection, upload writing samples.
3. Settings > Features: fill Writing style, pick the collection under Writing samples.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791738851&installation_model_id=431401&pr_number=687&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F687&signature=d1518c6521743268c420e78c13047514da5ccd62f10c1eca025a3f1cc83ad350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->