### PR TITLE
feat(web): shortlist view for ranked-option mission artifacts

### DIFF
--- a/web/src/components/missions/ArtifactShortlist.test.tsx
+++ b/web/src/components/missions/ArtifactShortlist.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { parseOptionShortlist } from '../../lib/optionShortlist'
+import { ArtifactShortlist } from './ArtifactShortlist'
+
+const navigate = vi.fn()
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+afterEach(() => {
+  cleanup()
+  navigate.mockClear()
+})
+
+function option(name: string, pitch: string): string {
+  return [
+    `### ${name}`,
+    `**Pitch:** ${pitch}`,
+    '**Fit:** satisfies R1.',
+    '**Differentiation:** closest is Thing, crowded.',
+    '**Build:** Go service plus a React panel.',
+    '**Demo:** three beats.',
+    '**Why choose it:** the judges asked for it.',
+    '**Why not:** ingest may not finish.',
+    '',
+  ].join('\n')
+}
+
+const doc = [
+  option('Signal Router', 'Routes alerts to the right human.'),
+  option('Ledger Lens', 'Shows where the spend went.'),
+  '## Dropped',
+  '- **Prompt Wrapper:** thin wrapper.',
+].join('\n')
+
+function renderShortlist(text = doc) {
+  const shortlist = parseOptionShortlist(text)!
+  return render(
+    <MemoryRouter>
+      <ArtifactShortlist missionId="m1" shortlist={shortlist} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ArtifactShortlist', () => {
+  it('renders one collapsed row per option with name and pitch', () => {
+    renderShortlist()
+    expect(screen.getByText('Signal Router')).toBeTruthy()
+    expect(screen.getByText('Routes alerts to the right human.')).toBeTruthy()
+    expect(screen.getByText('Ledger Lens')).toBeTruthy()
+    expect(screen.queryByText('three beats.')).toBeNull()
+  })
+
+  it('reveals the full section when a row is expanded', () => {
+    renderShortlist()
+    fireEvent.click(screen.getByText('Signal Router'))
+    expect(screen.getByText('three beats.', { exact: false })).toBeTruthy()
+    expect(screen.getByText('Why not', { exact: false })).toBeTruthy()
+  })
+
+  it('collapses the dropped section by default and shows entries when expanded', () => {
+    renderShortlist()
+    expect(screen.queryByText('thin wrapper.')).toBeNull()
+    fireEvent.click(screen.getByText('Dropped (1)'))
+    expect(screen.getByText('thin wrapper.')).toBeTruthy()
+    expect(screen.getByText('Prompt Wrapper:')).toBeTruthy()
+  })
+
+  it('omits the dropped disclosure when the document has none', () => {
+    renderShortlist(option('Only One', 'A single idea.'))
+    expect(screen.queryByText('Dropped', { exact: false })).toBeNull()
+  })
+
+  it('navigates to the follow-up form with the picked option carried over', () => {
+    renderShortlist()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Pick' })[1])
+    expect(navigate).toHaveBeenCalledWith('/missions/new?parent=m1', {
+      state: {
+        pickedOptionGoal: [
+          'Build "Ledger Lens".',
+          '',
+          'Objective: Shows where the spend went.',
+          'Scope: Go service plus a React panel.',
+        ].join('\n'),
+      },
+    })
+  })
+})

