### PR TITLE
feat(destinations): pr attribution line with settings switch

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -341,6 +341,9 @@ func main() {
 			githubPR = connsPRSource{conns}
 		}
 		githubAdapter = destinations.NewGitHubAdapter(missionWorkspace, missionStore, resolveGitHubToken, githubPR)
+		githubAdapter.Attribution = func(ctx context.Context) bool {
+			return flags.Enabled(ctx, settings.KeyPRAttribution)
+		}
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, githubAdapter, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {

--- a/internal/brain/destinations/github.go
+++ b/internal/brain/destinations/github.go
@@ -67,6 +67,14 @@ type GitHubAdapter struct {
 	Events       events
 	ResolveToken PushTokenResolver
 	PR           PRSource
+	// Attribution reports whether PR bodies end with the Timothy Agent
+	// line (settings.KeyPRAttribution); nil means on.
+	Attribution func(context.Context) bool
+}
+
+// attribution resolves the Attribution hook with its nil default.
+func (a *GitHubAdapter) attribution(ctx context.Context) bool {
+	return a.Attribution == nil || a.Attribution(ctx)
 }
 
 // NewGitHubAdapter builds a GitHubAdapter. resolveToken/pr may be nil
@@ -104,8 +112,9 @@ func (a *GitHubAdapter) PushBranch(ctx context.Context, m missions.Mission, toke
 }
 
 // PRBody composes the pull request's markdown body: goal, unit list
-// with pass state, and a short harness-verification line.
-func PRBody(m missions.Mission) string {
+// with pass state, and, when attribution is on, a closing line
+// crediting Timothy Agent with a link to its repository.
+func PRBody(m missions.Mission, attribution bool) string {
 	body := m.Goal + "\n\n"
 	if len(m.Plan.Units) > 0 {
 		body += "## Units\n\n"
@@ -118,7 +127,9 @@ func PRBody(m missions.Mission) string {
 		}
 		body += "\n"
 	}
-	body += "_Verified by Timothy's mission harness (declared artifacts + verify_cmd, checked by the harness itself, never claimed by the model)._\n"
+	if attribution {
+		body += "_PR was created by [Timothy Agent](https://github.com/timothy-agent/timothy)._\n"
+	}
 	return body
 }
 
@@ -157,7 +168,7 @@ func (a *GitHubAdapter) openPRFor(ctx context.Context, m missions.Mission, token
 	if base == "" {
 		return "", 0, fmt.Errorf("pr: repo has no default branch")
 	}
-	url, number, err = a.PR.CreatePR(ctx, connectorID, owner, repo, missions.PRTitle(m), m.Branch, base, PRBody(m))
+	url, number, err = a.PR.CreatePR(ctx, connectorID, owner, repo, missions.PRTitle(m), m.Branch, base, PRBody(m, a.attribution(ctx)))
 	if err != nil {
 		return "", 0, fmt.Errorf("pr: %w", err)
 	}

--- a/internal/brain/destinations/github_test.go
+++ b/internal/brain/destinations/github_test.go
@@ -3,6 +3,7 @@ package destinations
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -388,4 +389,34 @@ func TestDeliverMissionModes(t *testing.T) {
 			t.Fatal("DeliverMission with a rejected push: want an error, got nil")
 		}
 	})
+}
+
+func TestPRBody(t *testing.T) {
+	m := missions.Mission{Goal: "Add base62"}
+	m.Plan.Units = []missions.PlanUnit{{Title: "encode", Passes: true}, {Title: "decode"}}
+	got := PRBody(m, true)
+	for _, want := range []string{
+		"Add base62\n\n## Units\n\n",
+		"- [x] encode\n",
+		"- [ ] decode\n",
+		"_PR was created by [Timothy Agent](https://github.com/timothy-agent/timothy)._\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PRBody missing %q in:\n%s", want, got)
+		}
+	}
+	if off := PRBody(m, false); strings.Contains(off, "Timothy Agent") {
+		t.Errorf("PRBody(attribution=false) still carries the attribution line:\n%s", off)
+	}
+}
+
+func TestGitHubAdapterAttributionDefaultsOn(t *testing.T) {
+	a := &GitHubAdapter{}
+	if !a.attribution(context.Background()) {
+		t.Fatal("nil Attribution hook = false, want true")
+	}
+	a.Attribution = func(context.Context) bool { return false }
+	if a.attribution(context.Background()) {
+		t.Fatal("Attribution hook returning false was ignored")
+	}
 }

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -30,11 +30,16 @@ const (
 	// switch here it defaults OFF for an absent row (knownKeysOff), since
 	// enabling it means real gateway spend the operator must opt into.
 	KeyKBImageCaptioning = "kb_image_captioning_enabled"
+	// KeyPRAttribution gates the closing line on pull requests the
+	// github destination opens, crediting Timothy Agent with a link to
+	// its repository. Default on; off leaves the PR body at goal and
+	// units only.
+	KeyPRAttribution = "pr_attribution_enabled"
 )
 
 var knownKeys = map[string]bool{
 	KeyTools: true, KeyMemoryExtraction: true, KeyCompaction: true, KeyScheduler: true,
-	KeyKBImageCaptioning: true,
+	KeyKBImageCaptioning: true, KeyPRAttribution: true,
 }
 
 // knownKeysOff lists switches from knownKeys whose absent-row default is

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -69,6 +69,10 @@ const featureCopy: Record<string, { label: string; description: string }> = {
     label: 'KB image captioning',
     description: 'On: images in ingested documents get a vision-model caption, spending gateway tokens per image.',
   },
+  pr_attribution_enabled: {
+    label: 'PR attribution',
+    description: 'On: pull requests Timothy opens end with a line crediting Timothy Agent and linking to its repository.',
+  },
 }
 
 export function FeaturesTab() {


### PR DESCRIPTION
Replaces the harness verification sentence on delivered PRs with "PR was created by Timothy Agent" linking to this repository, and adds the `pr_attribution_enabled` switch (default on) to Settings > Features so the footer can be turned off.

Closes #697

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791774126&installation_model_id=431401&pr_number=700&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F700&signature=20a4f589690a3f569ab3a08676c381194ed9b32235a74f405e4e83d2720524e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->