### PR TITLE
fix(tools): cap writing_samples output by bytes, not runes

### DIFF
--- a/internal/brain/tools/builtin/writingsamples.go
+++ b/internal/brain/tools/builtin/writingsamples.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
@@ -15,9 +16,13 @@ import (
 const (
 	writingSamplesDefaultK = 3
 	writingSamplesMaxK     = 5
-	// writingSamplesTextCap bounds one rendered sample; several full
-	// documents would otherwise dominate the turn's context.
-	writingSamplesTextCap = 3000
+	// writingSamplesTotalByteBudget bounds the whole rendered result,
+	// not each sample: Bangla runes are 3 bytes each, so a per-sample
+	// rune cap let two samples cross the tool result offload threshold
+	// (loop.DefaultOffloadThreshold, 8KB) and the model never saw them
+	// inline. Sized so the default k stays comfortably under that with
+	// headroom for titles, dates, and separators.
+	writingSamplesTotalByteBudget = 6000
 	// bengaliShare is the fraction of letter runes in the Bengali block
 	// above which a text counts as Bangla.
 	bengaliShare = 0.3
@@ -129,6 +134,7 @@ and its text (long pieces are cut).`,
 }
 
 func formatWritingSamples(docs []kb.DocumentText) string {
+	perSample := writingSamplesTotalByteBudget / len(docs)
 	var b strings.Builder
 	for i, d := range docs {
 		if i > 0 {
@@ -140,19 +146,27 @@ func formatWritingSamples(docs []kb.DocumentText) string {
 		b.WriteString("\n")
 		b.WriteString(d.CreatedAt.Format("2006-01-02"))
 		b.WriteString("\n\n")
-		b.WriteString(capRunes(d.Text, writingSamplesTextCap))
+		b.WriteString(capBytes(d.Text, perSample))
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
 }
 
-// capRunes cuts s to at most n runes, marking a cut with " ...".
-func capRunes(s string, n int) string {
-	r := []rune(s)
-	if len(r) <= n {
+// capBytes cuts s to at most n bytes, backing off to the nearest rune
+// boundary so a multi-byte character is never split, and marks a cut
+// with " ...". n <= 0 returns "".
+func capBytes(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if len(s) <= n {
 		return s
 	}
-	return string(r[:n]) + " ..."
+	cut := n
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + " ..."
 }
 
 // detectLanguage reports "bn" when Bengali-block runes make up at

--- a/internal/brain/tools/builtin/writingsamples_test.go
+++ b/internal/brain/tools/builtin/writingsamples_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 )
@@ -165,17 +166,46 @@ func TestWritingSamplesEmptyCollection(t *testing.T) {
 
 func TestWritingSamplesTruncates(t *testing.T) {
 	t.Parallel()
-	long := strings.Repeat("অ", writingSamplesTextCap+500)
+	// One doc gets the whole budget; each rune is 3 bytes ("অ" is in
+	// the Bengali block), so this comfortably exceeds it.
+	long := strings.Repeat("অ", writingSamplesTotalByteBudget)
 	fk := &fakeSamples{docs: []kb.DocumentText{{Title: "Long", Text: long}}}
-	out, err := execTool(t, "samples", fk, map[string]any{"language": "bn"})
+	out, err := execTool(t, "samples", fk, map[string]any{"language": "bn", "k": 1})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if !strings.HasSuffix(strings.TrimSpace(out), " ...") {
 		t.Fatalf("truncated sample must end with the cut marker:\n%s", out[len(out)-40:])
 	}
-	if n := strings.Count(out, "অ"); n != writingSamplesTextCap {
-		t.Fatalf("kept %d runes, want %d", n, writingSamplesTextCap)
+	if !utf8.ValidString(out) {
+		t.Fatalf("cut split a multi-byte rune: %q", out)
+	}
+}
+
+// TestWritingSamplesStayUnderOffloadThreshold reproduces the original
+// bug: several full-length Bangla documents at a per-sample RUNE cap
+// crossed the tool result offload threshold (8KB), so the model never
+// saw the samples inline (issue #691). The total-byte budget must keep
+// the whole rendered result under that regardless of how many samples
+// or how long the source documents are.
+func TestWritingSamplesStayUnderOffloadThreshold(t *testing.T) {
+	t.Parallel()
+	const offloadThreshold = 8 << 10
+	long := strings.Repeat("অ ", 2000) // ~12KB of Bangla text per doc
+	fk := &fakeSamples{docs: []kb.DocumentText{
+		{Title: "One", Text: long},
+		{Title: "Two", Text: long},
+		{Title: "Three", Text: long},
+	}}
+	out, err := execTool(t, "samples", fk, map[string]any{"language": "bn"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(out) >= offloadThreshold {
+		t.Fatalf("rendered result is %d bytes, want under the %d byte offload threshold", len(out), offloadThreshold)
+	}
+	if !utf8.ValidString(out) {
+		t.Fatalf("cut split a multi-byte rune: %q", out)
 	}
 }
 


### PR DESCRIPTION
Closes #691

## Why

First live homelab call (alpha.84): `writing_samples` with `language: bn, k: 2` returned 11363 bytes and got offloaded, so the model saw only the first lines of one sample. Bengali runes are 3 bytes each; the old cap was 3000 runes PER SAMPLE, so two samples alone could reach ~9KB, over the 8KB tool result offload threshold (`loop.DefaultOffloadThreshold`).

## What

- Replaced the per-sample rune cap with a total byte budget (6000) split across the returned samples, sized to keep the default `k=3` comfortably under the 8KB offload threshold with headroom for titles/dates/separators.
- Cut lands on a rune boundary (`capBytes`, backs off to `utf8.RuneStart`) so no multi-byte character is split.
- New regression test reproduces the original bug shape directly: three ~12KB Bangla documents, asserts the whole rendered result stays under the offload threshold and is valid UTF-8.

## Verify

- `make build vet lint`: clean, 0 lint issues
- `make test`: full suite, all packages ok
- `make canary`: first run FAILed on an unrelated flake (`gpt-5-mini` failed a `verify_cmd` harness check on a chunked-transfer-encoding doc task, nothing to do with this change); retry PASSed (4 turns, 143s)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791759697&installation_model_id=431401&pr_number=693&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F693&signature=7645ba1666b0185ea55161469ed765581c39692677893ea48f0cb3859c6c008c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->