--- a/web/src/components/missions/ArtifactShortlist.tsx
+++ b/web/src/components/missions/ArtifactShortlist.tsx
@@ -1,0 +1,96 @@
+import { ChevronRight, Play } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import type { OptionShortlist, ShortlistOption } from '../../lib/optionShortlist'
+import { followUpGoal } from '../../lib/optionShortlist'
+import { FileMarkdownBlock } from '../FilePreviewBlocks'
+import { Button } from '../ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
+
+function OptionRow({
+  option,
+  rank,
+  onPick,
+}: {
+  option: ShortlistOption
+  rank: number
+  onPick: () => void
+}) {
+  return (
+    <Collapsible className="rounded-md border border-border">
+      <div className="flex items-start gap-2 p-3">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 items-start gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+          <ChevronRight
+            aria-hidden
+            className="mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform duration-100 data-[state=open]:rotate-90"
+          />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium">
+              <span className="mr-2 tabular-nums text-muted-foreground">{rank}.</span>
+              {option.name}
+            </span>
+            {option.pitch !== '' && (
+              <span className="mt-0.5 block text-sm text-muted-foreground">{option.pitch}</span>
+            )}
+          </span>
+        </CollapsibleTrigger>
+        <Button variant="outline" size="sm" className="shrink-0" onClick={onPick}>
+          <Play aria-hidden />
+          Pick
+        </Button>
+      </div>
+      <CollapsibleContent>
+        <div className="border-t border-border">
+          <FileMarkdownBlock text={option.rawMarkdown} raw={false} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+// ArtifactShortlist renders a parsed option shortlist: one collapsed
+// row per option in file order, then the dropped entries in a single
+// collapsed disclosure below.
+export function ArtifactShortlist({
+  missionId,
+  shortlist,
+}: {
+  missionId: string
+  shortlist: OptionShortlist
+}) {
+  const navigate = useNavigate()
+  const pick = (option: ShortlistOption) => {
+    navigate(`/missions/new?parent=${encodeURIComponent(missionId)}`, {
+      state: { pickedOptionGoal: followUpGoal(option) },
+    })
+  }
+  return (
+    <div className="space-y-2 p-3">
+      {shortlist.options.map((option, i) => (
+        <OptionRow key={option.name} option={option} rank={i + 1} onPick={() => pick(option)} />
+      ))}
+      {shortlist.dropped && (
+        <Collapsible className="rounded-md border border-border">
+          <CollapsibleTrigger className="flex w-full items-center gap-2 p-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+            <ChevronRight
+              aria-hidden
+              className="size-4 shrink-0 text-muted-foreground transition-transform duration-100 data-[state=open]:rotate-90"
+            />
+            <span className="text-sm text-muted-foreground">
+              Dropped ({shortlist.dropped.entries.length})
+            </span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="space-y-1.5 border-t border-border p-3">
+              {shortlist.dropped.entries.map((entry, i) => (
+                <li key={i} className="text-sm">
+                  {entry.name && <span className="font-medium">{entry.name}: </span>}
+                  <span className="text-muted-foreground">{entry.reason}</span>
+                </li>
+              ))}
+            </ul>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/FileViewer.test.tsx
+++ b/web/src/components/missions/FileViewer.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MissionFile } from '../../api/types'
 import { FileViewer } from './FileViewer'
@@ -163,5 +164,59 @@ describe('FileViewer', () => {
     expect(exportMissionPdf).toHaveBeenCalledWith('m1', 'notes.md')
     await screen.findByRole('button', { name: 'Export this file as a typeset PDF' })
     expect(downloadMissionPdfExport).toHaveBeenCalledWith('att-1', 'notes.pdf')
+  })
+})
+
+const shortlistDoc = [
+  '### Signal Router',
+  '**Pitch:** Routes alerts to the right human.',
+  '**Fit:** satisfies R1.',
+  '**Differentiation:** closest is Thing, crowded.',
+  '**Build:** Go service plus a React panel.',
+  '**Demo:** three beats.',
+  '**Why choose it:** the judges asked for it.',
+  '**Why not:** ingest may not finish.',
+].join('\n')
+
+describe('FileViewer option shortlist', () => {
+  it('renders a matching markdown artifact as the shortlist view', async () => {
+    vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob([shortlistDoc]))
+    render(
+      <MemoryRouter>
+        <FileViewer missionId="m1" file={file('ideas.md')} />
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Signal Router')
+    expect(screen.getByText('Routes alerts to the right human.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Pick' })).toBeTruthy()
+    expect(screen.queryByText('three beats.', { exact: false })).toBeNull()
+  })
+
+  it('still shows the plain source when raw markdown is toggled on', async () => {
+    vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob([shortlistDoc]))
+    render(
+      <MemoryRouter>
+        <FileViewer missionId="m1" file={file('ideas.md')} />
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('Signal Router')
+    fireEvent.click(screen.getByRole('button', { name: 'Show raw markdown source' }))
+    expect(await screen.findByText('**Pitch:**', { exact: false })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Pick' })).toBeNull()
+  })
+
+  it('renders a non-matching markdown artifact as plain markdown', async () => {
+    vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob(['# Report\n\n### Background\n\nProse.']))
+    render(
+      <MemoryRouter>
+        <FileViewer missionId="m1" file={file('report.md')} />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('heading', { name: 'Report' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Background' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Pick' })).toBeNull()
   })
 })

--- a/web/src/components/missions/FileViewer.tsx
+++ b/web/src/components/missions/FileViewer.tsx
@@ -19,6 +19,8 @@ import { CopyButton } from '../Message'
 import { errText } from '../../lib/errors'
 import { TooltipProvider } from '../ui/tooltip'
 import { previewKindOf } from './filePreviewKind'
+import { parseOptionShortlist } from '../../lib/optionShortlist'
+import { ArtifactShortlist } from './ArtifactShortlist'
 
 function humanSize(n: number): string {
   if (n < 1024) return `${n} B`
@@ -126,6 +128,8 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
   }
 
   const lineCount = state.status === 'text' ? state.text.split('\n').length : undefined
+  const shortlist =
+    kind === 'markdown' && state.status === 'text' ? parseOptionShortlist(state.text) : null
 
   return (
     <TooltipProvider>
@@ -203,7 +207,11 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
             <iframe src={state.url} title={file.path} className="size-full border-0" />
           )}
           {state.status === 'text' && kind === 'markdown' && (
-            <FileMarkdownBlock text={state.text} raw={showRawMarkdown} />
+            shortlist && !showRawMarkdown ? (
+              <ArtifactShortlist missionId={missionId} shortlist={shortlist} />
+            ) : (
+              <FileMarkdownBlock text={state.text} raw={showRawMarkdown} />
+            )
           )}
           {state.status === 'text' && kind === 'code' && (
             <FileCodeBlock code={state.text} path={file.path} />

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -623,6 +623,30 @@ describe('MissionForm: follow-up', () => {
       ),
     )
   })
+
+  it('seeds the goal field from initialGoal and submits it', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm-picked' } as Mission)
+    renderForm(
+      <MissionForm
+        mode="create"
+        initialGoal={'Build "Signal Router".\n\nObjective: Routes alerts.'}
+        parentMissionId="parent-1"
+        onDone={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText('Goal')).toHaveValue(
+      'Build "Signal Router".\n\nObjective: Routes alerts.',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: 'Build "Signal Router".\n\nObjective: Routes alerts.' }),
+      ),
+    )
+  })
 })
 
 describe('MissionForm: kind and light pre-fill (#447)', () => {

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -303,6 +303,7 @@ export function MissionForm({
   mode,
   schedule,
   initial,
+  initialGoal,
   parentMissionId,
   onDone,
   onCancel,
@@ -310,11 +311,15 @@ export function MissionForm({
   mode: 'create' | 'edit'
   schedule?: Schedule
   // initial seeds the form's create-mode state from a parent mission
-  // (a follow-up): everything except goal, which is left empty for
-  // the user to type. Read only once, in the useState initializers
+  // (a follow-up): everything except goal, which comes from
+  // initialGoal or is left empty for the user to type. Read only
+  // once, in the useState initializers
   // below, so the caller must render this component only once initial
   // is settled (e.g. after an async parent fetch resolves).
   initial?: Partial<CreateMissionInput>
+  // initialGoal seeds the goal field (a follow-up from a picked
+  // shortlist option). Read only once, same contract as initial.
+  initialGoal?: string
   // parentMissionId, when set, is included on the create payload:
   // makes this a follow-up mission (see CreateMissionInput).
   parentMissionId?: string
@@ -324,7 +329,7 @@ export function MissionForm({
   const agents = useAgents()
   const routes = useRoutes()
   const enabledRoutes = routes?.filter((r) => r.enabled) ?? []
-  const [goal, setGoal] = useState('')
+  const [goal, setGoal] = useState(initialGoal ?? '')
   const goalWordCount = useMemo(
     () => (goal.trim() === '' ? 0 : goal.trim().split(/\s+/).length),
     [goal],

--- a/web/src/lib/optionShortlist.test.ts
+++ b/web/src/lib/optionShortlist.test.ts
@@ -91,6 +91,44 @@ describe('parseOptionShortlist', () => {
     expect(parseOptionShortlist('   \n\n')).toBeNull()
   })
 
+  it('folds a continuation into a field whose own line carried no text', () => {
+    const text = option('Empty Label', 'Line one.').replace(
+      '**Build:** Go service plus a React panel.',
+      '**Build:**\nGo service plus a React panel.',
+    )
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.options[0].fields[3].text).toBe('Go service plus a React panel.')
+  })
+
+  it('ignores a level-2 section that is not the dropped list', () => {
+    const text = [option('Kept', 'A kept idea.'), '## Notes', '- not a dropped entry'].join('\n')
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.options).toHaveLength(1)
+    expect(parsed!.dropped).toBeUndefined()
+  })
+
+  it('leaves dropped unset when the section carries no entries', () => {
+    const text = [option('Kept', 'A kept idea.'), '## Dropped', '', '   '].join('\n')
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.options).toHaveLength(1)
+    expect(parsed!.dropped).toBeUndefined()
+  })
+
+  it('parses dropped entries written as plain lines', () => {
+    const text = [
+      option('Kept', 'A kept idea.'),
+      '## Dropped',
+      '',
+      'Prompt Wrapper: thin wrapper, no agent work.',
+      'violates R3 (team size)',
+    ].join('\n')
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.dropped!.entries).toEqual([
+      { name: 'Prompt Wrapper', reason: 'thin wrapper, no agent work.' },
+      { reason: 'violates R3 (team size)' },
+    ])
+  })
+
   it('ignores headings inside fenced code blocks', () => {
     const text = ['# Doc', '', '```md', option('Fenced', 'Inside a fence.'), '```'].join('\n')
     expect(parseOptionShortlist(text)).toBeNull()
@@ -107,6 +145,18 @@ describe('followUpGoal', () => {
         'Objective: Routes alerts.',
         'Scope: Go service plus a React panel.',
       ].join('\n'),
+    )
+  })
+
+  it('omits the scope line when the option carries no build text', () => {
+    const parsed = parseOptionShortlist(
+      option('No Build', 'Just an objective.').replace(
+        '**Build:** Go service plus a React panel.',
+        '**Build:**',
+      ),
+    )
+    expect(followUpGoal(parsed!.options[0])).toBe(
+      ['Build "No Build".', '', 'Objective: Just an objective.'].join('\n'),
     )
   })
 })

--- a/web/src/lib/optionShortlist.test.ts
+++ b/web/src/lib/optionShortlist.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { followUpGoal, parseOptionShortlist } from './optionShortlist'
+
+function option(name: string, pitch: string): string {
+  return [
+    `### ${name}`,
+    `**Pitch:** ${pitch}`,
+    '**Fit:** satisfies R1 and R4.',
+    '**Differentiation:** closest is [Thing](https://example.com/thing), crowded.',
+    '**Build:** Go service plus a React panel.',
+    '**Demo:** three beats ending on the graph.',
+    '**Why choose it:** the judges asked for exactly this.',
+    '**Why not:** the ingest path may not finish in time.',
+    '',
+  ].join('\n')
+}
+
+describe('parseOptionShortlist', () => {
+  it('parses a multi-option document with a dropped section', () => {
+    const text = [
+      'Ranked against R1-R9.',
+      '',
+      option('Signal Router', 'Routes alerts to the right on-call human.'),
+      option('Ledger Lens', 'Shows where the token spend actually went.'),
+      '## Dropped',
+      '- **Prompt Wrapper:** thin wrapper, no agent work.',
+      '- Chat over PDFs: crowded.',
+      '- violates R3 (team size)',
+    ].join('\n')
+
+    const parsed = parseOptionShortlist(text)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.options.map((o) => o.name)).toEqual(['Signal Router', 'Ledger Lens'])
+    expect(parsed!.options[0].pitch).toBe('Routes alerts to the right on-call human.')
+    expect(parsed!.options[0].fields.map((f) => f.label)).toEqual([
+      'Pitch',
+      'Fit',
+      'Differentiation',
+      'Build',
+      'Demo',
+      'Why choose it',
+      'Why not',
+    ])
+    expect(parsed!.options[0].fields[3].text).toBe('Go service plus a React panel.')
+    expect(parsed!.options[0].rawMarkdown.startsWith('### Signal Router')).toBe(true)
+    expect(parsed!.dropped!.entries).toEqual([
+      { name: 'Prompt Wrapper', reason: 'thin wrapper, no agent work.' },
+      { name: 'Chat over PDFs', reason: 'crowded.' },
+      { reason: 'violates R3 (team size)' },
+    ])
+  })
+
+  it('parses a document with no dropped section', () => {
+    const parsed = parseOptionShortlist(option('Only One', 'A single idea.'))
+    expect(parsed!.options).toHaveLength(1)
+    expect(parsed!.dropped).toBeUndefined()
+  })
+
+  it('tolerates label casing and spacing differences', () => {
+    const text = option('Loose', 'Loose labels.')
+      .replace('**Pitch:**', '**pitch:**')
+      .replace('**Why choose it:**', '**Why  Choose It:**')
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.options[0].pitch).toBe('Loose labels.')
+  })
+
+  it('folds a wrapped field continuation into the field text', () => {
+    const text = option('Wrapped', 'Line one.').replace(
+      '**Build:** Go service plus a React panel.',
+      '**Build:** Go service\nplus a React panel.',
+    )
+    const parsed = parseOptionShortlist(text)
+    expect(parsed!.options[0].fields[3].text).toBe('Go service\nplus a React panel.')
+  })
+
+  it('does not match prose with an unrelated level-3 heading', () => {
+    const text = ['# Report', '', '### Background', '', 'Some prose about the problem.'].join('\n')
+    expect(parseOptionShortlist(text)).toBeNull()
+  })
+
+  it('does not match a section missing a required label', () => {
+    const text = option('Partial', 'Missing a label.').replace(
+      '**Why not:** the ingest path may not finish in time.\n',
+      '',
+    )
+    expect(parseOptionShortlist(text)).toBeNull()
+  })
+
+  it('does not match an empty document', () => {
+    expect(parseOptionShortlist('')).toBeNull()
+    expect(parseOptionShortlist('   \n\n')).toBeNull()
+  })
+
+  it('ignores headings inside fenced code blocks', () => {
+    const text = ['# Doc', '', '```md', option('Fenced', 'Inside a fence.'), '```'].join('\n')
+    expect(parseOptionShortlist(text)).toBeNull()
+  })
+})
+
+describe('followUpGoal', () => {
+  it('formats the pitch as objective and the build line as scope', () => {
+    const parsed = parseOptionShortlist(option('Signal Router', 'Routes alerts.'))
+    expect(followUpGoal(parsed!.options[0])).toBe(
+      [
+        'Build "Signal Router".',
+        '',
+        'Objective: Routes alerts.',
+        'Scope: Go service plus a React panel.',
+      ].join('\n'),
+    )
+  })
+})

--- a/web/src/lib/optionShortlist.ts
+++ b/web/src/lib/optionShortlist.ts
@@ -63,7 +63,6 @@ function parseDropped(body: string[]): DroppedEntry[] {
     if (line === '') continue
     const item = /^(?:[-*+]|\d+\.)\s+(.*)$/.exec(line)
     const text = item ? item[1].trim() : line
-    if (text === '') continue
     const named = /^\*\*(.+?):?\*\*:?\s*(.*)$/.exec(text)
     if (named && named[2].trim() !== '') {
       entries.push({ name: named[1].trim(), reason: named[2].trim() })

--- a/web/src/lib/optionShortlist.ts
+++ b/web/src/lib/optionShortlist.ts
@@ -1,0 +1,139 @@
+// Detects and parses a ranked-option shortlist artifact: level-3
+// sections carrying bold-labeled fields (the shape the hackathon
+// skill's ideas.md uses), optionally followed by a `## Dropped`
+// section listing cut candidates one line each.
+
+export type OptionField = { label: string; text: string }
+
+export type ShortlistOption = {
+  name: string
+  pitch: string
+  fields: OptionField[]
+  rawMarkdown: string
+}
+
+export type DroppedEntry = { name?: string; reason: string }
+
+export type OptionShortlist = {
+  options: ShortlistOption[]
+  dropped?: { entries: DroppedEntry[] }
+}
+
+// Labels an option section must carry to count as the option template.
+const REQUIRED_LABELS = [
+  'pitch',
+  'fit',
+  'differentiation',
+  'build',
+  'demo',
+  'why choose it',
+  'why not',
+]
+
+const HEADING_RE = /^(#{2,3})\s+(.+?)\s*#*\s*$/
+const FIELD_RE = /^\*\*(.+?):?\*\*:?\s*(.*)$/
+
+function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+function parseFields(body: string[]): OptionField[] {
+  const fields: OptionField[] = []
+  for (const line of body) {
+    const m = FIELD_RE.exec(line.trim())
+    if (m) {
+      fields.push({ label: m[1].trim(), text: m[2].trim() })
+      continue
+    }
+    if (fields.length > 0 && line.trim() !== '') {
+      const last = fields[fields.length - 1]
+      last.text = last.text === '' ? line.trim() : `${last.text}\n${line.trim()}`
+    }
+  }
+  return fields
+}
+
+// Dropped entries are one line each ("`## Dropped` also carries the
+// pool candidates that were cut, one line each with the reason"), so
+// they parse as list items, with an optional bold name prefix.
+function parseDropped(body: string[]): DroppedEntry[] {
+  const entries: DroppedEntry[] = []
+  for (const raw of body) {
+    const line = raw.trim()
+    if (line === '') continue
+    const item = /^(?:[-*+]|\d+\.)\s+(.*)$/.exec(line)
+    const text = item ? item[1].trim() : line
+    if (text === '') continue
+    const named = /^\*\*(.+?):?\*\*:?\s*(.*)$/.exec(text)
+    if (named && named[2].trim() !== '') {
+      entries.push({ name: named[1].trim(), reason: named[2].trim() })
+      continue
+    }
+    const colon = /^([^:]{1,80}):\s*(.+)$/.exec(text)
+    if (colon) {
+      entries.push({ name: colon[1].trim(), reason: colon[2].trim() })
+      continue
+    }
+    entries.push({ reason: text })
+  }
+  return entries
+}
+
+// parseOptionShortlist returns the parsed shortlist, or null when the
+// document does not follow the option template.
+export function parseOptionShortlist(text: string): OptionShortlist | null {
+  if (!text.trim()) return null
+  const lines = text.split('\n')
+
+  type Block = { level: number; title: string; body: string[]; raw: string[] }
+  const blocks: Block[] = []
+  let current: Block | undefined
+  let inFence = false
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence
+    const m = inFence ? null : HEADING_RE.exec(line)
+    if (m) {
+      current = { level: m[1].length, title: m[2].trim(), body: [], raw: [line] }
+      blocks.push(current)
+      continue
+    }
+    if (current) {
+      current.body.push(line)
+      current.raw.push(line)
+    }
+  }
+
+  const options: ShortlistOption[] = []
+  let dropped: { entries: DroppedEntry[] } | undefined
+  for (const block of blocks) {
+    if (block.level === 2) {
+      if (normalizeLabel(block.title) === 'dropped') {
+        const entries = parseDropped(block.body)
+        if (entries.length > 0) dropped = { entries }
+      }
+      continue
+    }
+    const fields = parseFields(block.body)
+    const labels = new Set(fields.map((f) => normalizeLabel(f.label)))
+    if (!REQUIRED_LABELS.every((l) => labels.has(l))) continue
+    const pitch = fields.find((f) => normalizeLabel(f.label) === 'pitch')?.text ?? ''
+    options.push({
+      name: block.title,
+      pitch,
+      fields,
+      rawMarkdown: block.raw.join('\n').trimEnd(),
+    })
+  }
+
+  if (options.length === 0) return null
+  return dropped ? { options, dropped } : { options }
+}
+
+// followUpGoal formats a picked option as follow-up goal text, in the
+// objective/scope shape the followup_mission brief uses.
+export function followUpGoal(option: ShortlistOption): string {
+  const build = option.fields.find((f) => normalizeLabel(f.label) === 'build')?.text ?? ''
+  const parts = [`Build "${option.name}".`, '', `Objective: ${option.pitch}`]
+  if (build.trim() !== '') parts.push(`Scope: ${build}`)
+  return parts.join('\n')
+}

--- a/web/src/pages/NewMission.test.tsx
+++ b/web/src/pages/NewMission.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NewMission } from './NewMission'
+
+vi.mock('../api/client', () => ({ getMission: vi.fn() }))
+vi.mock('../components/missions/MissionForm', () => ({
+  MissionForm: ({ initialGoal }: { initialGoal?: string }) => (
+    <div data-testid="seeded-goal">{initialGoal ?? ''}</div>
+  ),
+}))
+
+import { getMission } from '../api/client'
+
+afterEach(cleanup)
+
+describe('NewMission', () => {
+  it('passes a picked shortlist option through as the seeded goal', async () => {
+    vi.mocked(getMission).mockResolvedValue({ id: 'parent-1', kind: 'general' } as never)
+    render(
+      <MemoryRouter
+        initialEntries={[
+          { pathname: '/missions/new', search: '?parent=parent-1', state: { pickedOptionGoal: 'Build "X".' } },
+        ]}
+      >
+        <NewMission />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('seeded-goal')).toHaveTextContent('Build "X".'))
+  })
+
+  it('seeds no goal for a plain new mission', () => {
+    render(
+      <MemoryRouter initialEntries={['/missions/new']}>
+        <NewMission />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByTestId('seeded-goal')).toHaveTextContent('')
+  })
+})

--- a/web/src/pages/NewMission.tsx
+++ b/web/src/pages/NewMission.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router'
+import { useLocation, useNavigate, useSearchParams } from 'react-router'
 import { getMission, type CreateMissionInput } from '../api/client'
 import type { Mission } from '../api/types'
 import { MissionForm } from '../components/missions/MissionForm'
@@ -30,6 +30,10 @@ export function NewMission() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const parentID = searchParams.get('parent') ?? undefined
+  // A shortlist pick carries its goal text through router state
+  // rather than the URL: an option's section is long and means
+  // nothing as a query param.
+  const { pickedOptionGoal } = (useLocation().state ?? {}) as { pickedOptionGoal?: string }
 
   // MissionForm's initial prop only ever seeds its useState
   // initializers (they run once) — so a follow-up's form must not
@@ -68,6 +72,7 @@ export function NewMission() {
           <MissionForm
             mode="create"
             initial={parent ? missionToInitial(parent) : undefined}
+            initialGoal={pickedOptionGoal}
             parentMissionId={parent?.id}
             onCancel={() => navigate(-1)}
             onDone={(result) => {


### PR DESCRIPTION
Closes #637

## Why

A mission that ends in a ranked shortlist (`ideas.md` from the hackathon skill, first among them) renders today as one plain markdown document. Comparing option 2 against option 4 means scrolling between two page-long sections; picking one means leaving the page to write a follow-up goal by hand.

## What

- `optionShortlist.ts`: detects and parses the option template (a level-3 heading whose body carries all seven bold fields: Pitch, Fit, Differentiation, Build, Demo, Why choose it, Why not). A `## Dropped` section, when present, parses as one-line entries (list items or plain lines), with an optional name prefix. No SKILL.md-produced `ideas.md` exists in the repo to check against, so the dropped shape follows the skill text's own description ("one line each with the reason") rather than the full-page option shape.
- `ArtifactShortlist.tsx`: one collapsed row per option in file order (no re-ranking), pitch visible collapsed, expands to the full section via the existing `FileMarkdownBlock`. Dropped entries sit in one collapsed disclosure below. Each row has a Pick button.
- `FileViewer.tsx`: renders the shortlist view instead of plain markdown when the document matches and the raw-markdown toggle is off; toggling raw still shows the plain source.
- Pick wiring: navigates to `/missions/new?parent=<id>` (so the existing follow-up config seeding still applies) with the option's name and Build line carried over as router state, consumed by a new `MissionForm` `initialGoal` prop that seeds the goal field once, same "read only once" contract `initial` already has. Goal text mirrors the objective/scope shape `followup_mission`'s brief uses.
- Non-matching documents render exactly as before; verified explicitly in tests.

## Verify

Docker `node:24.18.0-alpine`: build ok, lint 0 errors, 143 test files / 1884 tests passed. New tests: 10 detector/parser cases, 5 component cases, 3 FileViewer cases, 2 NewMission cases, 1 MissionForm case for `initialGoal`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763445&installation_model_id=431401&pr_number=696&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F696&signature=6b1d3c938ace437f6a26696019341f9c766f67e37f9976227e81977293187db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->