### PR TITLE
fix(missions): delegated runs keep their work, home and a unit-last prompt

### DIFF
--- a/internal/brain/missions/CLAUDE.md
+++ b/internal/brain/missions/CLAUDE.md
@@ -128,4 +128,19 @@ CLAUDE.md so other work does not pay for it every session.
   failure, auth failure), never on local file errors, idle or
   run-budget kills. Gateway no-failover codes (400/404/413/422,
   invalid_request) surface as `ErrProviderRejected` and pause as infra.
+- A delegated DONE over an untouched worktree (WT summary clean) is a
+  forced retry with `session_reset` on `executor.result` (issue #706);
+  `LastRunState` reads it and the next run starts fresh. Forced
+  retries never roll the worktree back; only a worker-declared RETRY
+  or a review rework does.
+- CLI session state lives in `<workspace>/executor/<harness>`
+  (`InvocationSpec.StateDir`, issue #707): codex's CODEX_HOME is shared
+  by every run of a mission so `codex exec resume` finds its rollout.
+  A resume whose stderr says the session is gone dies as
+  `session_lost` with `session_reset`, no cooldown, next run fresh.
+- `RenderForDelegated(runDir)` (issue #705) orders the CLI prompt goal,
+  lineage line, reference list, plan, findings, progress, git log,
+  attachments, then the current unit last with artifacts and verify
+  command. Parent digest and references are files under `runs/<id>/refs/`
+  (returned as files, written by `launchRun`), never inline.
 - `make canary` is the regression gate for any harness change.

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -142,6 +142,9 @@ type runState struct {
 	// polling it, only (if genuinely still needed) treat it as already
 	// decided.
 	Finished bool
+	// SessionReset is true when the latest run's executor.result carried
+	// session_reset (issue #706): its session must not be resumed.
+	SessionReset bool
 	// SessionID is the harness's own CLI session id (issue #499),
 	// recorded by the executor.session event once the run's first
 	// KindSystem line reported one. Empty when the run died before any
@@ -343,11 +346,12 @@ func (r *delegatedRunner) runDelegatedReview(ctx context.Context, m Mission, pac
 		SystemAppend: reviewSystemPrompt + delegatedReviewSystemAppend,
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
 		ResultSchema: reviewVerdictSchema, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
+		StateDir: executorStateDir(m.Workspace, m.ReviewHarness),
 		// ResumeSessionID stays empty: every review round is a cold
 		// session (D-092). ReadOnly is the enforced safety knob.
 		ReadOnly: true,
 	}
-	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, renderReviewContent(packet), resumeDecision{reason: resumeReasonNoPriorRun}); err != nil {
+	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, renderReviewContent(packet), nil, resumeDecision{reason: resumeReasonNoPriorRun}); err != nil {
 		if errors.Is(err, executor.ErrReadOnlyUnsupported) {
 			return ReviewVerdict{}, fallbackRefused, err
 		}
@@ -385,7 +389,7 @@ func (r *delegatedRunner) finishReview(ctx context.Context, m Mission, run cliRu
 	if perr != nil {
 		parseKind = "none"
 	}
-	authErr := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, decision)
+	authErr := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, decision, false)
 	if authErr != nil {
 		return ReviewVerdict{}, fallbackAuthFailed, authErr
 	}
@@ -671,6 +675,14 @@ func (r *delegatedRunner) resolveCredential(ctx context.Context, ref string, cap
 	return executor.AuthAPIKey, key, nil
 }
 
+// executorStateDir is the per-mission home a CLI keeps its session
+// state in across runs (issue #707): a sibling of runs/, outside the
+// worktree, one per harness so a review harness never shares state
+// with the worker's.
+func executorStateDir(missionRoot, harness string) string {
+	return filepath.Join(missionRoot, "executor", harness)
+}
+
 // runDir builds the per-run scratch directory path as a sibling of the
 // worktree, under the mission's own directory (Mission.Workspace) rather
 // than inside the git worktree itself — keeps it out of git
@@ -690,6 +702,9 @@ func runDir(missionRoot, runID string) string {
 func writeInvocationFiles(rdir string, files map[string]string) error {
 	for rel, content := range files {
 		full := filepath.Join(rdir, rel)
+		if filepath.IsAbs(rel) {
+			full = rel // a StateDir file (issue #707), shared across runs
+		}
 		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
 			return err
 		}
@@ -787,7 +802,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		return WorkerVerdict{}, "", err
 	}
 	rdir := runDir(m.Workspace, runID)
-	system, user := packet.RenderForDelegated()
+	system, user, refFiles := packet.RenderForDelegated(rdir)
 	system += delegatedSystemAppend
 
 	decision := r.planSessionResume(ctx, m, workRoot, adapter)
@@ -800,8 +815,9 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
 		ResultSchema: resultSchemaJSON, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 		ResumeSessionID: decision.sessionID,
+		StateDir:        executorStateDir(m.Workspace, m.Harness),
 	}
-	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, decision); err != nil {
+	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, refFiles, decision); err != nil {
 		return WorkerVerdict{}, "", err
 	}
 
@@ -813,7 +829,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 // CLI detached. Shared by worker and review runs (issue #582). Only a
 // spawn failure cools the entry down: the file and invocation errors
 // before it are local to this brain, not the provider's fault.
-func (r *delegatedRunner) launchRun(ctx context.Context, m Mission, run cliRun, workRoot, rdir, runID string, spec executor.InvocationSpec, user string, decision resumeDecision) error {
+func (r *delegatedRunner) launchRun(ctx context.Context, m Mission, run cliRun, workRoot, rdir, runID string, spec executor.InvocationSpec, user string, refFiles map[string]string, decision resumeDecision) error {
 	inv, err := run.adapter.BuildInvocation(spec)
 	if err != nil {
 		return fmt.Errorf("delegated runner: build invocation: %w", err)
@@ -826,6 +842,11 @@ func (r *delegatedRunner) launchRun(ctx context.Context, m Mission, run cliRun, 
 	}
 	if err := os.WriteFile(filepath.Join(rdir, "prompt.md"), []byte(user), 0o600); err != nil {
 		return fmt.Errorf("delegated runner: write prompt: %w", err)
+	}
+	// refFiles are the prompt's lineage and reference documents (issue
+	// #705), read by the CLI on demand from rdir/refs rather than inlined.
+	if err := writeInvocationFiles(rdir, refFiles); err != nil {
+		return fmt.Errorf("delegated runner: write reference files: %w", err)
 	}
 	if err := writeInvocationFiles(rdir, inv.Files); err != nil {
 		return fmt.Errorf("delegated runner: write invocation files: %w", err)
@@ -897,6 +918,7 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 const (
 	resumeReasonNoPriorRun         = "no_prior_run"
 	resumeReasonNoSessionID        = "no_session_id"
+	resumeReasonSessionReset       = "session_reset"
 	resumeReasonAdapterUnsupported = "adapter_unsupported"
 	resumeReasonContainerRecreated = "container_recreated"
 )
@@ -927,6 +949,9 @@ func (r *delegatedRunner) planSessionResume(ctx context.Context, m Mission, work
 	state, err := r.lastRun(ctx, m.ID)
 	if err != nil || state == nil || state.Harness != m.Harness {
 		return resumeDecision{reason: resumeReasonNoPriorRun}
+	}
+	if state.SessionReset {
+		return resumeDecision{reason: resumeReasonSessionReset}
 	}
 	if state.SessionID == "" {
 		return resumeDecision{reason: resumeReasonNoSessionID}
@@ -1485,9 +1510,21 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st 
 			verdict = forcedRetryVerdict("executor finished without a status report")
 		}
 	}
+	// A DONE that left the worktree exactly as it found it is a
+	// refusal, not a result (issue #706): the CLI read its prompt and
+	// concluded the unit was already finished. Nothing to verify, so
+	// the harness artifact check would only catch it one turn later and
+	// then resume the same session that already decided. Forced retry
+	// instead, and the session is reset so the next run starts fresh.
+	// A nil summary (no git worktree) proves nothing and passes through.
+	sessionReset := false
+	if ok && verdict.Outcome == "done" && st.worktree != nil && st.worktree.Untracked == 0 && st.worktree.Modified == 0 {
+		verdict = forcedRetryVerdict("executor reported DONE but changed nothing in the worktree; the unit is not done")
+		sessionReset = true
+	}
 	stampServed(&verdict, run, st)
 
-	if err := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, strings.ToUpper(verdict.Outcome)); err != nil {
+	if err := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, strings.ToUpper(verdict.Outcome), sessionReset); err != nil {
 		return WorkerVerdict{}, st.textBuf.String(), err
 	}
 	return verdict, st.textBuf.String(), nil
@@ -1498,7 +1535,7 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st 
 // check, which cools the entry down and returns ErrExecutorAuth since
 // retrying the same entry is futile. status is the parsed verdict
 // (DONE/RETRY/BLOCKED for a worker, APPROVE/REWORK for a review).
-func (r *delegatedRunner) finishCommon(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int, parseKind, status string) error {
+func (r *delegatedRunner) finishCommon(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int, parseKind, status string, sessionReset bool) error {
 	authFailed := st.resultEvent.Err != "" && isAuthFailure(st.resultEvent.Err)
 	errorCode := ""
 	if authFailed {
@@ -1516,7 +1553,7 @@ func (r *delegatedRunner) finishCommon(ctx context.Context, m Mission, run cliRu
 	// different, provider-priced figure or none at all, so the UI must
 	// not present the raw CLI number as billed.
 	cliCostTrusted := run.authMode == executor.AuthAPIKey && run.entry.Driver == "anthropic" && run.adapter.Capabilities().ReportsCost
-	r.recordResult(ctx, m.ID, run.phase, st, start, exitCode, st.resultEvent, parseKind, status, cliCostTrusted)
+	r.recordResult(ctx, m.ID, run.phase, st, start, exitCode, st.resultEvent, parseKind, status, cliCostTrusted, sessionReset)
 	r.recordLedger(ctx, m, run, st.resultEvent.Usage, start, exitCode == 0 && st.resultEvent.Err == "", errorCode, st.reportedModel)
 	if authFailed {
 		r.coolDown(run.harness, run.entry)
@@ -1558,6 +1595,19 @@ func (r *delegatedRunner) finishNoResult(ctx context.Context, m Mission, run cli
 		return "", fmt.Errorf("%w: %s", ErrExecutorAuth, stderrTail)
 	}
 
+	if exitCode != 0 && isSessionLost(stderrTail) {
+		// The CLI could not find the session it was asked to resume
+		// (issue #707). The provider did nothing wrong, so no cooldown;
+		// session_reset makes LastRunState start the next run fresh.
+		payload := map[string]any{
+			"reason": "session_lost", "stderr_tail": NeutralizeSlot(truncate(stderrTail, 2000)),
+			"phase": run.phase, "exit_code": exitCode, "session_reset": true,
+		}
+		r.recordEventForce(ctx, m.ID, "executor.died", payload)
+		r.recordLedger(ctx, m, run, nil, start, false, "", st.reportedModel)
+		return "executor could not find the session it was asked to resume; the next run starts fresh", nil
+	}
+
 	r.recordDied(ctx, m.ID, run.phase, "transport_death", &exitCode, stderrTail)
 	r.recordLedger(ctx, m, run, nil, start, false, "", st.reportedModel)
 	r.coolDown(run.harness, run.entry)
@@ -1583,6 +1633,21 @@ var authFailureSignatures = []string{
 	"invalid api key",
 	"please run /login",
 	"authentication_error",
+}
+
+// sessionLostSignatures are the stderr lines a CLI prints when a
+// resume names a session it no longer has (codex, claude).
+var sessionLostSignatures = []string{"no rollout found", "no conversation found"}
+
+// isSessionLost reports whether text carries a lost-session signature.
+func isSessionLost(text string) bool {
+	lower := strings.ToLower(text)
+	for _, sig := range sessionLostSignatures {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 func isAuthFailure(text string) bool {
@@ -1668,11 +1733,17 @@ func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID
 // cost_usd is priced against Anthropic's table and was never booked at
 // all). The UI keys off this to avoid presenting an unbooked number as
 // billed.
-func (r *delegatedRunner) recordResult(ctx context.Context, missionID, phase string, st *pollState, start time.Time, exitCode int, ev executor.Event, parseKind, status string, cliCostTrusted bool) {
+func (r *delegatedRunner) recordResult(ctx context.Context, missionID, phase string, st *pollState, start time.Time, exitCode int, ev executor.Event, parseKind, status string, cliCostTrusted, sessionReset bool) {
 	payload := map[string]any{
 		"status": status, "is_error": ev.Err != "",
 		"duration_ms": time.Since(start).Milliseconds(),
 		"exit_code":   exitCode, "parse": parseKind, "phase": phase,
+		"tool_calls": st.toolCalls,
+	}
+	if sessionReset {
+		// issue #706: the run reported DONE without changing anything;
+		// LastRunState reads this so the next run never resumes it.
+		payload["session_reset"] = true
 	}
 	if len(ev.Denials) > 0 {
 		payload["denials"] = ev.Denials

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -124,10 +124,14 @@ type fakeSandbox struct {
 	launches   int
 	launchErr  error
 	lastLaunch string
+	lastEnv    map[string]string
 	pollErrN   int // fail this many poll calls with an infra error before succeeding
 	pollErrs   int
 
 	stderrText string
+	// seedWorktree, when set, is the WT: summary every poll reports
+	// ("0 0 0" = clean), modelling the git worktree state (issue #706).
+	seedWorktree string
 
 	// containerAlive gates probeContainerMarker's command (D-103, issue
 	// #499): true (the default) simulates the same container instance
@@ -257,6 +261,7 @@ func (s *fakeSandbox) launch(command string, env map[string]string) (int, error)
 	defer s.mu.Unlock()
 	s.launches++
 	s.lastLaunch = command
+	s.lastEnv = env
 	if s.launchErr != nil {
 		return 1, s.launchErr
 	}
@@ -305,6 +310,9 @@ func (s *fakeSandbox) poll(command string, out io.Writer) (int, error) {
 	}
 	if !r.exited && !r.killed {
 		buf.WriteString("ALIVE\n")
+	}
+	if s.seedWorktree != "" {
+		fmt.Fprintf(buf, "WT:%s\n", s.seedWorktree)
 	}
 	_, _ = out.Write(buf.Bytes())
 	return 0, nil
@@ -569,6 +577,36 @@ func TestDelegatedRunWorker_HappyPath(t *testing.T) {
 	}
 }
 
+// TestDelegatedRunWorker_WritesReferenceFiles (issue #705): the
+// prompt's reference documents are written under the run dir's refs/.
+func TestDelegatedRunWorker_WritesReferenceFiles(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+	packet := WorkPacket{Goal: "test", ParentContext: "parent digest", References: []SourceEntry{{Source: SourceKindKB, Name: "Design", Digest: "kb body"}}}
+
+	if _, _, err := r.RunWorker(testCtx(t), m, packet); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	rdir, _ := spawnedPayload(t, events)["run_dir"].(string)
+	for rel, want := range map[string]string{"refs/parent-mission.md": "parent digest", "refs/01-design.md": "kb body"} {
+		got, err := os.ReadFile(filepath.Join(rdir, rel))
+		if err != nil || string(got) != want {
+			t.Fatalf("%s = %q, %v; want %q", rel, got, err, want)
+		}
+	}
+	prompt, _ := os.ReadFile(filepath.Join(rdir, "prompt.md"))
+	if strings.Contains(string(prompt), "kb body") || !strings.Contains(string(prompt), filepath.Join(rdir, "refs", "01-design.md")) {
+		t.Fatalf("prompt inlines the reference or lacks its path:\n%s", prompt)
+	}
+}
+
 // TestDelegatedRunWorker_HappyPath_VerdictCarriesServedProviderAndModel
 // covers issue #507: a delegated turn's verdict reports the executor's
 // own chain entry as who served it (the same values executor.spawned
@@ -700,6 +738,190 @@ func TestDelegatedRunWorker_IdleHang_KilledAndRetried(t *testing.T) {
 	}
 	if _, cooled := r.cooledUntil(m.Harness, entry); cooled {
 		t.Fatal("idle kill cooled the entry down; it says nothing about the provider (issue #704)")
+	}
+}
+
+// --- scenario 3b: DONE that changed nothing (issue #706) -----------------
+
+// TestDelegatedRunWorker_DoneWithCleanWorktree_ForcedFreshRetry: a DONE
+// verdict over a worktree the run left untouched is a refusal, not a
+// result: forced retry, and the result event marks the session reset
+// so the next run starts fresh instead of resuming a session that
+// already decided the unit was done.
+func TestDelegatedRunWorker_DoneWithCleanWorktree_ForcedFreshRetry(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	sandbox.seedWorktree = "0 0 0"
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "retry" || !verdict.Forced {
+		t.Fatalf("verdict = %+v, want forced retry", verdict)
+	}
+	if !strings.Contains(verdict.Analysis, "changed nothing") {
+		t.Fatalf("verdict analysis = %q, want it to say nothing changed", verdict.Analysis)
+	}
+	if verdict.Provider != entry.ProviderName || verdict.Model != entry.Model {
+		t.Fatalf("verdict provider/model = %q/%q, want %q/%q", verdict.Provider, verdict.Model, entry.ProviderName, entry.Model)
+	}
+	result, ok := events.last("executor.result")
+	if !ok {
+		t.Fatal("no executor.result event")
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(result.Payload, &payload)
+	if payload["status"] != "RETRY" || payload["session_reset"] != true {
+		t.Fatalf("executor.result payload = %v, want status RETRY and session_reset true", payload)
+	}
+	if _, cooled := r.cooledUntil(m.Harness, entry); cooled {
+		t.Fatal("a DONE without work cooled the entry; the provider did nothing wrong")
+	}
+}
+
+// TestDelegatedRunWorker_DoneWithDirtyWorktree_Accepted: the same DONE
+// over a worktree with changes is a real result.
+func TestDelegatedRunWorker_DoneWithDirtyWorktree_Accepted(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	sandbox.seedWorktree = "2 1 1735689600"
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("verdict = %+v, want done", verdict)
+	}
+	result, _ := events.last("executor.result")
+	var payload map[string]any
+	_ = json.Unmarshal(result.Payload, &payload)
+	if _, has := payload["session_reset"]; has {
+		t.Fatalf("executor.result payload = %v, want no session_reset", payload)
+	}
+}
+
+// TestDelegatedRunWorker_SessionResume_ResetSessionStartsFresh: a prior
+// run whose result carried session_reset (issue #706) never resumes,
+// even with a session id, a resume-capable adapter and a live container.
+func TestDelegatedRunWorker_SessionResume_ResetSessionStartsFresh(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.containerAlive = true
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	lastRun := func(ctx context.Context, missionID string) (*runState, error) {
+		return &runState{Harness: "claude-cli", RunID: "prior", RunDir: "/x", Finished: true, SessionID: "sess-prior-123", SessionReset: true}, nil
+	}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, lastRun, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if strings.Contains(sandbox.lastLaunchCmd(), "--resume") {
+		t.Fatalf("launch command resumed a reset session: %s", sandbox.lastLaunchCmd())
+	}
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != false || payload["resume_reason"] != "session_reset" {
+		t.Fatalf("executor.spawned resumed/resume_reason = %v/%v, want false/session_reset", payload["resumed"], payload["resume_reason"])
+	}
+}
+
+// --- scenario 3c: lost session and shared executor home (issue #707) ----
+
+// TestDelegatedRunWorker_SessionLost_FreshRetryNoCooldown: a CLI that
+// cannot find the session it was asked to resume dies with
+// session_lost, marks the session reset so the next run starts fresh,
+// and never cools the entry (the provider did nothing wrong).
+func TestDelegatedRunWorker_SessionLost_FreshRetryNoCooldown(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = nil
+	sandbox.seedExitCode = 1
+	sandbox.stderrText = "Error: no rollout found for thread id 019a-7c"
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "retry" || !verdict.Forced {
+		t.Fatalf("verdict = %+v, want forced retry", verdict)
+	}
+	died, ok := events.last("executor.died")
+	if !ok {
+		t.Fatal("no executor.died event")
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(died.Payload, &payload)
+	if payload["reason"] != "session_lost" || payload["session_reset"] != true {
+		t.Fatalf("executor.died payload = %v, want reason session_lost and session_reset true", payload)
+	}
+	if _, cooled := r.cooledUntil(m.Harness, entry); cooled {
+		t.Fatal("a lost session cooled the entry down")
+	}
+}
+
+// TestDelegatedRunWorker_CodexHomeSharedAcrossRuns: two runs of one
+// mission launch codex with the same CODEX_HOME under the mission's
+// executor dir, and the home's files land there, so a resume can find
+// the rollout the first run wrote.
+func TestDelegatedRunWorker_CodexHomeSharedAcrossRuns(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = nil
+	sandbox.seedExitCode = 1
+	sandbox.stderrText = "boom"
+	events := &fakeEventSink{}
+	entry := gwclient.ResolvedRouteEntry{
+		ProviderID: "prov-oa", ProviderName: "openai", Driver: "openaicompat", Wire: "openai",
+		Model: "gpt-5.3-codex", CredentialRef: "OPENAI_KEY", Usable: true,
+	}
+	route := &gwclient.ResolvedRoute{Route: "builder", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+	m.Harness = "codex-cli"
+	want := filepath.Join(m.Workspace, "executor", "codex-cli")
+
+	homes := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		r.cooldown = map[cooldownKey]time.Time{} // transport death cools the entry; the test is about the home, not the cooldown
+		if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker %d: %v", i, err)
+		}
+		homes[sandbox.lastEnv["CODEX_HOME"]] = true
+	}
+	if len(homes) != 1 || !homes[want] {
+		t.Fatalf("CODEX_HOME across runs = %v, want only %q", homes, want)
+	}
+	if _, err := os.Stat(filepath.Join(want, "config.toml")); err != nil {
+		t.Fatalf("config.toml not written under the state dir: %v", err)
+	}
+	if sandbox.launches != 2 {
+		t.Fatalf("launches = %d, want 2", sandbox.launches)
 	}
 }
 

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1663,7 +1663,12 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	case "blocked":
 		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question, Provider: verdict.Provider, Model: verdict.Model}, nil
 	default: // "retry" or anything unrecognized
-		if wt := m.WorktreePath(); wt != "" {
+		// Only a RETRY the worker itself declared rolls the tree back
+		// (issue #706): a forced retry comes from transport death, an
+		// idle or run-budget kill, or an unreadable result, none of
+		// which says the edits so far are wrong, and the retry works
+		// on top of them.
+		if wt := m.WorktreePath(); wt != "" && !verdict.Forced {
 			if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
 				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
 			}
@@ -2085,7 +2090,7 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	p := WorkPacket{
 		Goal: m.Goal, Kind: m.Kind, Plan: m.Plan, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
-		ExecEnvironmentNote: execEnvironmentNote(loc), ParentContext: m.ParentContext(), ReferencedContext: m.ReferencedContext(), Attachments: m.Attachments(),
+		ExecEnvironmentNote: execEnvironmentNote(loc), ParentContext: m.ParentContext(), ReferencedContext: m.ReferencedContext(), References: m.ReferenceEntries(), Attachments: m.Attachments(),
 		Light: m.RunsPlanless(), Location: loc,
 		Findings: m.ReviewFindings, ReworkRound: m.ReworkRounds, MaxRounds: m.MaxIterations,
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1559,6 +1559,55 @@ func TestDriverReworkUntouchedEvent(t *testing.T) {
 	}
 }
 
+// TestDriverRetryRollbackOnlyForWorkerDeclaredRetry (issue #706): a
+// forced retry (transport death, idle or run-budget kill, unreadable
+// result) keeps the worktree's edits; only a RETRY the worker declared
+// rolls them back.
+func TestDriverRetryRollbackOnlyForWorkerDeclaredRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		verdict  WorkerVerdict
+		wantKept bool
+	}{
+		{"forced retry keeps the tree", forcedRetryVerdict("executor process was lost"), true},
+		{"worker retry rolls back", WorkerVerdict{Outcome: "retry", Analysis: "wrong approach"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			wt := filepath.Join(root, "wt")
+			if err := os.MkdirAll(wt, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			gitRun(t, wt, "init", "-q", "-b", "main")
+			if err := os.WriteFile(filepath.Join(wt, "base.go"), []byte("package x\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			gitRun(t, wt, "add", "base.go")
+			gitRun(t, wt, "-c", "user.name=t", "-c", "user.email=t@example.com", "commit", "-q", "-m", "base")
+			store := newFakeStore()
+			store.put("m1", Mission{
+				ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8,
+				Workspace: root, Plan: Plan{Units: []PlanUnit{{Title: "u1"}}},
+			})
+			runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{tc.verdict}}
+			workspace := NewWorkspace(root, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			d := NewDriver(store, runner, workspace, nil, nil, nil, fakeSandboxExec, nil, slog.Default())
+			edited := filepath.Join(wt, "x.go")
+			if err := os.WriteFile(edited, []byte("package x\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := d.Advance(context.Background(), "m1"); err != nil {
+				t.Fatalf("Advance: %v", err)
+			}
+			_, statErr := os.Stat(edited)
+			if kept := statErr == nil; kept != tc.wantKept {
+				t.Fatalf("x.go kept = %v, want %v", kept, tc.wantKept)
+			}
+		})
+	}
+}
+
 // TestDriverReplanOnFirstStall confirms a mission's FIRST stall (two
 // identical-fingerprint worker retries, ReplanUsed still false) goes
 // back to planning instead of pausing, the driver-level counterpart of

--- a/internal/brain/missions/executor/codex.go
+++ b/internal/brain/missions/executor/codex.go
@@ -74,11 +74,20 @@ func (codexAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		baseURL = codexDefaultBaseURL
 	}
 
+	// CODEX_HOME holds the session rollouts `codex exec resume` reads,
+	// so it lives in the mission's StateDir when the runner gives one
+	// (issue #707) and every run of the mission shares it; a run-local
+	// home made every resume fail with "no rollout found".
 	runDir := filepath.Dir(spec.PromptPath)
 	codexHome := filepath.Join(runDir, "codex-home")
+	homeFile := func(name string) string { return "codex-home/" + name }
+	if spec.StateDir != "" {
+		codexHome = spec.StateDir
+		homeFile = func(name string) string { return filepath.Join(codexHome, name) }
+	}
 
 	files := map[string]string{
-		"codex-home/config.toml": codexConfigTOML(baseURL),
+		homeFile("config.toml"): codexConfigTOML(baseURL),
 	}
 
 	// `codex exec resume <SESSION_ID>` is a distinct subcommand form
@@ -107,7 +116,7 @@ func (codexAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		if err != nil {
 			return Invocation{}, fmt.Errorf("executor/codex: result schema: %w", err)
 		}
-		files["codex-home/schema.json"] = compact
+		files[homeFile("schema.json")] = compact
 		argv = append(argv, "--output-schema", schemaPath)
 	}
 	argv = append(argv, "@PROMPT@") // substituted by the runner via PromptFile
@@ -117,7 +126,7 @@ func (codexAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	// codex's docs: "Custom instructions with AGENTS.md"), so
 	// SystemAppend rides that file instead.
 	if spec.SystemAppend != "" {
-		files["codex-home/AGENTS.md"] = spec.SystemAppend
+		files[homeFile("AGENTS.md")] = spec.SystemAppend
 	}
 
 	env := map[string]string{

--- a/internal/brain/missions/executor/codex_test.go
+++ b/internal/brain/missions/executor/codex_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -302,6 +303,30 @@ func TestCodexAdapter_BuildInvocation(t *testing.T) {
 					t.Errorf("CODEX_HOME = %q, want /tmp/run/codex-home", inv.Env["CODEX_HOME"])
 				}
 				assertCodexConfigTOML(t, inv, "http://host.docker.internal:11434/v1")
+			},
+		},
+		{
+			name: "state dir hosts codex home across runs",
+			spec: InvocationSpec{
+				Model: "gpt-5.3-codex", PromptPath: "/ws/runs/r1/prompt.md", Workdir: "/ws/wt",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+				StateDir: "/ws/executor/codex-cli", ResultSchema: json.RawMessage(`{"type":"object"}`), SystemAppend: "rules",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if inv.Env["CODEX_HOME"] != "/ws/executor/codex-cli" {
+					t.Errorf("CODEX_HOME = %q, want the state dir", inv.Env["CODEX_HOME"])
+				}
+				for _, name := range []string{"config.toml", "schema.json", "AGENTS.md"} {
+					if _, ok := inv.Files["/ws/executor/codex-cli/"+name]; !ok {
+						t.Errorf("Files lacks %s under the state dir: %v", name, keys(inv.Files))
+					}
+				}
+				if _, ok := inv.Files["codex-home/config.toml"]; ok {
+					t.Error("Files still carries a run-local codex-home/config.toml")
+				}
+				if !slices.Contains(inv.Argv, "/ws/executor/codex-cli/schema.json") {
+					t.Errorf("argv --output-schema does not point into the state dir: %v", inv.Argv)
+				}
 			},
 		},
 		{
@@ -613,4 +638,13 @@ func flagIndex(argv []string, flag string) int {
 		}
 	}
 	return -1
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
 }

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -68,6 +68,11 @@ type InvocationSpec struct {
 	// The runner only ever sets this when Capabilities().SupportsResume
 	// is true for the adapter in play.
 	ResumeSessionID string
+	// StateDir, when non-empty, is a per-mission directory the CLI keeps
+	// its own session state in across runs (issue #707): codex's
+	// CODEX_HOME, so `codex exec resume` finds the rollout the previous
+	// run wrote. Empty keeps state inside the run dir.
+	StateDir string
 	// ReadOnly asks for a run that can read the workdir but never
 	// modify it or run shell commands (issue #582, the delegated
 	// reviewer). Each adapter maps it onto its own CLI knob; an adapter
@@ -91,9 +96,10 @@ type Invocation struct {
 	Argv       []string
 	Env        map[string]string // allowlisted names only; values never logged
 	PromptFile string
-	// Files are extra files the runner writes into the run dir before
-	// spawn, keyed by slash-separated path relative to the run dir
-	// (e.g. "pi-agent/models.json"). Values are never logged.
+	// Files are extra files the runner writes before spawn, keyed by
+	// slash-separated path relative to the run dir (e.g.
+	// "pi-agent/models.json") or by an absolute path under the mission's
+	// StateDir. Values are never logged.
 	Files map[string]string
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -180,15 +180,15 @@ type Mission struct {
 	// time, same as AutoApproveTools; scheduler.go and the workflow
 	// engine both force this true regardless of template/step input:
 	// an unattended mission has nobody to approve its plan.
-	AutoApprovePlan bool   `json:"auto_approve_plan"`
+	AutoApprovePlan bool `json:"auto_approve_plan"`
 	// HasPlan (D-102, issue #496) marks a mission whose goal already
 	// carries the operator's own plan: the plan turn runs in transcribe
 	// mode (PlanSession), converting the goal's plan into units instead
 	// of designing one from scratch. Snapshotted at create time, never
 	// model-mutable; light missions never plan, so this has no effect
 	// there.
-	HasPlan         bool   `json:"has_plan,omitempty"`
-	ScheduleID      string `json:"schedule_id,omitempty"`
+	HasPlan    bool   `json:"has_plan,omitempty"`
+	ScheduleID string `json:"schedule_id,omitempty"`
 	// ParentMissionID names the terminal mission this one follows up on
 	// (api/missions.go's create) — empty for an ordinary mission.
 	ParentMissionID string `json:"parent_mission_id,omitempty"`
@@ -438,6 +438,17 @@ func (m Mission) ParentContext() string {
 // Mission.ReferencedContext column's replacement.
 func (m Mission) ReferencedContext() string {
 	var b strings.Builder
+	for _, e := range m.ReferenceEntries() {
+		fmt.Fprintf(&b, "%s:\n%s\n\n", referenceName(e), e.Digest)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// ReferenceEntries returns the picked reference sources ReferencedContext
+// renders, in order: a delegated worker gets each as a file in its run
+// dir instead of inline text (issue #705).
+func (m Mission) ReferenceEntries() []SourceEntry {
+	var out []SourceEntry
 	for _, e := range m.Sources {
 		switch e.Source {
 		case SourceKindChat, SourceKindKB, SourceKindBrief:
@@ -451,13 +462,18 @@ func (m Mission) ReferencedContext() string {
 		if e.Digest == "" {
 			continue
 		}
-		name := e.Name
-		if name == "" {
-			name = e.MissionID + e.SessionID + e.DocID
-		}
-		fmt.Fprintf(&b, "%s:\n%s\n\n", name, e.Digest)
+		out = append(out, e)
 	}
-	return strings.TrimRight(b.String(), "\n")
+	return out
+}
+
+// referenceName labels a reference entry in prompts: its name, else
+// the ids that identify it.
+func referenceName(e SourceEntry) string {
+	if e.Name != "" {
+		return e.Name
+	}
+	return e.MissionID + e.SessionID + e.DocID
 }
 
 // WorktreePath derives the worktree directory (issue #479 dropped the

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -2,6 +2,7 @@ package missions
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -48,6 +49,10 @@ type WorkPacket struct {
 	// the worker the content of what the user explicitly pinned at
 	// create time.
 	ReferencedContext string
+	// References are the same picks as entries (Mission.ReferenceEntries());
+	// RenderForDelegated writes each to a file in the run dir and lists
+	// the paths instead of inlining the digests (issue #705).
+	References []SourceEntry
 	// Attachments are the mission's create-time documents, images, and
 	// audio clips ("pdf" Sources entries, issue #359) -- reach every
 	// worker turn via Render, including a delegated executor's turn
@@ -158,12 +163,112 @@ func (p WorkPacket) Render() (system, user string) {
 // to confuse a model into reporting BLOCKED over tools it was never
 // offered, rather than using its own native file-edit/patch tool and
 // the harness's structured-output contract.
-func (p WorkPacket) RenderForDelegated() (system, user string) {
-	return p.render("")
+//
+// The body order differs from Render (issue #705): a one-shot CLI reads
+// the prompt top to bottom and weighs the tail, so lineage and
+// references are one line each pointing at files under runDir/refs
+// (returned in files, keyed relative to runDir), and the current unit
+// with its artifacts and verify command comes last. Codex once read a
+// parent digest saying "done, docs only" as the final word and reported
+// DONE without a single tool call.
+func (p WorkPacket) RenderForDelegated(runDir string) (system, user string, files map[string]string) {
+	system = p.systemPrompt("")
+	files = map[string]string{}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Goal: %s\n", NeutralizeSlot(p.Goal))
+	fmt.Fprintf(&b, "Iteration: %d\n\n", p.Iteration)
+
+	if p.DiscoverNotes != "" {
+		b.WriteString("Discovery findings:\n")
+		b.WriteString(NeutralizeSlot(p.DiscoverNotes))
+		b.WriteString("\n\n")
+	}
+
+	if p.ParentContext != "" {
+		files["refs/parent-mission.md"] = p.ParentContext
+		fmt.Fprintf(&b, "Follow-up of a previous mission; its outcome digest is at %s (background only, this mission's plan below is the work).\n\n", filepath.Join(runDir, "refs", "parent-mission.md"))
+	}
+	if len(p.References) > 0 {
+		b.WriteString("Referenced documents, read when the unit needs them:\n")
+		for i, e := range p.References {
+			rel := filepath.Join("refs", fmt.Sprintf("%02d-%s.md", i+1, slugify(referenceName(e))))
+			files[rel] = e.Digest
+			fmt.Fprintf(&b, "- %s: %s\n", NeutralizeSlot(referenceName(e)), filepath.Join(runDir, rel))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(p.Plan.Units) > 0 {
+		b.WriteString("Plan:\n")
+		for _, u := range p.Plan.Units {
+			b.WriteString(renderPlanLine(u))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(renderOpenFindings(p.Findings, p.ReworkRound, p.MaxRounds))
+	b.WriteString(p.renderProgress())
+
+	if p.GitLog != "" {
+		b.WriteString("Recent commits in this worktree:\n")
+		b.WriteString(NeutralizeSlot(p.GitLog))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(renderAttachments(p.Attachments))
+
+	if len(p.Plan.Units) > 0 {
+		if unit, _ := currentUnit(p.Plan); unit != nil {
+			b.WriteString("\n")
+			fmt.Fprintf(&b, "Current unit: %s\n", NeutralizeSlot(unit.Title))
+			b.WriteString(renderUnitFailure(*unit))
+			for _, c := range unit.Criteria {
+				fmt.Fprintf(&b, "  criterion: %s\n", NeutralizeSlot(c))
+			}
+			for _, a := range unit.Artifacts {
+				fmt.Fprintf(&b, "  must produce (exact path): %s\n", NeutralizeSlot(a))
+			}
+			if unit.VerifyCmd != "" {
+				fmt.Fprintf(&b, "  verified by: %s\n", NeutralizeSlot(unit.VerifyCmd))
+			}
+			b.WriteString("Do this unit now.\n")
+		}
+	}
+
+	return system, b.String(), files
 }
 
-func (p WorkPacket) render(preamble string) (system, user string) {
-	system = preamble + p.ExecEnvironmentNote
+// slugify turns a reference name into a short filename stem.
+func slugify(name string) string {
+	var b strings.Builder
+	last := '-'
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			last = r
+		default:
+			if last != '-' {
+				b.WriteRune('-')
+				last = '-'
+			}
+		}
+		if b.Len() >= 40 {
+			break
+		}
+	}
+	s := strings.Trim(b.String(), "-")
+	if s == "" {
+		return "reference"
+	}
+	return s
+}
+
+// systemPrompt assembles the system half shared by Render and
+// RenderForDelegated.
+func (p WorkPacket) systemPrompt(preamble string) string {
+	system := preamble + p.ExecEnvironmentNote
 	if preamble != "" && p.SkillsIndex != "" {
 		// preamble=="" is the delegated path (RenderForDelegated) —
 		// no load_skill tool there, so the index would only mislead.
@@ -178,6 +283,35 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 	if block := WritingStyleBlock(p.WritingStyle, p.WritingSamples); block != "" {
 		system += "\n\n" + block
 	}
+	return system
+}
+
+// renderProgress is the "Progress so far" block, capped at
+// progressRenderCap notes.
+func (p WorkPacket) renderProgress() string {
+	if len(p.Progress) == 0 {
+		return ""
+	}
+	loc := p.Location
+	if loc == nil {
+		loc = time.UTC
+	}
+	var b strings.Builder
+	b.WriteString("Progress so far:\n")
+	notes := p.Progress
+	if len(notes) > progressRenderCap {
+		fmt.Fprintf(&b, "(%d earlier notes omitted)\n", len(notes)-progressRenderCap)
+		notes = notes[len(notes)-progressRenderCap:]
+	}
+	for _, n := range notes {
+		fmt.Fprintf(&b, "- %s: %s\n", n.At.In(loc).Format("2006-01-02 15:04 MST"), NeutralizeSlot(n.Note))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (p WorkPacket) render(preamble string) (system, user string) {
+	system = p.systemPrompt(preamble)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Goal: %s\n", NeutralizeSlot(p.Goal))
@@ -211,23 +345,7 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 	}
 
 	b.WriteString(renderOpenFindings(p.Findings, p.ReworkRound, p.MaxRounds))
-
-	if len(p.Progress) > 0 {
-		loc := p.Location
-		if loc == nil {
-			loc = time.UTC
-		}
-		b.WriteString("Progress so far:\n")
-		notes := p.Progress
-		if len(notes) > progressRenderCap {
-			fmt.Fprintf(&b, "(%d earlier notes omitted)\n", len(notes)-progressRenderCap)
-			notes = notes[len(notes)-progressRenderCap:]
-		}
-		for _, n := range notes {
-			fmt.Fprintf(&b, "- %s: %s\n", n.At.In(loc).Format("2006-01-02 15:04 MST"), NeutralizeSlot(n.Note))
-		}
-		b.WriteString("\n")
-	}
+	b.WriteString(p.renderProgress())
 
 	if p.GitLog != "" {
 		b.WriteString("Recent commits in this worktree:\n")

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -121,8 +121,9 @@ func TestWorkPacketRenderOpenFindings(t *testing.T) {
 	if strings.Contains(user, "F1") || strings.Contains(user, "</system>") {
 		t.Fatalf("Render leaked a resolved finding or raw injected text:\n%s", user)
 	}
-	_, delegated := p.RenderForDelegated()
-	if !strings.Contains(delegated, want) {
+	_, delegated, _ := p.RenderForDelegated("/run")
+	findings := want[strings.Index(want, "Current work:"):]
+	if !strings.Contains(delegated, findings) {
 		t.Fatalf("RenderForDelegated findings block mismatch:\n%s", delegated)
 	}
 
@@ -144,7 +145,7 @@ func TestWorkPacketRenderForDelegatedOmitsNativePreamble(t *testing.T) {
 		Goal: "Merge dependabot PRs",
 		Plan: Plan{Units: []PlanUnit{{Title: "Assess PRs"}}},
 	}
-	system, user := p.RenderForDelegated()
+	system, user, _ := p.RenderForDelegated("/run")
 	if strings.Contains(system, "mission_status") || strings.Contains(system, "write_file") {
 		t.Fatalf("RenderForDelegated system prompt mentions native-only tools: %q", system)
 	}
@@ -153,6 +154,47 @@ func TestWorkPacketRenderForDelegatedOmitsNativePreamble(t *testing.T) {
 	}
 	if !strings.Contains(user, "Assess PRs") {
 		t.Fatal("RenderForDelegated did not include the plan")
+	}
+}
+
+// TestWorkPacketRenderForDelegatedShape (issue #705): the delegated
+// prompt names lineage and references as files, never inlines them,
+// and ends with the current unit's artifacts and verify command.
+func TestWorkPacketRenderForDelegatedShape(t *testing.T) {
+	p := WorkPacket{
+		Goal:          "Implement slice 1",
+		Plan:          Plan{Units: []PlanUnit{{Title: "Core codes", Artifacts: []string{"internal/core/code.go"}, VerifyCmd: "go test ./internal/core/"}}},
+		GitLog:        "abc123 chore: scaffold",
+		ParentContext: "Parent goal: docs only. Terminal state: done.",
+		References:    []SourceEntry{{Source: SourceKindKB, Name: "Design: URL Shortener", Digest: "very long kb article body"}},
+		Progress:      []ProgressNote{{At: time.Date(2026, 9, 12, 10, 0, 0, 0, time.UTC), Note: "started"}},
+	}
+	_, user, files := p.RenderForDelegated("/w/runs/r1")
+
+	for _, inline := range []string{"Terminal state: done", "very long kb article body"} {
+		if strings.Contains(user, inline) {
+			t.Fatalf("prompt inlines %q, want it only in a file:\n%s", inline, user)
+		}
+	}
+	if files["refs/parent-mission.md"] != p.ParentContext || files["refs/01-design-url-shortener.md"] != "very long kb article body" {
+		t.Fatalf("files = %v, want the digest and the reference under refs/", files)
+	}
+	for _, path := range []string{"/w/runs/r1/refs/parent-mission.md", "/w/runs/r1/refs/01-design-url-shortener.md"} {
+		if !strings.Contains(user, path) {
+			t.Fatalf("prompt does not point at %s:\n%s", path, user)
+		}
+	}
+	order := []string{"Goal:", "Follow-up of a previous mission", "Referenced documents", "Plan:", "Progress so far:", "Recent commits", "Current unit: Core codes", "must produce (exact path): internal/core/code.go", "verified by: go test ./internal/core/", "Do this unit now."}
+	last := -1
+	for _, marker := range order {
+		i := strings.Index(user, marker)
+		if i < 0 || i < last {
+			t.Fatalf("marker %q missing or out of order (at %d after %d):\n%s", marker, i, last, user)
+		}
+		last = i
+	}
+	if !strings.HasSuffix(strings.TrimSpace(user), "Do this unit now.") {
+		t.Fatalf("prompt does not end with the unit:\n%s", user)
 	}
 }
 
@@ -242,7 +284,7 @@ func TestWorkPacketRenderIncludesWritingStyle(t *testing.T) {
 
 	t.Run("delegated", func(t *testing.T) {
 		p := WorkPacket{Goal: "Draft the note", WritingStyle: "Short sentences.", WritingSamples: true}
-		system, _ := p.RenderForDelegated()
+		system, _, _ := p.RenderForDelegated("/run")
 		if !strings.Contains(system, "Short sentences.") || !strings.Contains(system, WritingSamplesNote) {
 			t.Fatalf("delegated render dropped the writing-style block: %q", system)
 		}
@@ -481,7 +523,7 @@ func TestWorkPacketRenderSkillsIndex(t *testing.T) {
 	if !strings.Contains(system, "email-research") {
 		t.Fatal("native render missing skills index")
 	}
-	system, _ = p.RenderForDelegated()
+	system, _, _ = p.RenderForDelegated("/run")
 	if strings.Contains(system, "email-research") {
 		t.Fatal("delegated render must not carry the skills index")
 	}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1022,6 +1022,12 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 				state = &runState{}
 			}
 			state.Finished = true
+			var result struct {
+				SessionReset bool `json:"session_reset"`
+			}
+			if err := json.Unmarshal(payload, &result); err == nil && result.SessionReset {
+				state.SessionReset = true
+			}
 		case "executor.progress":
 			if state == nil {
 				state = &runState{}


### PR DESCRIPTION
Stacked on #711; retargets to main once that merges.

## Why

Mission ae69e3f0 on homelab: codex answered DONE with zero tool calls because the prompt ended with the parent digest ("docs only, done") and a full KB article; the retry resumed a session whose rollout lived in a run dir that no longer applied; the forced retry rolled back the worktree. None of it was the worker's fault.

## What changes

**Prompt shape (#705).** `RenderForDelegated(runDir)` orders goal, one-line lineage, reference list, plan, findings, progress, git log, attachments, and the current unit last with criteria, artifacts and verify command. Parent digest and each reference are written to `runs/<id>/refs/*.md` and named by path, never inlined. Native `Render` is unchanged.

**DONE without work (#706).** A DONE over a worktree the run left untouched (WT summary clean) is a forced retry. `executor.result` carries `session_reset`, `LastRunState` reads it, and the next run starts fresh. Forced retries (transport death, idle or run-budget kill, unreadable result) keep the worktree; only a worker-declared RETRY rolls it back. The worktree summary is the signal rather than tool-call count because the claude adapter counts the StructuredOutput call as a tool.

**Session home (#707).** `InvocationSpec.StateDir` = `<workspace>/executor/<harness>`, shared by every run of a mission; codex puts CODEX_HOME there so `codex exec resume` finds its rollout. Stderr "no rollout found" or "No conversation found" dies as `session_lost` with `session_reset`, no cooldown. Claude CLI keeps its state in the container home already.

Closes #705
Closes #706
Closes #707

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./internal/brain/...` green. New tests: prompt shape and file placement, DONE-clean forced retry, DONE-dirty accepted, reset session never resumed, rollback only for worker RETRY, lost session no cooldown, shared codex home across two runs, codex invocation with a state dir.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791778113&installation_model_id=431401&pr_number=714&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F714&signature=842de32bd87909f874e375be22677a91feafd4824307cc28c27df163a615eba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->