### PR TITLE
feat(web): cost breakdown by model shows subscription-covered spend

### DIFF
--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -634,6 +634,43 @@ describe('Analytics latency panel', () => {
   })
 })
 
+describe('Analytics model cost table with subscription-covered spend', () => {
+  function modelRows() {
+    const table = screen.getByText('Cost breakdown by model').closest('[data-density]') as HTMLElement
+    return within(table).getAllByRole('row').map((row) => row.textContent ?? '')
+  }
+
+  it('shows the unbilled figure instead of 0 and marks it as subscription', async () => {
+    const subscription: UsagePoint = { ...providerPoint, group: 'claude-sonnet-5', cost: 0, unbilled_cost: 2.5 }
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) => (group === 'model' ? [subscription] : []))
+    renderPage()
+    await screen.findByText('Cost breakdown by model')
+    const row = modelRows().find((r) => r.includes('claude-sonnet-5'))
+    expect(row).toContain('$2.50')
+    expect(row).toContain('subscription')
+  })
+
+  it('sums billed and unbilled for a mixed row', async () => {
+    const mixed: UsagePoint = { ...providerPoint, group: 'claude-sonnet-5', cost: 1, unbilled_cost: 2.5 }
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) => (group === 'model' ? [mixed] : []))
+    renderPage()
+    await screen.findByText('Cost breakdown by model')
+    const row = modelRows().find((r) => r.includes('claude-sonnet-5'))
+    expect(row).toContain('$3.50')
+    expect(row).toContain('subscription')
+  })
+
+  it('leaves a fully billed row unmarked', async () => {
+    const billed: UsagePoint = { ...providerPoint, group: 'gpt-5.4', cost: 1.5, unbilled_cost: 0 }
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) => (group === 'model' ? [billed] : []))
+    renderPage()
+    await screen.findByText('Cost breakdown by model')
+    const row = modelRows().find((r) => r.includes('gpt-5.4'))
+    expect(row).toContain('$1.50')
+    expect(row).not.toContain('subscription')
+  })
+})
+
 describe('Analytics provider cost table sorting', () => {
   // cost puts openai first by default (cost desc); alphabetical sort puts anthropic
   // first, so the two orders are distinguishable in the assertions below.

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -137,6 +137,10 @@ function pivot(points: UsagePoint[], metric: (p: UsagePoint) => number, onlyGrou
 interface TotalsRow extends ConvertedRow {
   group: string
   cost: number
+  // unbilled is subscription-covered spend the executor reported
+  // (issue #710): shown in the per-model table, never in cost.
+  unbilled: number
+  converted_unbilled?: number
   requests: number
   errors: number
   tokens: number
@@ -154,17 +158,31 @@ function totals(points: UsagePoint[]): TotalsRow[] {
   for (const p of points) {
     const key = `${p.group} ${p.currency}`
     const t = acc.get(key) ?? {
-      group: p.group, currency: p.currency, cost: 0, requests: 0, errors: 0, tokens: 0,
+      group: p.group, currency: p.currency, cost: 0, unbilled: 0, requests: 0, errors: 0, tokens: 0,
       converted_amount: p.converted_amount != null ? 0 : undefined, converted_currency: p.converted_currency,
+      converted_unbilled: p.converted_unbilled_cost != null ? 0 : undefined,
     }
     t.cost += p.cost
+    t.unbilled += p.unbilled_cost
     t.requests += p.requests
     t.errors += p.errors
     t.tokens += p.input_tokens + p.output_tokens
     if (t.converted_amount != null && p.converted_amount != null) t.converted_amount += p.converted_amount
+    if (t.converted_unbilled != null && p.converted_unbilled_cost != null) t.converted_unbilled += p.converted_unbilled_cost
     acc.set(key, t)
   }
-  return [...acc.values()].sort((a, b) => b.cost - a.cost)
+  return [...acc.values()].sort((a, b) => b.cost + b.unbilled - (a.cost + a.unbilled))
+}
+
+// withUnbilled folds a row's subscription-covered spend into the
+// amounts the per-model table shows (issue #710): the operator wants
+// to see what the work would have cost, the tiles keep the true bill.
+function withUnbilled(t: TotalsRow): { row: ConvertedRow; amount: number } {
+  if (t.unbilled <= 0) return { row: t, amount: t.cost }
+  return {
+    row: { ...t, converted_amount: t.converted_amount != null ? t.converted_amount + (t.converted_unbilled ?? 0) : undefined },
+    amount: t.cost + t.unbilled,
+  }
 }
 
 const bucketLabel = (iso: string, bucket: string) => {
@@ -742,15 +760,28 @@ function BreakdownTable({
     <Panel title={title} density="operational">
       <Table>
         <TableBody>
-          {rows.map((t) => (
+          {rows.map((t) => {
+            const { row, amount } = withUnbilled(t)
+            return (
             <TableRow key={`${t.group} ${t.currency}`}>
               <TableCell className="max-w-36 truncate">{t.group}</TableCell>
               <TableCell numeric className="text-muted-foreground">{compact(t.tokens)} tok</TableCell>
               <TableCell numeric className="font-medium">
-                {primaryMoney(t, t.cost)}
-                {secondaryMoney(t, t.cost) && (
+                {primaryMoney(row, amount)}
+                {secondaryMoney(row, amount) && (
                   <span className="ml-1 text-xs font-normal text-muted-foreground">
-                    ({secondaryMoney(t, t.cost)})
+                    ({secondaryMoney(row, amount)})
+                  </span>
+                )}
+                {t.unbilled > 0 && (
+                  <span
+                    className="ml-1 text-xs font-normal text-muted-foreground"
+                    title={`${primaryMoney(
+                      { ...t, converted_amount: t.converted_unbilled },
+                      t.unbilled,
+                    )} of this is covered by a subscription and not billed`}
+                  >
+                    subscription
                   </span>
                 )}
                 {(estimates?.get(t.group) ?? 0) > 0 && (
@@ -763,7 +794,8 @@ function BreakdownTable({
                 )}
               </TableCell>
             </TableRow>
-          ))}
+            )
+          })}
           {rows.length === 0 && (
             <TableRow>
               <TableCell className="py-6 text-center text-muted-foreground">Nothing in range.</TableCell>


### PR DESCRIPTION
## Why

Claude Code reports `total_cost_usd` for a subscription run. The ledger stores it as unbilled and every total excludes it, so the per-model row read `70.7k tok  ৳0 ($0)` while the header showed `+৳600.52` beside spend. The operator wants to see what the model's work cost even when the subscription covers it.

## What changes

The Analytics "Cost breakdown by model" table shows billed plus unbilled per row (converted when a rate exists) with a muted `subscription` marker whose tooltip names the covered share. Rows without unbilled spend are unchanged. Header tiles and budget gauges keep excluding unbilled spend, so the true bill is untouched. Web only; the ledger already had the figure.

Closes #710

## Verification

Three component tests (unbilled only, mixed, billed only). `tsc --noEmit`, `npm run lint` (0 errors), Analytics suite 43/43 in the node container.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791776959&installation_model_id=431401&pr_number=713&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F713&signature=3fd4e574c07f410b48d58462f5fb973590e3c58e1b5ced1d058d8c455492e618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->