### PR TITLE
fix(web): read the running version from /health, not a baked constant

### DIFF
--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -87,7 +87,7 @@ func health(ctx context.Context, mgr *sandboxd.Manager) httpserver.Health {
 	} else {
 		checks["image"] = httpserver.Check{Status: "ok"}
 	}
-	return httpserver.Health{Status: status, Checks: checks}
+	return httpserver.Health{Status: status, Version: service.Version, Checks: checks}
 }
 
 // execConfig reads the concurrency caps from the environment — bare

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,9 +11,16 @@ COPY internal/ internal/
 COPY migrations/ migrations/
 
 ARG SERVICE
+# APP_VERSION is baked into the binary so /health reports the release
+# it was built from. The web footer reads that, instead of a version
+# baked into a web image release.yml may have copied forward unchanged.
+# Unset (local `make build`) links an empty string, which /health omits.
+ARG APP_VERSION
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -trimpath -o /out/app ./cmd/${SERVICE}
+    CGO_ENABLED=0 go build -trimpath \
+    -ldflags "-X github.com/SumonMSelim/timothy/internal/platform/service.Version=${APP_VERSION}" \
+    -o /out/app ./cmd/${SERVICE}
 
 # Brain's shell tool needs /bin/sh; alpine provides busybox sh while
 # staying minimal. Select with build target runtime-shell. Everything

--- a/internal/platform/httpserver/server.go
+++ b/internal/platform/httpserver/server.go
@@ -28,10 +28,12 @@ type Check struct {
 
 // Health is the /health response body. Status is "ok" or "degraded";
 // the endpoint always answers 200 — it reports liveness, and a
-// degraded service is alive by design.
+// degraded service is alive by design. Version is the release the
+// running binary was built from, empty on a build with none baked in.
 type Health struct {
-	Status string           `json:"status"`
-	Checks map[string]Check `json:"checks,omitempty"`
+	Status  string           `json:"status"`
+	Version string           `json:"version,omitempty"`
+	Checks  map[string]Check `json:"checks,omitempty"`
 }
 
 // HealthFunc supplies the current health snapshot.

--- a/internal/platform/httpserver/server_test.go
+++ b/internal/platform/httpserver/server_test.go
@@ -56,6 +56,46 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 }
 
