### PR TITLE
fix(missions): turn model on executor death, empty tool output on Responses

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -1091,13 +1091,30 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, run cliR
 	case runEndResult:
 		return r.finish(ctx, m, run, st, start, exitCode)
 	case runEndIdle:
-		return forcedRetryVerdict("the executor produced no output for the idle timeout and was killed"), st.textBuf.String(), nil
+		v := forcedRetryVerdict("the executor produced no output for the idle timeout and was killed")
+		stampServed(&v, run, st)
+		return v, st.textBuf.String(), nil
 	default:
 		reason, err := r.finishNoResult(ctx, m, run, workRoot, rdir, st, start, exitCode)
 		if err != nil {
 			return WorkerVerdict{}, st.textBuf.String(), err
 		}
-		return forcedRetryVerdict(reason), st.textBuf.String(), nil
+		v := forcedRetryVerdict(reason)
+		stampServed(&v, run, st)
+		return v, st.textBuf.String(), nil
+	}
+}
+
+// stampServed records which chain entry ran the turn on the verdict
+// (issue #701): the paired entry's provider and model, the harness's
+// own reported model taking precedence, same rule recordLedger uses.
+// Applied on every worker end, including deaths, since the entry is
+// known before the process ever starts.
+func stampServed(v *WorkerVerdict, run cliRun, st *pollState) {
+	v.Provider = run.entry.ProviderName
+	v.Model = run.entry.Model
+	if st.reportedModel != "" {
+		v.Model = st.reportedModel
 	}
 }
 
@@ -1452,15 +1469,7 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st 
 			verdict = forcedRetryVerdict("executor finished without a status report")
 		}
 	}
-	// issue #507: the executor did produce a result (or a text-form
-	// sentinel), so the entry that ran it is who served the turn.
-	// reportedModel (the harness's own claimed model) takes precedence
-	// over entry.Model, same precedence recordLedger already uses.
-	verdict.Provider = run.entry.ProviderName
-	verdict.Model = run.entry.Model
-	if st.reportedModel != "" {
-		verdict.Model = st.reportedModel
-	}
+	stampServed(&verdict, run, st)
 
 	if err := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, strings.ToUpper(verdict.Outcome)); err != nil {
 		return WorkerVerdict{}, st.textBuf.String(), err

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -607,6 +607,11 @@ func TestDelegatedRunWorker_MissingResult_ForcedRetry(t *testing.T) {
 	if events.count("executor.died") != 1 {
 		t.Fatalf("executor.died count = %d, want 1", events.count("executor.died"))
 	}
+	// issue #701: a death still names the entry that ran, so the turn
+	// timeline shows the model instead of falling back to the route.
+	if verdict.Provider != entry.ProviderName || verdict.Model != entry.Model {
+		t.Fatalf("verdict provider/model = %q/%q, want %q/%q", verdict.Provider, verdict.Model, entry.ProviderName, entry.Model)
+	}
 }
 
 // --- scenario 2b: wall-clock run budget hit (issue #498) -----------------
@@ -671,6 +676,9 @@ func TestDelegatedRunWorker_IdleHang_KilledAndRetried(t *testing.T) {
 	}
 	if events.count("executor.idle_killed") != 1 {
 		t.Fatalf("executor.idle_killed count = %d, want 1", events.count("executor.idle_killed"))
+	}
+	if verdict.Provider != entry.ProviderName || verdict.Model != entry.Model {
+		t.Fatalf("verdict provider/model = %q/%q, want %q/%q", verdict.Provider, verdict.Model, entry.ProviderName, entry.Model)
 	}
 }
 

--- a/internal/gateway/provider/openairesponses.go
+++ b/internal/gateway/provider/openairesponses.go
@@ -71,8 +71,10 @@ type orsInputItem struct {
 	CallID    string `json:"call_id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
-	// function_call_output field
-	Output string `json:"output,omitempty"`
+	// function_call_output field: a pointer so an empty tool result
+	// still serializes as "output": "", which the API requires on
+	// every function_call_output item (issue #702).
+	Output *string `json:"output,omitempty"`
 }
 
 type orsTool struct {
@@ -224,7 +226,7 @@ func appendMessage(items []orsInputItem, m Message) []orsInputItem {
 			output = "ERROR: " + output
 		}
 		return append(items, orsInputItem{
-			Type: "function_call_output", CallID: m.ToolResult.ID, Output: output,
+			Type: "function_call_output", CallID: m.ToolResult.ID, Output: &output,
 		})
 	case len(m.ToolCalls) > 0:
 		if m.Content != "" {

--- a/internal/gateway/provider/openairesponses_test.go
+++ b/internal/gateway/provider/openairesponses_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -275,8 +276,24 @@ func TestOpenAIResponsesContinuationMatchingDriver(t *testing.T) {
 	if len(got.Input) != 1 {
 		t.Fatalf("input items = %d, want 1 (only the tool result): %+v", len(got.Input), got.Input)
 	}
-	if got.Input[0].Type != "function_call_output" || got.Input[0].CallID != "call_1" || got.Input[0].Output != "sunny" {
+	if got.Input[0].Type != "function_call_output" || got.Input[0].CallID != "call_1" || got.Input[0].Output == nil || *got.Input[0].Output != "sunny" {
 		t.Fatalf("input[0] = %+v", got.Input[0])
+	}
+}
+
+// TestOpenAIResponsesEmptyToolResultKeepsOutputField pins issue #702: a
+// tool that returned nothing must still serialize "output": "" on its
+// function_call_output item, or the API rejects the whole request with
+// missing_required_parameter.
+func TestOpenAIResponsesEmptyToolResultKeepsOutputField(t *testing.T) {
+	t.Parallel()
+	items := appendMessage(nil, Message{Role: "tool", ToolResult: &ToolResult{ID: "call_1", Content: ""}})
+	raw, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"output":""`) {
+		t.Fatalf("empty tool result dropped the output field: %s", raw)
 	}
 }
 


### PR DESCRIPTION
## Why

Two harness defects surfaced while running molla-go Slice 1 on homelab:

- Death-path verdicts (idle kill, run budget, missing result) carried no provider or model, so the mission timeline showed the route name instead of the model. `stampServed` fills both from the served entry and the reported model.
- The OpenAI Responses driver dropped `output` on an empty tool result via `omitempty`. OpenAI answers `400 Missing required parameter: 'input[N].output'`, and the discover phase burned every iteration on it. `Output` is now a `*string` so `""` is sent.

Closes #701
Closes #702

## Verification

- `go test -race ./internal/brain/missions/ ./internal/gateway/provider/` green in the toolchain container.
- New tests: `TestOpenAIResponsesEmptyToolResultKeepsOutputField`, model assertions in the two death-path runner tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791775584&installation_model_id=431401&pr_number=703&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F703&signature=adf98c0fa41cc834677b3f6fbb95337c8be14087f0e6bf90c7607bba74b57c0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->