### PR TITLE
feat(tools): writing_samples returns owner voice samples by language

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -755,6 +755,10 @@ func main() {
 		return out, nil
 	})
 	svc.SetKBRead(kbReadFromStore(kbStore))
+	// writing_samples: the operator's own writing by language, which
+	// search_kb (topic similarity) cannot surface. The collection name
+	// comes from settings via SetWriting.
+	svc.SetKBSamples(kbStore.RecentDocumentTexts)
 	svc.SetKBDocStore(kbStore)
 	// missionStore backs kind=mission #-mention references (chat.go's
 	// ResolveReferences); nil-boxing guard, same reasoning as
@@ -1109,7 +1113,9 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		}
 		return out, nil
 	}
-	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, kbReadFromStore(kb.New(db)), log)
+	missionKB := kb.New(db)
+	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, kbReadFromStore(missionKB), log)
+	nativeRunner.SetKBSamples(missionKB.RecentDocumentTexts)
 	// search_memory: nil-safe in the same sense as kbSearch above (mc
 	// is never nil), calling the same memclient.Retrieve chat's own
 	// per-turn recall uses. Missions read memory as a tool rather than

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -158,6 +158,7 @@ type Service struct {
 	whisperHTTP    *http.Client                         // shared client for the whisper sidecar call
 	kbSearch       KBSearch                             // nil: search_kb never offered, regardless of agent config; whole-KB by default, agent Knowledge only boosts ranking
 	kbRead         KBRead                               // nil: read_kb never offered, regardless of agent config; reaches any document, not just the agent's Knowledge collections
+	kbSamples      KBSamples                            // nil: writing_samples never offered
 	missions       MissionStore                         // nil: mission #-mention references never resolve
 	kbDocs         KBDocStore                           // nil: kb doc #-mention references never resolve
 	logger         *slog.Logger
@@ -325,6 +326,34 @@ func (s *Service) kbReadTool() *tools.Tool {
 	}
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		return s.kbRead(ctx, documentID)
+	})
+}
+
+// KBSamples returns the newest ready documents in the named
+// collection as plain text; main curries kb.Store.RecentDocumentTexts
+// in.
+type KBSamples func(ctx context.Context, name string, limit int) ([]kb.DocumentText, error)
+
+// SetKBSamples wires the writing_samples tool's backing fetch.
+// Optional: same nil contract as SetKBSearch.
+func (s *Service) SetKBSamples(fn KBSamples) { s.kbSamples = fn }
+
+// writingSamplesTool builds this turn's writing_samples ExtraTool,
+// gated exactly like kbSearchTool: no backend wired means the tool is
+// not offered. The collection name comes from settings via SetWriting,
+// never from the model.
+func (s *Service) writingSamplesTool() *tools.Tool {
+	if s.kbSamples == nil {
+		return nil
+	}
+	return builtin.WritingSamples(func(ctx context.Context) string {
+		if s.writing == nil {
+			return ""
+		}
+		_, samples := s.writing(ctx)
+		return samples
+	}, func(ctx context.Context, name string, limit int) ([]kb.DocumentText, error) {
+		return s.kbSamples(ctx, name, limit)
 	})
 }
 
