### PR TITLE
feat(web): show pre-tool narration as step notes, not answer text

### DIFF
--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -272,6 +272,38 @@ describe('copy buttons', () => {
     vi.unstubAllGlobals()
   })
 
+  it('copies the message text only, never the step notes', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const msg = play([
+      { type: 'chunk', text: 'Checking your notes for tone.' },
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'search_kb' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'search_kb', status: 'ok', duration_ms: 5 } },
+      { type: 'chunk', text: 'the answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    fireEvent.click(screen.getByTestId('copy-button'))
+    expect(writeText).toHaveBeenCalledWith('the answer')
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps step notes out of the message bubble', () => {
+    const msg = play([
+      { type: 'chunk', text: 'Checking your notes for tone.' },
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'search_kb' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'search_kb', status: 'ok', duration_ms: 5 } },
+      { type: 'chunk', text: 'the answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    expect(screen.getByText('the answer')).toBeInTheDocument()
+    expect(screen.queryByText('Checking your notes for tone.')).not.toBeInTheDocument()
+  })
+
   it('copies the user message text', () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     vi.stubGlobal('navigator', { clipboard: { writeText } })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -524,7 +524,11 @@ export function AssistantMessage({
 
       {msg.tools.length > 0 && (
         <div className="mt-3 w-full min-w-0">
-          <ToolCallGroup runs={msg.tools} defaultOpen={msg.tools.some((t) => t.status === 'running')} />
+          <ToolCallGroup
+            runs={msg.tools}
+            stepNotes={msg.stepNotes}
+            defaultOpen={msg.tools.some((t) => t.status === 'running')}
+          />
         </div>
       )}
 

--- a/web/src/components/chat/ToolCallCard.test.tsx
+++ b/web/src/components/chat/ToolCallCard.test.tsx
@@ -153,4 +153,26 @@ describe('ToolCallGroup', () => {
     expect(screen.getByText('Search web')).toBeInTheDocument()
     expect(screen.getByText('Read file')).toBeInTheDocument()
   })
+
+  it('hides step notes while collapsed and shows them when expanded', () => {
+    const runs: ToolRun[] = [
+      { id: '1', name: 'search_web', status: 'ok' },
+      { id: '2', name: 'read_file', status: 'ok' },
+    ]
+    const notes = ['Checking your notes for tone.', 'Loading the writing skill.']
+    render(<ToolCallGroup runs={runs} stepNotes={notes} />)
+
+    expect(screen.queryByText(notes[0])).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('2 tool calls'))
+    expect(screen.getByText(notes[0])).toBeInTheDocument()
+    expect(screen.getByText(notes[1])).toBeInTheDocument()
+  })
+
+  it('keeps group chrome for a single run that carries step notes', () => {
+    const runs: ToolRun[] = [{ id: '1', name: 'search_web', status: 'ok' }]
+    render(<ToolCallGroup runs={runs} stepNotes={['Looking that up.']} />)
+
+    fireEvent.click(screen.getByText('1 tool call'))
+    expect(screen.getByText('Looking that up.')).toBeInTheDocument()
+  })
 })

--- a/web/src/components/chat/ToolCallCard.tsx
+++ b/web/src/components/chat/ToolCallCard.tsx
@@ -99,12 +99,36 @@ export function ToolCallCard({
   )
 }
 
+// StepNotes lists a turn's narration lines, the text the model emitted
+// before each tool call, as muted rows above the tool calls.
+function StepNotes({ notes }: { notes: string[] }) {
+  return (
+    <div className="space-y-0.5 py-1" data-testid="step-notes">
+      {notes.map((note, i) => (
+        <p key={i} className="text-sm text-muted-foreground">
+          {note}
+        </p>
+      ))}
+    </div>
+  )
+}
+
 // ToolCallGroup folds several tool calls into one group row (14.5); a
 // single call renders as a plain ToolCallCard with no group chrome,
 // wrapped in the same recess TraceGroup applies so single and
-// multiple calls sit at identical indentation.
-export function ToolCallGroup({ runs, defaultOpen = false }: { runs: ToolRun[]; defaultOpen?: boolean }) {
-  if (runs.length === 1)
+// multiple calls sit at identical indentation. Step notes, when the
+// turn has them, sit at the top of the expanded panel.
+export function ToolCallGroup({
+  runs,
+  stepNotes,
+  defaultOpen = false,
+}: {
+  runs: ToolRun[]
+  stepNotes?: string[]
+  defaultOpen?: boolean
+}) {
+  const notes = stepNotes && stepNotes.length > 0 ? stepNotes : undefined
+  if (runs.length === 1 && !notes)
     return (
       <div className="ml-1 border-l-2 border-border pl-3">
         <ToolCallCard run={runs[0]} defaultOpen={defaultOpen} />
@@ -112,12 +136,14 @@ export function ToolCallGroup({ runs, defaultOpen = false }: { runs: ToolRun[]; 
     )
 
   const anyRunning = runs.some((r) => r.status === 'running')
+  const summary = runs.length === 1 ? '1 tool call' : `${runs.length} tool calls`
   return (
     <TraceGroup
-      summary={`${runs.length} tool calls`}
+      summary={summary}
       duration={formatDuration(totalDuration(runs))}
       defaultOpen={defaultOpen || anyRunning}
     >
+      {notes && <StepNotes notes={notes} />}
       {runs.map((run) => (
         <ToolCallCard key={run.id} run={run} />
       ))}

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -15,6 +15,14 @@ export interface ToolRun {
 
 export interface AssistantState {
   text: string
+  // stepNotes are the turn's earlier agent-loop text segments (the
+  // short narration lines before each tool call); `text` holds only
+  // the final segment, the answer.
+  stepNotes?: string[]
+  // sawTool marks a tool event landed since the last text chunk.
+  // Mirrors brain's segment rule: the next chunk after a tool event,
+  // with text already present, opens a new agent-loop segment.
+  sawTool?: boolean
   reasoning: string
   notices: string[]
   tools: ToolRun[]
@@ -45,14 +53,26 @@ export function emptyAssistant(): AssistantState {
 // applyEvent folds one SSE event into the assistant message state.
 export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
   switch (ev.type) {
-    case 'chunk':
-      return { ...msg, text: msg.text + (ev.text ?? '') }
+    case 'chunk': {
+      // A chunk arriving after a tool event, with text already in
+      // hand, closes the previous segment: it becomes a step note and
+      // text restarts from this chunk. Brain persists the same split.
+      if (msg.sawTool && msg.text !== '')
+        return {
+          ...msg,
+          stepNotes: [...(msg.stepNotes ?? []), msg.text],
+          text: ev.text ?? '',
+          sawTool: false,
+        }
+      return { ...msg, text: msg.text + (ev.text ?? ''), sawTool: false }
+    }
     case 'reasoning_chunk':
       return { ...msg, reasoning: msg.reasoning + (ev.text ?? '') }
     case 'tool_start': {
       if (!ev.tool_call) return msg
       return {
         ...msg,
+        sawTool: true,
         tools: [...msg.tools, { id: ev.tool_call.id, name: ev.tool_call.name, status: 'running' }],
       }
     }
@@ -61,6 +81,7 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
       const { id, input } = ev.tool_call
       return {
         ...msg,
+        sawTool: true,
         tools: msg.tools.map((t) =>
           t.id === id ? { ...t, args: input === undefined ? t.args : JSON.stringify(input) } : t,
         ),
@@ -71,6 +92,7 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
       const r = ev.tool_result
       return {
         ...msg,
+        sawTool: true,
         tools: msg.tools.map((t) =>
           t.id === r.id
             ? { ...t, status: r.status, digest: r.digest, durationMs: r.duration_ms }

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -65,6 +65,105 @@ describe('fromTranscript', () => {
     expect(items[0]).toMatchObject({ role: 'assistant', text: 'part one\n\npart two' })
   })
 
+  it('splits text blocks into step notes and a message when the turn ran tools', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'tool', tool: { call_id: 'c1', name: 'load_skill', status: 'ok' }, created_at: at },
+      { seq: 2, kind: 'tool', tool: { call_id: 'c2', name: 'search_kb', status: 'ok' }, created_at: at },
+      {
+        seq: 3,
+        kind: 'assistant',
+        blocks: [
+          { type: 'text', text: 'Checking your notes for tone.' },
+          { type: 'text', text: 'Loading the writing skill.' },
+          { type: 'text', text: 'Reading your samples.' },
+          { type: 'text', text: 'Here is the answer.' },
+        ],
+        created_at: at,
+      },
+    ])
+    expect(items).toHaveLength(1)
+    if (items[0].role !== 'assistant') throw new Error('expected assistant')
+    expect(items[0].stepNotes).toEqual([
+      'Checking your notes for tone.',
+      'Loading the writing skill.',
+      'Reading your samples.',
+    ])
+    expect(items[0].text).toBe('Here is the answer.')
+  })
+
+  it('leaves a single text block alone even when the turn ran tools', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'tool', tool: { call_id: 'c1', name: 'shell', status: 'ok' }, created_at: at },
+      { seq: 2, kind: 'assistant', blocks: [{ type: 'text', text: 'just the answer' }], created_at: at },
+    ])
+    if (items[0].role !== 'assistant') throw new Error('expected assistant')
+    expect(items[0].stepNotes).toBeUndefined()
+    expect(items[0].text).toBe('just the answer')
+  })
+
+  it('leaves multiple text blocks joined when the turn ran no tools', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'assistant',
+        blocks: [
+          { type: 'text', text: 'part one' },
+          { type: 'text', text: 'part two' },
+        ],
+        created_at: at,
+      },
+    ])
+    if (items[0].role !== 'assistant') throw new Error('expected assistant')
+    expect(items[0].stepNotes).toBeUndefined()
+    expect(items[0].text).toBe('part one\n\npart two')
+  })
+
+  it('skips empty text blocks so they never become step notes', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'tool', tool: { call_id: 'c1', name: 'shell', status: 'ok' }, created_at: at },
+      {
+        seq: 2,
+        kind: 'assistant',
+        blocks: [
+          { type: 'text' },
+          { type: 'text', text: 'Looking that up.' },
+          { type: 'text' },
+          { type: 'text', text: 'Found it.' },
+        ],
+        created_at: at,
+      },
+    ])
+    if (items[0].role !== 'assistant') throw new Error('expected assistant')
+    expect(items[0].stepNotes).toEqual(['Looking that up.'])
+    expect(items[0].text).toBe('Found it.')
+  })
+
+  it('splits live step notes the same way the replay projection does', () => {
+    const events: ChatEvent[] = [
+      { type: 'chunk', text: 'Checking your notes for tone.' },
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'search_kb' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'search_kb', status: 'ok', duration_ms: 5 } },
+      { type: 'chunk', text: 'Loading the writing skill.' },
+      { type: 'tool_start', tool_call: { id: 'c2', name: 'load_skill' } },
+      { type: 'tool_result', tool_result: { id: 'c2', name: 'load_skill', status: 'ok', duration_ms: 5 } },
+      { type: 'chunk', text: 'Here is ' },
+      { type: 'chunk', text: 'the answer.' },
+    ]
+    const live = events.reduce(applyEvent, emptyAssistant())
+    expect(live.stepNotes).toEqual(['Checking your notes for tone.', 'Loading the writing skill.'])
+    expect(live.text).toBe('Here is the answer.')
+  })
+
+  it('keeps live text whole when no tool runs between chunks', () => {
+    const events: ChatEvent[] = [
+      { type: 'chunk', text: 'part ' },
+      { type: 'chunk', text: 'one' },
+    ]
+    const live = events.reduce(applyEvent, emptyAssistant())
+    expect(live.stepNotes).toBeUndefined()
+    expect(live.text).toBe('part one')
+  })
+
   it('replays a media block into the assistant item', () => {
     const items = fromTranscript([
       {

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -89,24 +89,33 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
         if (item.permission) pendingPermissions.push({ seq: item.seq, permission: item.permission })
         break
       case 'assistant': {
-        let text = ''
+        // An empty block serializes without its text key (omitempty);
+        // it is skipped so it never becomes a blank note or a literal
+        // "undefined".
+        const segments: string[] = []
         let reasoning = ''
         let media: NonNullable<(typeof item)['blocks']>[number]['media'] = undefined
         for (const b of item.blocks ?? []) {
-          // An empty block serializes without its text key (omitempty);
-          // naive concat would render a literal "undefined".
-          if (b.type === 'text') text += (text && b.text ? '\n\n' : '') + (b.text ?? '')
-          else if (b.type === 'reasoning') reasoning += b.text ?? ''
+          if (b.type === 'text') {
+            if (b.text) segments.push(b.text)
+          } else if (b.type === 'reasoning') reasoning += b.text ?? ''
           else if (b.type === 'media' && b.media) media = [...(media ?? []), ...b.media]
         }
         const tools = pendingTools.map((p) => toToolRun(p.tool))
         const permissions = pendingPermissions.map((p) => p.permission)
         pendingTools = []
         pendingPermissions = []
+        // With tool runs, every segment but the last is a step note
+        // (the narration line before a tool call) and the last is the
+        // answer. Without them the segments stay one message.
+        const split = tools.length > 0 && segments.length > 1
+        const text = split ? segments[segments.length - 1] : segments.join('\n\n')
+        const stepNotes = split ? segments.slice(0, -1) : undefined
         out.push({
           id,
           role: 'assistant',
           text,
+          stepNotes,
           reasoning,
           notices: [],
           tools,


### PR DESCRIPTION
Closes #689

## Why

GPT-5.x emits a short line before almost every tool call ("Checking your notes for tone."). The brain already persists each agent-loop segment as its own `text` block, but the web transcript joined every block into one bubble, so the narration rendered as the opening of the answer.

## What

- `transcript.ts`: with tool runs present and more than one text segment, every segment but the last becomes `stepNotes`, the last is `text`. One segment, or no tool runs: unchanged. Empty blocks skipped.
- `chat.ts` (live stream): the first chunk after a tool event, with text already present, closes the previous segment into `stepNotes`. Same rule the brain uses, so live and replay match and nothing jumps when the persisted item lands.
- `ToolCallCard.tsx`: step notes render muted at the top of the expanded tool-call panel. Collapsed row unchanged. A single tool call with notes keeps the group chrome so the notes have a panel.
- Copy reads `msg.text`, so notes are never copied.

## Verify

Docker `node:24.18.0-alpine`: build ok, lint 0 errors (75 pre-existing warnings, none in changed files), 140 test files / 1864 tests passed. New tests: 6 transcript, 2 ToolCallCard, 2 Message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791757739&installation_model_id=431401&pr_number=692&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F692&signature=affadffea121458a2703a95452de875d1b2b191c480afd86dcba495e4ae5448e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->