### PR TITLE
feat(destinations): pull request titles follow Conventional Commits

### DIFF
--- a/internal/brain/destinations/github.go
+++ b/internal/brain/destinations/github.go
@@ -157,7 +157,7 @@ func (a *GitHubAdapter) openPRFor(ctx context.Context, m missions.Mission, token
 	if base == "" {
 		return "", 0, fmt.Errorf("pr: repo has no default branch")
 	}
-	url, number, err = a.PR.CreatePR(ctx, connectorID, owner, repo, missions.PRTitle(m), m.Branch, base, PRBody(m))
+	url, number, err = a.PR.CreatePR(ctx, connectorID, owner, repo, missions.ConventionalPRTitle(m), m.Branch, base, PRBody(m))
 	if err != nil {
 		return "", 0, fmt.Errorf("pr: %w", err)
 	}

--- a/internal/brain/destinations/github_test.go
+++ b/internal/brain/destinations/github_test.go
@@ -39,6 +39,7 @@ type fakePRSource struct {
 	prNumber      int
 	createErr     error
 	createCalls   int
+	lastTitle     string
 
 	repoExists      bool
 	existsErr       error
@@ -52,8 +53,9 @@ func (f *fakePRSource) DefaultBranch(_ context.Context, _, _, _ string) (string,
 	return f.defaultBranch, f.defaultErr
 }
 
-func (f *fakePRSource) CreatePR(_ context.Context, _, _, _, _, _, _, _ string) (string, int, error) {
+func (f *fakePRSource) CreatePR(_ context.Context, _, _, _, title, _, _, _ string) (string, int, error) {
 	f.createCalls++
+	f.lastTitle = title
 	if f.createErr != nil {
 		return "", 0, f.createErr
 	}
@@ -359,6 +361,7 @@ func TestDeliverMissionModes(t *testing.T) {
 	t.Run("push_pr records branch, pr url and number", func(t *testing.T) {
 		t.Parallel()
 		m := pushableMission(t)
+		m.Name = "Molla-go URL Shortener Design"
 		p := &fakePusher{host: "github.com"}
 		pr := &fakePRSource{repoExists: true, defaultBranch: "main", prURL: "https://github.com/octo/repo/pull/1", prNumber: 1}
 		resolveToken := func(context.Context, string) (string, error) { return "tok", nil }
@@ -371,6 +374,9 @@ func TestDeliverMissionModes(t *testing.T) {
 		}
 		if e.PRURL != "https://github.com/octo/repo/pull/1" || e.PRNumber != 1 {
 			t.Fatalf("entry after push_pr = %+v", e)
+		}
+		if pr.lastTitle != "feat: molla-go url shortener design" {
+			t.Fatalf("PR title = %q, want a Conventional Commits title (issue #709)", pr.lastTitle)
 		}
 	})
 

--- a/internal/brain/missions/push.go
+++ b/internal/brain/missions/push.go
@@ -70,6 +70,40 @@ func PRTitle(m Mission) string {
 	return m.Goal[:PRTitleGoalCap] + "…"
 }
 
+// prTitleTypes maps the first word of a mission's name or goal to a
+// Conventional Commits type; anything else is a feat (issue #709).
+var prTitleTypes = map[string]string{
+	"fix": "fix", "fixes": "fix", "bug": "fix", "bugfix": "fix", "hotfix": "fix", "repair": "fix",
+	"docs": "docs", "doc": "docs", "document": "docs", "documentation": "docs", "readme": "docs",
+	"refactor": "refactor", "refactoring": "refactor", "rename": "refactor", "restructure": "refactor",
+	"test": "test", "tests": "test",
+	"chore": "chore", "ci": "chore", "bump": "chore", "upgrade": "chore",
+}
+
+// ConventionalPRTitle renders PRTitle as a Conventional Commits subject
+// line (issue #709): "<type>: <subject>", lowercase, no trailing
+// period, at most PRTitleGoalCap bytes. The type comes from the first
+// word of the name (or goal) via prTitleTypes, feat otherwise; an
+// explicit "type:" prefix already in the name is kept, not doubled.
+func ConventionalPRTitle(m Mission) string {
+	subject := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(PRTitle(m), "…")))
+	subject = strings.TrimRight(subject, ". ")
+	kind := "feat"
+	if fields := strings.Fields(subject); len(fields) > 0 {
+		if t, ok := prTitleTypes[strings.Trim(fields[0], ":,")]; ok {
+			kind = t
+			if len(fields) > 1 && strings.HasSuffix(fields[0], ":") {
+				subject = strings.TrimSpace(strings.TrimPrefix(subject, fields[0]))
+			}
+		}
+	}
+	title := kind + ": " + subject
+	if len(title) > PRTitleGoalCap {
+		title = strings.TrimRight(title[:PRTitleGoalCap], " ")
+	}
+	return title
+}
+
 // pushTimeout bounds one push attempt — long enough for a real repo
 // over the network, short enough that a hung remote doesn't pin the
 // request indefinitely.

--- a/internal/brain/missions/push_test.go
+++ b/internal/brain/missions/push_test.go
@@ -234,6 +234,34 @@ func TestParseGitHubRepoURL(t *testing.T) {
 	}
 }
 
+// TestConventionalPRTitle covers the Conventional Commits shape the
+// github destination uses for PR titles (issue #709).
+func TestConventionalPRTitle(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		m    Mission
+		want string
+	}{
+		{"feat by default, lowercase", Mission{Name: "Molla-go URL Shortener Design"}, "feat: molla-go url shortener design"},
+		{"fix cue from the name", Mission{Name: "Fix Login Bug"}, "fix: fix login bug"},
+		{"docs cue from the goal", Mission{Goal: "Document the deploy runbook."}, "docs: document the deploy runbook"},
+		{"explicit prefix is not doubled", Mission{Name: "fix: login redirect loop"}, "fix: login redirect loop"},
+		{"long goal is cut at the cap", Mission{Goal: strings.Repeat("a", 100)}, "feat: " + strings.Repeat("a", PRTitleGoalCap-len("feat: "))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConventionalPRTitle(tc.m)
+			if got != tc.want {
+				t.Fatalf("ConventionalPRTitle = %q, want %q", got, tc.want)
+			}
+			if len(got) > PRTitleGoalCap {
+				t.Fatalf("len = %d, want <= %d", len(got), PRTitleGoalCap)
+			}
+		})
+	}
+}
+
 // TestPRTitleFallsBackToTruncatedGoal covers PRTitle's name-vs-goal
 // precedence and the truncation cap for a long goal with no name yet.
 func TestPRTitleFallsBackToTruncatedGoal(t *testing.T) {


### PR DESCRIPTION
## Why

A PR Timothy opened was titled "Molla-go URL Shortener Design", the mission's display name. The repos it pushes to use Conventional Commits for commits and PR titles.

## What changes

`ConventionalPRTitle` renders `<type>: <subject>`: lowercase subject, no trailing period, 72-byte cap. The type comes from a cue word at the start of the name or goal (fix/bug, docs/readme, refactor, test, chore/ci), feat otherwise; an explicit `type:` prefix already in the name is kept, not doubled. Only the github destination uses it; notifications and sweep messages keep the plain display name.

Closes #709

## Verification

Table test on the builder and a title assertion in the push_pr destination test. `go test -race ./internal/brain/missions/ ./internal/brain/destinations/` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791776956&installation_model_id=431401&pr_number=712&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F712&signature=4769f40b2bd656ab8b119c1f1e0d0fd83ec4893c016aa212371482a19e757625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->