@@ -1441,6 +1470,9 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 		extraTools = append(extraTools, t)
 	}
 	if t := s.kbReadTool(); t != nil {
+		extraTools = append(extraTools, t)
+	}
+	if t := s.writingSamplesTool(); t != nil {
 		extraTools = append(extraTools, t)
 	}
 	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -7,7 +7,7 @@ import (
 )
 
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 8
+const systemPromptVersion = 9
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -483,3 +483,64 @@ func (s *Store) DeleteDocument(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+// DocumentText is one ready document with its chunks reassembled into
+// plain text: the writing_samples tool's row shape.
+type DocumentText struct {
+	Title     string
+	CreatedAt time.Time
+	Text      string
+}
+
+// recentTextsFetchFactor over-fetches so the caller can drop documents
+// in the wrong language and still fill its own limit.
+const recentTextsFetchFactor = 4
+
+// recentTextsFetchCap bounds the over-fetch regardless of limit.
+const recentTextsFetchCap = 40
+
+// RecentDocumentTexts returns the newest ready documents in the
+// collection with that exact name, each document's kb_chunks content
+// joined in seq order. An unknown collection name returns an empty
+// slice, not an error. Returns up to limit*recentTextsFetchFactor rows
+// (capped) so a caller filtering by language still has candidates.
+func (s *Store) RecentDocumentTexts(ctx context.Context, collectionName string, limit int) ([]DocumentText, error) {
+	if limit < 1 {
+		return []DocumentText{}, nil
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("kb recent document texts: %w", err)
+	}
+	rows, err := db.Query(ctx, `
+		SELECT d.title, d.created_at,
+		       COALESCE((SELECT string_agg(c.content, E'\n\n' ORDER BY c.seq)
+		                 FROM kb_chunks c WHERE c.document_id = d.id), '')
+		FROM kb_documents d
+		JOIN kb_collections col ON col.id = d.collection_id
+		WHERE col.name = $1 AND d.status = 'ready'
+		ORDER BY d.created_at DESC
+		LIMIT $2`, collectionName, recentTextsFetch(limit))
+	if err != nil {
+		return nil, fmt.Errorf("kb recent document texts: %w", err)
+	}
+	defer rows.Close()
+	out := []DocumentText{}
+	for rows.Next() {
+		var d DocumentText
+		if err := rows.Scan(&d.Title, &d.CreatedAt, &d.Text); err != nil {
+			return nil, fmt.Errorf("kb recent document texts: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// recentTextsFetch is the over-fetch size for a caller asking for
+// limit documents.
+func recentTextsFetch(limit int) int {
+	if n := limit * recentTextsFetchFactor; n < recentTextsFetchCap {
+		return n
+	}
+	return recentTextsFetchCap
+}

--- a/internal/brain/kb/kb_test.go
+++ b/internal/brain/kb/kb_test.go
@@ -27,3 +27,24 @@ func TestTruncate(t *testing.T) {
 		t.Fatal("truncate must keep the original prefix")
 	}
 }
+
+// TestRecentTextsFetch pins the writing_samples over-fetch: a caller
+// filtering by language needs more candidates than it returns, bounded
+// so a large k cannot pull the whole collection.
+func TestRecentTextsFetch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		limit int
+		want  int
+	}{
+		{1, recentTextsFetchFactor},
+		{3, 3 * recentTextsFetchFactor},
+		{5, 5 * recentTextsFetchFactor},
+		{100, recentTextsFetchCap},
+	}
+	for _, tc := range cases {
+		if got := recentTextsFetch(tc.limit); got != tc.want {
+			t.Fatalf("recentTextsFetch(%d) = %d, want %d", tc.limit, got, tc.want)
+		}
+	}
+}

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -98,7 +98,7 @@ type WorkPacket struct {
 // the package chat already imports.
 const (
 	WritingStyleHeading = "# Owner writing style"
-	WritingSamplesNote  = "The owner's own writing is in the knowledge base. Before drafting or rewriting prose, search_kb for two or three pieces in the same language and of the same kind, and match their voice."
+	WritingSamplesNote  = "The owner's own writing is in the knowledge base. Before drafting or rewriting prose, call writing_samples with the language of the piece and match the voice of what comes back."
 )
 
 // WritingStyleBlock renders the operator writing-style block, "" when

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
@@ -213,6 +214,10 @@ type nativeRunner struct {
 	// kbRead backs the per-turn read_kb ExtraTool: same nil contract
 	// as kbSearch.
 	kbRead KBReadFunc
+
+	// kbSamples backs the per-turn writing_samples ExtraTool: same nil
+	// contract as kbSearch.
+	kbSamples KBSamplesFunc
 
 	// recall backs the per-turn search_memory ExtraTool: same nil
 	// contract as kbSearch. Missions get memory as a tool rather than
@@ -533,6 +538,10 @@ type SearchMemoryFunc func(ctx context.Context, query string, limit int) ([]buil
 // (D-078: collections no longer gate read access: issue #368).
 type KBReadFunc func(ctx context.Context, documentID string) (builtin.KBDocument, error)
 
+// KBSamplesFunc returns the newest ready documents in a collection as
+// plain text: main curries kb.Store.RecentDocumentTexts in.
+type KBSamplesFunc func(ctx context.Context, name string, limit int) ([]kb.DocumentText, error)
+
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
 // agent instance is expected to be brain's existing chat agent: a
 // mission worker turn is just another loop.Agent caller, not a
@@ -599,6 +608,29 @@ func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
 	}
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		return r.kbRead(ctx, documentID)
+	})
+}
+
+// SetKBSamples wires the writing_samples tool's backing fetch.
+// Optional: unwired means writing_samples is never offered, exactly as
+// kbSearch behaves.
+func (r *nativeRunner) SetKBSamples(fn KBSamplesFunc) { r.kbSamples = fn }
+
+// writingSamplesTool builds this turn's writing_samples ExtraTool,
+// gated exactly like kbSearchTool. The collection name comes from the
+// operator's writing settings (SetWriting), never from the model.
+func (r *nativeRunner) writingSamplesTool() *tools.Tool {
+	if r.kbSamples == nil {
+		return nil
+	}
+	return builtin.WritingSamples(func(ctx context.Context) string {
+		if r.writing == nil {
+			return ""
+		}
+		_, samples := r.writing(ctx)
+		return samples
+	}, func(ctx context.Context, name string, limit int) ([]kb.DocumentText, error) {
+		return r.kbSamples(ctx, name, limit)
 	})
 }
 
@@ -1238,6 +1270,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		extra = append(extra, t)
 	}
 	if t := r.kbReadTool(m); t != nil {
+		extra = append(extra, t)
+	}
+	if t := r.writingSamplesTool(); t != nil {
 		extra = append(extra, t)
 	}
 	if t := r.searchMemoryTool(); t != nil {

--- a/internal/brain/tools/builtin/writingsamples.go
+++ b/internal/brain/tools/builtin/writingsamples.go
@@ -1,0 +1,175 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+const (
+	writingSamplesDefaultK = 3
+	writingSamplesMaxK     = 5
+	// writingSamplesTextCap bounds one rendered sample; several full
+	// documents would otherwise dominate the turn's context.
+	writingSamplesTextCap = 3000
+	// bengaliShare is the fraction of letter runes in the Bengali block
+	// above which a text counts as Bangla.
+	bengaliShare = 0.3
+)
+
+var writingSamplesLanguages = map[string]bool{"bn": true, "en": true}
+
+// WritingSamplesCollectionFunc resolves the name of the kb collection
+// holding the operator's own writing, "" when unset.
+type WritingSamplesCollectionFunc func(ctx context.Context) string
+
+// WritingSamplesFetchFunc returns the newest ready documents in a
+// collection as plain text; main curries kb.Store.RecentDocumentTexts
+// in.
+type WritingSamplesFetchFunc func(ctx context.Context, name string, limit int) ([]kb.DocumentText, error)
+
+type writingSamplesArgs struct {
+	Language string `json:"language"`
+	K        *int   `json:"k"`
+}
+
+// WritingSamples returns the operator's own writing by language rather
+// than by topic: search_kb ranks on topic similarity, so an off-topic
+// style sample never surfaces there.
+func WritingSamples(collection WritingSamplesCollectionFunc, fetch WritingSamplesFetchFunc) *tools.Tool {
+	return &tools.Tool{
+		Name: "writing_samples",
+		Description: `Returns pieces the owner wrote themselves, selected by language.
+
+Use before drafting or rewriting any prose the owner will send or
+publish, so the result sounds like them. Pass the language of the piece
+you are about to write.
+
+The samples are about unrelated topics on purpose: they are here for
+voice, not for content. Copy sentence length, tone, how they address
+the reader, and their punctuation habits. Never copy their subject
+matter, facts, or sentences into what you write.
+
+Do not use this to look up facts. search_kb is for facts.
+
+Arguments:
+- language (string, optional): "bn" for Bangla or "en" for English;
+  omit to get the most recent samples in any language.
+- k (integer, optional): how many samples to return, 1-5, default 3.
+
+Returns numbered samples, each with its title, the date it was added,
+and its text (long pieces are cut).`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"language": {
+					"type": "string",
+					"enum": ["bn", "en"],
+					"description": "Language of the piece being written; omit for any language."
+				},
+				"k": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 5,
+					"description": "Number of samples to return; defaults to 3."
+				}
+			},
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args writingSamplesArgs
+			if len(raw) > 0 {
+				if err := json.Unmarshal(raw, &args); err != nil {
+					return "", fmt.Errorf("writing_samples: invalid arguments: %w", err)
+				}
+			}
+			if args.Language != "" && !writingSamplesLanguages[args.Language] {
+				return "", fmt.Errorf("writing_samples: language must be bn or en, got %q", args.Language)
+			}
+			k := writingSamplesDefaultK
+			if args.K != nil {
+				k = *args.K
+				if k < 1 || k > writingSamplesMaxK {
+					return "", fmt.Errorf("writing_samples: k must be between 1 and %d, got %d", writingSamplesMaxK, k)
+				}
+			}
+			name := collection(ctx)
+			if name == "" {
+				return "No writing samples collection is configured.", nil
+			}
+			docs, err := fetch(ctx, name, k)
+			if err != nil {
+				return "", fmt.Errorf("writing_samples: %w", err)
+			}
+			matched := make([]kb.DocumentText, 0, k)
+			for _, d := range docs {
+				if args.Language != "" && detectLanguage(d.Text) != args.Language {
+					continue
+				}
+				matched = append(matched, d)
+				if len(matched) == k {
+					break
+				}
+			}
+			if len(matched) == 0 {
+				if args.Language == "" {
+					return "No samples found in " + name + ".", nil
+				}
+				return "No " + args.Language + " samples found in " + name + ".", nil
+			}
+			return formatWritingSamples(matched), nil
+		},
+	}
+}
+
+func formatWritingSamples(docs []kb.DocumentText) string {
+	var b strings.Builder
+	for i, d := range docs {
+		if i > 0 {
+			b.WriteString("\n---\n\n")
+		}
+		b.WriteString(strconv.Itoa(i + 1))
+		b.WriteString(". ")
+		b.WriteString(d.Title)
+		b.WriteString("\n")
+		b.WriteString(d.CreatedAt.Format("2006-01-02"))
+		b.WriteString("\n\n")
+		b.WriteString(capRunes(d.Text, writingSamplesTextCap))
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// capRunes cuts s to at most n runes, marking a cut with " ...".
+func capRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + " ..."
+}
+
+// detectLanguage reports "bn" when Bengali-block runes make up at
+// least bengaliShare of the letters, "en" otherwise.
+func detectLanguage(s string) string {
+	var letters, bengali int
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		letters++
+		if r >= 0x0980 && r <= 0x09FF {
+			bengali++
+		}
+	}
+	if letters > 0 && float64(bengali)/float64(letters) >= bengaliShare {
+		return "bn"
+	}
+	return "en"
+}

