### PR TITLE
fix(gateway): skip Responses-only models on chat rows in the native walk

### DIFF
--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -490,7 +490,24 @@ func (s *Snapshot) entryGate(row ProviderRow, model string, required []provider.
 			return nil, row.Name + "/" + model, fmt.Sprintf("lacks %s capability", want)
 		}
 	}
+	if s.responsesOnly(row, model) {
+		return nil, row.Name + "/" + model, "responses_only: the model serves /v1/responses only, not chat/completions; use an openai-responses provider row"
+	}
 	return p, "", ""
+}
+
+// responsesOnly reports whether row would send model over
+// chat/completions when the catalog says the model only speaks the
+// Responses API (LiteLLM mode "responses", the gpt-5.x-codex family),
+// issue #708. The chat driver gets a 404 on every call there, so the
+// native walk skips the row instead of failing over into it. A
+// missing catalog match keeps the row usable: the driver decides.
+func (s *Snapshot) responsesOnly(row ProviderRow, model string) bool {
+	if row.Driver != "openaicompat" {
+		return false
+	}
+	m, ok := s.catalogModel(row, model)
+	return ok && m.Mode == "responses"
 }
 
 // Strategy weights: relative importance of each additive factor,

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -377,6 +377,41 @@ func TestResolveModelCapabilityExhaustionNamesModel(t *testing.T) {
 	}
 }
 
+// TestResolveDetailSkipsResponsesOnlyModelOnChatDriver (issue #708): a
+// catalog model in Responses-only mode is unusable on an openaicompat
+// row, whose native calls go to chat/completions, but stays usable on
+// an openai-responses row for the same model.
+func TestResolveDetailSkipsResponsesOnlyModelOnChatDriver(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "openai", Kind: "api", Driver: "openaicompat", BaseURL: "https://api.openai.com/v1",
+			DefaultModel: "gpt-5.3-codex", CredentialRef: "OPENAI_KEY", Enabled: true},
+		{ID: "p2", Name: "openai-responses", Kind: "api", Driver: "openai-responses", BaseURL: "https://api.openai.com/v1",
+			DefaultModel: "gpt-5.3-codex", CredentialRef: "OPENAI_KEY", Enabled: true},
+	}
+	routeRows := []RouteRow{{Name: "builder", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "gpt-5.3-codex"},
+		{ProviderID: "p2", Model: "gpt-5.3-codex"},
+	}, Enabled: true}}
+	cat := &fakeCatalog{pool: []catalog.Model{catModel("gpt-5.3-codex", "responses", nil)}}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" }, cat)
+
+	d := snap.ResolveDetail("builder")
+	if len(d) != 2 {
+		t.Fatalf("ResolveDetail = %d entries, want 2", len(d))
+	}
+	if d[0].Usable || !strings.HasPrefix(d[0].SkipReason, "responses_only") {
+		t.Fatalf("chat row = usable %v, skip %q; want unusable with a responses_only reason", d[0].Usable, d[0].SkipReason)
+	}
+	if !d[1].Usable {
+		t.Fatalf("openai-responses row skip = %q, want usable", d[1].SkipReason)
+	}
+	attempts, err := snap.Resolve("builder", "", Sticky{})
+	if err != nil || len(attempts) != 1 || attempts[0].ProviderName != "openai-responses" {
+		t.Fatalf("Resolve = %d attempts, %v; want only the openai-responses row", len(attempts), err)
+	}
+}
+
 // TestResolveVisionRejectsModelDeclaringOnlyChat confirms a catalog
 // model that does NOT declare SupportsVision is skipped when the
 // caller asks for CapVision as an extra requirement (D-045) — the


### PR DESCRIPTION
## Why

Missions ae69e3f0 and 316a71ec burned every iteration on `404 This model is not supported in the v1/chat/completions endpoint`: the native walk landed on the openaicompat row that serves gpt-5.3-codex for codex-cli, and a chat call there always fails.

## What changes

`entryGate` asks the catalog: a model whose LiteLLM mode is `responses` on an `openaicompat` row is unusable with reason `responses_only`. The same model on an `openai-responses` row stays usable, and a missing catalog match leaves the row usable. No new flag or schema; the catalog already carries the mode. The routes UI already shows skip reasons.

Closes #708

## Verification

New router test: chat row skipped with the reason, responses row usable, `Resolve` returns only the responses row. `go test -race ./internal/gateway/...` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791778115&installation_model_id=431401&pr_number=715&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F715&signature=04dd6b90a893a064d1f0d3bd7339cf055a3e8a5d7c8e3fe2eb3db9dae172f08e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->