+// TestHealthVersion: the version a service reports rides in the health
+// body, and an empty one (a local build with none baked in) is omitted
+// rather than rendered as an empty string.
+func TestHealthVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		version   string
+		wantField bool
+	}{
+		{"baked version", "0.1.0-alpha.84", true},
+		{"local build", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := newTestServer(func() Health {
+				return Health{Status: "ok", Version: tc.version}
+			})
+
+			rec := httptest.NewRecorder()
+			s.srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			var h Health
+			if err := json.Unmarshal(rec.Body.Bytes(), &h); err != nil {
+				t.Fatalf("body not JSON: %v", err)
+			}
+			if h.Version != tc.version {
+				t.Fatalf("version = %q, want %q", h.Version, tc.version)
+			}
+			if got := strings.Contains(rec.Body.String(), `"version"`); got != tc.wantField {
+				t.Fatalf("body %s: version field present = %v, want %v", rec.Body.String(), got, tc.wantField)
+			}
+		})
+	}
+}
+
 func TestMetricsEndpoint(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(func() Health { return Health{Status: "ok"} })

--- a/internal/platform/service/service.go
+++ b/internal/platform/service/service.go
@@ -24,6 +24,11 @@ import (
 
 const migrateRetryDelay = 5 * time.Second
 
+// Version is the release this binary was built from, set at link time
+// by deploy/Dockerfile with -ldflags "-X ...service.Version=<tag>".
+// Local builds leave it empty; /health then omits the field.
+var Version string
+
 // App is a bootstrapped service. Register routes on Server, then Run.
 type App struct {
 	Config  config.Service
@@ -97,7 +102,7 @@ func (a *App) health() httpserver.Health {
 			status = "degraded"
 		}
 	}
-	return httpserver.Health{Status: status, Checks: checks}
+	return httpserver.Health{Status: status, Version: Version, Checks: checks}
 }
 
 func (a *App) migrationsCheck() httpserver.Check {

--- a/internal/platform/service/service_test.go
+++ b/internal/platform/service/service_test.go
@@ -56,6 +56,26 @@ func TestMigrationsStateTransitions(t *testing.T) {
 	}
 }
 
+// TestHealthCarriesVersion: the link-time Version reaches /health.
+// Empty (an unset -ldflags on a local build) is a valid state, not an
+// error, and simply omits the field from the response.
+func TestHealthCarriesVersion(t *testing.T) {
+	app := newTestApp(t)
+
+	original := Version
+	t.Cleanup(func() { Version = original })
+
+	Version = ""
+	if v := app.health().Version; v != "" {
+		t.Fatalf("version = %q, want empty on an unset build", v)
+	}
+
+	Version = "0.1.0-alpha.84"
+	if v := app.health().Version; v != "0.1.0-alpha.84" {
+		t.Fatalf("version = %q, want 0.1.0-alpha.84", v)
+	}
+}
+
 func TestProbeHealth(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/web/nginx/default.conf.template
+++ b/web/nginx/default.conf.template
@@ -13,12 +13,22 @@ server {
         try_files $uri /index.html;
     }
 
-    # API, including SSE chat streams: no buffering, long read timeout
-    # so a slow turn is not cut mid-stream. proxy_pass through a
-    # variable + Docker's embedded DNS defers name resolution to
-    # request time: nginx boots before brain and survives brain
-    # getting a new address on restart.
+    # proxy_pass through a variable + Docker's embedded DNS defers name
+    # resolution to request time: nginx boots before brain and survives
+    # brain getting a new address on restart.
     resolver 127.0.0.11 valid=30s ipv6=off;
+
+    # brain's /health, for the footer's running version. Unauthenticated
+    # and outside /v1/, so it needs its own location.
+    location = /health {
+        set $brain_health ${BRAIN_URL};
+        proxy_pass $brain_health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # API, including SSE chat streams: no buffering, long read timeout
+    # so a slow turn is not cut mid-stream.
     location /v1/ {
         set $brain ${BRAIN_URL};
         proxy_pass $brain;

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -140,3 +140,52 @@ describe('API token dialog', () => {
     expect(screen.getByText(/not an LLM provider API key/)).toBeTruthy()
   })
 })
+
+// The footer's version comes from brain's /health, not the constant
+// Vite baked in: release.yml copies an unchanged web image forward, so
+// the baked string goes stale while the backend moves to a new tag.
+describe('Footer version', () => {
+  it('shows the version reported by /health', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((input: RequestInfo | URL) => {
+        if (String(input) === '/health') {
+          return Promise.resolve(
+            new Response(JSON.stringify({ status: 'ok', version: '9.9.9-from-brain' }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          )
+        }
+        return Promise.reject(new Error('no network in tests'))
+      }),
+    )
+    renderAt('/')
+    expect(await screen.findByText(`v9.9.9-from-brain (${__GIT_SHA__})`)).toBeTruthy()
+  })
+
+  it('falls back to the baked version when /health fails', async () => {
+    renderAt('/')
+    expect(await screen.findByText(`v${__APP_VERSION__} (${__GIT_SHA__})`)).toBeTruthy()
+  })
+
+  it('falls back to the baked version while the fetch is in flight', () => {
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+    renderAt('/')
+    expect(screen.getByText(`v${__APP_VERSION__} (${__GIT_SHA__})`)).toBeTruthy()
+  })
+
+  it('falls back to the baked version when /health reports no version', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ status: 'ok' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+    renderAt('/')
+    expect(await screen.findByText(`v${__APP_VERSION__} (${__GIT_SHA__})`)).toBeTruthy()
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { Brain, ChartColumn, ChevronRight, House, KeyRound, Library, MessageCirc
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
 import { toast, Toaster } from 'sonner'
-import { getToken, subscribeNeedToken } from './api/client'
+import { backendVersion, getToken, subscribeNeedToken } from './api/client'
 import { BrandMark } from './components/BrandMark'
 import { SessionList } from './components/SessionList'
 import { SessionsProvider } from './components/SessionsProvider'
@@ -95,6 +95,26 @@ function breadcrumbFor(pathname: string): string[] {
   return [match?.label ?? 'Timothy']
 }
 
+// useRunningVersion reports the version of the brain actually serving
+// this app. The baked-in __APP_VERSION__ can be stale: release.yml
+// copies the web image forward unchanged when nothing under web/
+// changed for a tag, so it keeps the previous tag's string while the
+// backend moves on. Falls back to the baked constant while the fetch
+// is in flight and if it fails, so the footer is never blank.
+function useRunningVersion(): string {
+  const [version, setVersion] = useState('')
+  useEffect(() => {
+    let active = true
+    backendVersion().then((v) => {
+      if (active) setVersion(v)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+  return version || __APP_VERSION__
+}
+
 // AppSidebar is the persistent left navigation: icon-collapsible via
 // the shadcn Sidebar primitive, a flat destination list (this app has
 // no "workspace" concept to group under), and the chat history panel
@@ -122,6 +142,7 @@ function AppSidebar({
   // it from there, same "sticky until touched" feel as the rest of
   // the sidebar's collapse state.
   const [settingsOpen, setSettingsOpen] = useState(() => pathname.startsWith('/settings'))
+  const version = useRunningVersion()
   // Icon-collapsed mode hides the submenu entirely (no room for it),
   // so a click there jumps straight to the first area instead of
   // toggling an invisible expand state.
@@ -234,7 +255,7 @@ function AppSidebar({
           </SidebarMenuItem>
         </SidebarMenu>
         <div className="whitespace-nowrap px-2 py-1 text-xs text-muted-foreground transition-[opacity,visibility] duration-150 ease-out group-data-[collapsible=icon]:invisible group-data-[collapsible=icon]:opacity-0">
-          v{__APP_VERSION__} ({__GIT_SHA__})
+          v{version} ({__GIT_SHA__})
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1704,3 +1704,18 @@ export async function patchSchedule(
 export async function deleteSchedule(id: string): Promise<void> {
   await request<void>(`/v1/schedules/${id}`, { method: 'DELETE' })
 }
+
+// backendVersion reads the running brain's version from /health. That
+// endpoint is unauthenticated and returns no version on a build with
+// none baked in, so this skips `request`'s bearer token and 401
+// handling and returns '' rather than throwing on any failure.
+export async function backendVersion(): Promise<string> {
+  try {
+    const res = await fetch('/health')
+    if (!res.ok) return ''
+    const body = (await res.json()) as { version?: string }
+    return body.version ?? ''
+  } catch {
+    return ''
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
         target: process.env.BRAIN_URL ?? 'http://localhost:8300',
         changeOrigin: true,
       },
+      // brain's /health, which the footer reads for the running version.
+      '/health': {
+        target: process.env.BRAIN_URL ?? 'http://localhost:8300',
+        changeOrigin: true,
+      },
     },
   },
   test: {


### PR DESCRIPTION
Closes #694

## Why

The footer showed a version baked into the web bundle at Docker build time. release.yml copies the web image forward unchanged when nothing under `web/` changed for a tag, so a copy-forwarded image kept the previous tag's string while the backend moved on. Confirmed live: after alpha.83, the footer read alpha.83 while every container was on alpha.84.

## What

`APP_VERSION` was already passed as a build-arg to every image by release.yml; only `web/Dockerfile` consumed it. Now:

- `deploy/Dockerfile` bakes `APP_VERSION` into brain, gateway, memoryd, and sandboxd via `-ldflags -X internal/platform/service.Version=...`. Unset (local `make build`) links an empty string.
- `httpserver.Health` gains a `version` field (omitted when empty); `service.App.health()` and sandboxd's hand-rolled health both report it.
- nginx and the Vite dev proxy gain a `/health` location (brain mounts it outside `/v1/`, unauthenticated).
- The web footer fetches `/health` on mount and shows that version, falling back to the baked `__APP_VERSION__` while in flight or on any failure, so it is never blank. `__GIT_SHA__` stays baked, a fixed build identity rather than a drift-prone "what's running now" value.

## Verify

- Go: `go build`/`go vet` clean, `make test` full suite ok, `make lint` 0 issues.
- Web: build/lint/test clean, 140 files / 1868 tests passed, including 4 new footer-version tests (shows fetched version, falls back on failure/in-flight/no-version-in-response).
- Manually built the brain image both with `APP_VERSION=0.1.0-test` (health reports it) and with no `APP_VERSION` (builds fine, field omitted) via `docker build --target runtime-shell`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791762291&installation_model_id=431401&pr_number=695&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F695&signature=4aae2d6f34fef64fdef8684ad55e3d88912ddb3919b3d032e9c556b7c3c1dc7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->