--- a/internal/brain/tools/builtin/writingsamples_test.go
+++ b/internal/brain/tools/builtin/writingsamples_test.go
@@ -1,0 +1,211 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+)
+
+const (
+	bnText = "আমি আজ সকালে অফিসে গিয়েছিলাম। কাজের চাপ ছিল অনেক বেশি।"
+	enText = "I went to the office this morning. The workload was heavier than usual."
+	mixed  = "আমি GitHub এ একটা PR খুলেছি। email পাঠিয়ে দিয়েছি সকালেই।"
+)
+
+func TestDetectLanguage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bangla", bnText, "bn"},
+		{"english", enText, "en"},
+		{"bangla with english tech words", mixed, "bn"},
+		{"empty", "", "en"},
+		{"digits and punctuation only", "123 ... !!!", "en"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := detectLanguage(tc.in); got != tc.want {
+				t.Fatalf("detectLanguage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+type fakeSamples struct {
+	docs     []kb.DocumentText
+	err      error
+	sawName  string
+	sawLimit int
+}
+
+func (f *fakeSamples) fetch(_ context.Context, name string, limit int) ([]kb.DocumentText, error) {
+	f.sawName, f.sawLimit = name, limit
+	return f.docs, f.err
+}
+
+func fixedCollection(name string) WritingSamplesCollectionFunc {
+	return func(context.Context) string { return name }
+}
+
+func sampleDocs() []kb.DocumentText {
+	day := time.Date(2026, 9, 11, 10, 0, 0, 0, time.UTC)
+	return []kb.DocumentText{
+		{Title: "Bangla note", CreatedAt: day, Text: bnText},
+		{Title: "English post", CreatedAt: day.AddDate(0, 0, -1), Text: enText},
+		{Title: "Mixed note", CreatedAt: day.AddDate(0, 0, -2), Text: mixed},
+	}
+}
+
+func execTool(t *testing.T, coll string, fk *fakeSamples, args map[string]any) (string, error) {
+	t.Helper()
+	tool := WritingSamples(fixedCollection(coll), fk.fetch)
+	raw, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return tool.Execute(context.Background(), raw)
+}
+
+func TestWritingSamplesUnsetCollection(t *testing.T) {
+	t.Parallel()
+	fk := &fakeSamples{docs: sampleDocs()}
+	out, err := execTool(t, "", fk, map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "No writing samples collection is configured." {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	if fk.sawName != "" {
+		t.Fatal("fetch must not be called without a configured collection")
+	}
+}
+
+func TestWritingSamplesFilters(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		args    map[string]any
+		want    []string
+		notWant []string
+	}{
+		{"bn filter", map[string]any{"language": "bn"}, []string{"1. Bangla note", "2. Mixed note", "2026-09-11"}, []string{"English post"}},
+		{"en filter", map[string]any{"language": "en"}, []string{"1. English post", "2026-09-10"}, []string{"Bangla note", "Mixed note"}},
+		{"no filter", map[string]any{}, []string{"1. Bangla note", "2. English post", "3. Mixed note"}, nil},
+		{"k bound", map[string]any{"k": 1}, []string{"1. Bangla note"}, []string{"English post"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fk := &fakeSamples{docs: sampleDocs()}
+			out, err := execTool(t, "samples", fk, tc.args)
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Fatalf("output missing %q:\n%s", w, out)
+				}
+			}
+			for _, w := range tc.notWant {
+				if strings.Contains(out, w) {
+					t.Fatalf("output has unwanted %q:\n%s", w, out)
+				}
+			}
+			if fk.sawName != "samples" {
+				t.Fatalf("collection name = %q, want samples", fk.sawName)
+			}
+		})
+	}
+}
+
+func TestWritingSamplesDefaultK(t *testing.T) {
+	t.Parallel()
+	fk := &fakeSamples{docs: sampleDocs()}
+	if _, err := execTool(t, "samples", fk, map[string]any{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fk.sawLimit != writingSamplesDefaultK {
+		t.Fatalf("limit = %d, want %d", fk.sawLimit, writingSamplesDefaultK)
+	}
+}
+
+func TestWritingSamplesNoMatch(t *testing.T) {
+	t.Parallel()
+	fk := &fakeSamples{docs: []kb.DocumentText{{Title: "English post", Text: enText}}}
+	out, err := execTool(t, "samples", fk, map[string]any{"language": "bn"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "No bn samples found in samples." {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestWritingSamplesEmptyCollection(t *testing.T) {
+	t.Parallel()
+	fk := &fakeSamples{}
+	out, err := execTool(t, "samples", fk, map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "No samples found in samples." {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestWritingSamplesTruncates(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("অ", writingSamplesTextCap+500)
+	fk := &fakeSamples{docs: []kb.DocumentText{{Title: "Long", Text: long}}}
+	out, err := execTool(t, "samples", fk, map[string]any{"language": "bn"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(out), " ...") {
+		t.Fatalf("truncated sample must end with the cut marker:\n%s", out[len(out)-40:])
+	}
+	if n := strings.Count(out, "অ"); n != writingSamplesTextCap {
+		t.Fatalf("kept %d runes, want %d", n, writingSamplesTextCap)
+	}
+}
+
+func TestWritingSamplesBadArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"malformed json", `{"language":`},
+		{"unknown language", `{"language":"fr"}`},
+		{"k too low", `{"k":0}`},
+		{"k too high", `{"k":6}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fk := &fakeSamples{docs: sampleDocs()}
+			tool := WritingSamples(fixedCollection("samples"), fk.fetch)
+			if _, err := tool.Execute(context.Background(), json.RawMessage(tc.raw)); err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func TestWritingSamplesFetchError(t *testing.T) {
+	t.Parallel()
+	fk := &fakeSamples{err: errors.New("boom")}
+	if _, err := execTool(t, "samples", fk, map[string]any{}); err == nil {
+		t.Fatal("expected the fetch error to surface")
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -109,6 +109,10 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// read_kb is the same pure read, one document at a time,
 			// with the collection allowlist bound the same way.
 			"read_kb": true,
+			// writing_samples is a pure read of the operator's own
+			// writing collection, whose name is bound in Go from
+			// settings, never model input.
+			"writing_samples": true,
 			// search_memory is the same class of read over long-term
 			// memory (issue #648): the query is the only argument and
 			// nothing it returns reaches a side effect.

--- a/skills/writing/SKILL.md
+++ b/skills/writing/SKILL.md
@@ -9,7 +9,7 @@ description: Drafts, rewrites, and edits prose in the owner's own voice, in Bang
 
 - The owner's voice is data on this instance, not something to invent. Before drafting, look for it in this order and stop at the first hit that covers the task:
   1. Style rules in the system prompt or the task brief. They win over every default below.
-  2. If a search_kb tool is available, search the knowledge base for the owner's own writing in the same language and of the same kind (email, post, note). Two or three close samples are enough. Read them for sentence length, register, how they open and close, which words they never use.
+  2. If a writing_samples tool is available, call it with the language of the piece you are about to write and k of 2 or 3. It returns the owner's own writing selected by language, not by topic, so the samples will be about unrelated subjects. Read them for sentence length, register, how they open and close, which words they never use. Take voice only, never content. If writing_samples is not offered, fall back to search_kb for the owner's own writing in the same language and of the same kind (email, post, note).
   3. If a search_memory tool is available, search long-term memory for standing writing preferences: forbidden words, spelling convention, sign-off, address form (আপনি/তুমি, first name/title).
 - Match what you found. When samples and defaults disagree, samples win. When two samples disagree, follow the one closest in kind and audience.
 - When nothing is configured, use the defaults below and say so in one line only if the owner asked how the voice was chosen. Never pad the answer with a note about it otherwise.
@@ -68,7 +68,7 @@ Fluent text is cheap. Two kinds of slop need two fixes: epistemic slop (invented
 
 | Excuse                                                    | Rebuttal                                                                                                    |
 |-----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| "It is a short email, no need to check samples"           | Short pieces show voice mismatch fastest; one search_kb call costs less than a rewrite.                     |
+| "It is a short email, no need to check samples"           | Short pieces show voice mismatch fastest; one writing_samples call costs less than a rewrite.               |
 | "The owner will edit it anyway"                           | The job is text the owner can send. Editing debt is the failure mode this skill exists to prevent.          |
 | "A little balance makes it sound fair"                    | Unrequested balance is hedging. Say the thing, then the real exception if one exists.                       |
 | "The reader expects an introduction"                      | The reader expects the point. Cut the paragraph that restates the request.                                  |
@@ -80,7 +80,7 @@ Fluent text is cheap. Two kinds of slop need two fixes: epistemic slop (invented
 
 ## Red flags: stop and re-check
 
-- You are about to produce prose without having searched for the owner's samples or rules when a search_kb or search_memory tool is available.
+- You are about to produce prose without having called writing_samples (or searched for the owner's samples) when a writing_samples, search_kb, or search_memory tool is available.
 - The draft contains a number, date, name, quotation, or capability that neither the request nor a retrieved source contains.
 - The draft opens by restating the request or closes by summarizing itself.
 - Three items in a row, three adjectives in a row, or three parallel clauses that content did not demand.
@@ -93,7 +93,7 @@ Fluent text is cheap. Two kinds of slop need two fixes: epistemic slop (invented
 
 ## Evidence required
 
-- Which voice source was used: prompt rules, knowledge-base samples, memory preferences, or defaults. One line, only when the owner asks.
+- Which voice source was used: prompt rules, writing_samples, knowledge-base search, memory preferences, or defaults. One line, only when the owner asks.
 - On the full path: the claim list exists and every consequential claim in the text maps to a labelled entry with a supporting source.
 - No fact in the text that the request or retrieved sources did not supply.
 - The prose pass ran after the claims pass, not merged with it.


### PR DESCRIPTION
Closes #688

## Why

`search_kb` is topic retrieval. Style samples are off-topic to the piece being written by nature, so on a live chat the `writing` pack loaded, made two `search_kb` calls, and got zero hits from the samples collection:

- the semantic leg drops chunks under 0.25 similarity
- the keyword leg is `to_tsvector('english')`, so Bangla yields no lexemes
- the 1.5x collection boost multiplies after both legs, so it cannot rescue a chunk neither leg returned

## What

- New builtin `writing_samples` (`internal/brain/tools/builtin/writingsamples.go`): args `language` (`bn` | `en`, optional) and `k` (1 to 5, default 3). No query. Returns the newest ready documents from the collection named by the `writing_samples_collection` setting, chunks joined in order, each capped at 3000 runes. Language by Bengali-block share of letter runes in Go, never a model argument. Unset setting returns a plain message.
- `kb.Store.RecentDocumentTexts` backs it, over-fetching so the language filter can still fill `k`.
- Offered as a per-turn ExtraTool in chat and on the mission worker turn, nil-gated like `search_kb`. Permission exempt (pure read). Opt-in through agent tool allowlists like every other tool.
- `WritingSamplesNote` and the `writing` skill pack point at the tool; `search_kb` stays the fallback for facts. `systemPromptVersion` 8 to 9 since the note rides the cacheable prefix.

## Verify

- `make build test vet lint`: clean, 0 lint issues, all packages ok
- `make skills-validate`: embedding similarity check passed, 6 skills valid
- `make canary`: PASS (4 turns, 146s)

## Operator step after deploy

Add `writing_samples` to the tool allowlist of each agent that should draft prose (Settings, Agents, Tools picker, or `PATCH /v1/admin/agents/{id}`). `writing_samples_collection` must name an existing collection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791754094&installation_model_id=431401&pr_number=690&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F690&signature=2bdfee51e8564b773976ab9e91c2be756ad13dcbfd7529fc182121ed3d6b6d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->