### PR TITLE
fix(missions): stop sending codex a schema that costs it its tools

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -345,7 +345,7 @@ func (r *delegatedRunner) runDelegatedReview(ctx context.Context, m Mission, pac
 		PromptPath:   filepath.Join(rdir, "prompt.md"),
 		SystemAppend: reviewSystemPrompt + delegatedReviewSystemAppend,
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
-		ResultSchema: reviewVerdictSchema, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
+		ResultSchema: reviewSchemaFor(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 		StateDir: executorStateDir(m.Workspace, m.ReviewHarness),
 		// ResumeSessionID stays empty: every review round is a cold
 		// session (D-092). ReadOnly is the enforced safety knob.
@@ -733,6 +733,27 @@ func newRunID() (string, error) {
 // schema without it.
 var resultSchemaJSON = json.RawMessage(`{"type":"object","properties":{"status":{"type":"string","enum":["DONE","RETRY","BLOCKED"]},"note":{"type":"string"}},"required":["status","note"],"additionalProperties":false}`)
 
+// reviewSchemaFor is workerResultSchema's review counterpart (issue
+// #716): a reviewer that loses its tools to a schema cannot read the
+// diff it is meant to review.
+func reviewSchemaFor(adapter executor.Adapter) json.RawMessage {
+	if adapter.Capabilities().SchemaSuppressesTools {
+		return nil
+	}
+	return reviewVerdictSchema
+}
+
+// workerResultSchema is the structured-result schema for adapter, or
+// nil when asking for one would cost the CLI its tools (issue #716).
+// The prompt still demands the same shape, and the adapter reads it
+// back from the final message, so the verdict contract is unchanged.
+func workerResultSchema(adapter executor.Adapter) json.RawMessage {
+	if adapter.Capabilities().SchemaSuppressesTools {
+		return nil
+	}
+	return resultSchemaJSON
+}
+
 // delegatedSystemAppend is appended to the packet's own system prompt
 // (WorkPacket.Render's SystemAppend) — it tells the harness to end with
 // the structured status output instead of a mission_status tool call
@@ -741,6 +762,11 @@ var resultSchemaJSON = json.RawMessage(`{"type":"object","properties":{"status":
 // harness-side verify_cmd/CheckArtifacts runs regardless of what it
 // reports.
 const delegatedSystemAppend = " You are running as a delegated coding CLI, not through mission_status. End your turn by producing the required structured output with status DONE, RETRY, or BLOCKED and a short note. Only report DONE when every acceptance criterion for the current unit is genuinely met — the harness independently verifies your artifacts and verify_cmd regardless of what you report, so a false DONE only costs a wasted review round, never actually passes. The harness commits the unit's files itself after your turn, so never run git add, commit, reset, stash, or checkout."
+
+// delegatedVerdictShapeAppend spells out the result contract for an
+// adapter that cannot be sent a schema (issue #716). The object must
+// come last so the adapter's trailing-JSON extraction finds it.
+const delegatedVerdictShapeAppend = " Finish your final message with a single JSON object on its own line and nothing after it: {\"status\": \"DONE\" | \"RETRY\" | \"BLOCKED\", \"note\": \"<one sentence>\"}. Do the unit's actual work with your tools first; the object reports what you did, it is never a substitute for doing it."
 
 // delegatedAllowTools/delegatedDenyTools are the delegated worker's
 // static tool surface, passed as the CLI's own allow/deny flags at
@@ -804,6 +830,12 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	rdir := runDir(m.Workspace, runID)
 	system, user, refFiles := packet.RenderForDelegated(rdir)
 	system += delegatedSystemAppend
+	if adapter.Capabilities().SchemaSuppressesTools {
+		// No schema is sent (issue #716), so the shape has to be asked
+		// for in words; the adapter reads the trailing JSON object of
+		// the final message.
+		system += delegatedVerdictShapeAppend
+	}
 
 	decision := r.planSessionResume(ctx, m, workRoot, adapter)
 
@@ -813,7 +845,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		SystemAppend: system,
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
 		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
-		ResultSchema: resultSchemaJSON, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
+		ResultSchema: workerResultSchema(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 		ResumeSessionID: decision.sessionID,
 		StateDir:        executorStateDir(m.Workspace, m.Harness),
 	}

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -741,6 +741,68 @@ func TestDelegatedRunWorker_IdleHang_KilledAndRetried(t *testing.T) {
 	}
 }
 
+// --- scenario 3a2: schema suppresses tools (issue #716) ------------------
+
+// schemaSuppressingAdapter wraps a registered adapter, declaring that a
+// strict result schema would cost it its tools.
+type schemaSuppressingAdapter struct{ executor.Adapter }
+
+func (a schemaSuppressingAdapter) Capabilities() executor.Capabilities {
+	caps := a.Adapter.Capabilities()
+	caps.SchemaSuppressesTools = true
+	return caps
+}
+
+// TestWorkerResultSchema_OmittedWhenItWouldSuppressTools (issue #716):
+// codex answered the Responses API with one schema-shaped message and
+// zero tool calls, so an adapter that declares the conflict is sent no
+// schema, while every other adapter still gets one.
+func TestWorkerResultSchema_OmittedWhenItWouldSuppressTools(t *testing.T) {
+	plain, ok := executor.Lookup("claude-cli")
+	if !ok {
+		t.Fatal("claude-cli adapter not registered")
+	}
+	if got := workerResultSchema(plain); len(got) == 0 {
+		t.Fatal("workerResultSchema for a normal adapter = empty, want the schema")
+	}
+	if got := reviewSchemaFor(plain); len(got) == 0 {
+		t.Fatal("reviewSchemaFor for a normal adapter = empty, want the schema")
+	}
+	suppressing := schemaSuppressingAdapter{Adapter: plain}
+	if got := workerResultSchema(suppressing); got != nil {
+		t.Fatalf("workerResultSchema for a schema-suppressing adapter = %s, want nil", got)
+	}
+	if got := reviewSchemaFor(suppressing); got != nil {
+		t.Fatalf("reviewSchemaFor for a schema-suppressing adapter = %s, want nil", got)
+	}
+}
+
+// TestCodexDeclaresSchemaSuppressesTools pins the adapter's own
+// declaration: the runner's behavior above hangs off it.
+func TestCodexDeclaresSchemaSuppressesTools(t *testing.T) {
+	codex, ok := executor.Lookup("codex-cli")
+	if !ok {
+		t.Fatal("codex-cli adapter not registered")
+	}
+	if !codex.Capabilities().SchemaSuppressesTools {
+		t.Fatal("codex-cli Capabilities().SchemaSuppressesTools = false, want true (issue #716)")
+	}
+	if workerResultSchema(codex) != nil {
+		t.Fatal("codex-cli is still sent a result schema")
+	}
+}
+
+// TestDelegatedSystemAppend_CarriesVerdictShapeWithoutSchema: with no
+// schema to enforce the shape, the system prompt must ask for it and
+// insist the work happens first (issue #716).
+func TestDelegatedSystemAppend_CarriesVerdictShapeWithoutSchema(t *testing.T) {
+	for _, want := range []string{`{"status"`, "DONE", "RETRY", "BLOCKED", "tools first"} {
+		if !strings.Contains(delegatedVerdictShapeAppend, want) {
+			t.Fatalf("delegatedVerdictShapeAppend does not mention %q: %s", want, delegatedVerdictShapeAppend)
+		}
+	}
+}
+
 // --- scenario 3b: DONE that changed nothing (issue #706) -----------------
 
 // TestDelegatedRunWorker_DoneWithCleanWorktree_ForcedFreshRetry: a DONE

--- a/internal/brain/missions/executor/codex.go
+++ b/internal/brain/missions/executor/codex.go
@@ -39,6 +39,12 @@ func (codexAdapter) Capabilities() Capabilities {
 		// resume --help`); BuildInvocation switches to that subcommand
 		// form when ResumeSessionID is set.
 		SupportsResume: true,
+		// issue #716: --output-schema on the Responses wire turns the
+		// turn into a single structured message with no function calls,
+		// so codex can never touch the worktree. The verdict is read
+		// from the trailing JSON object of its final message instead
+		// (buildResultEvent).
+		SchemaSuppressesTools: true,
 	}
 }
 

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -41,6 +41,15 @@ type Capabilities struct {
 	// issue #499). False means the runner must never set
 	// ResumeSessionID for this adapter: it always starts fresh.
 	SupportsResume bool
+	// SchemaSuppressesTools declares that asking this CLI for a strict
+	// structured result costs it the ability to call tools at all, so
+	// the runner must not send ResultSchema (issue #716). Observed on
+	// codex against the Responses API: the turn comes back as one
+	// schema-shaped message with zero function calls, and the model
+	// says it was never allowed to run anything. Such an adapter reads
+	// its verdict out of the final message instead, so the contract
+	// still holds, one rung lower on the ladder.
+	SchemaSuppressesTools bool
 }
 
 // InvocationSpec is what the runner supplies to build one CLI invocation.


### PR DESCRIPTION
## Why

molla-go Slice 1 (mission b1e34df8) ran four codex build turns after the alpha.87 fixes. Each one: ~10 seconds, 13.5k input tokens, **zero** reasoning tokens, **zero** `command_execution` items, one `agent_message`, clean worktree. The fourth turn stated the cause itself:

> I'm blocked from making the required code changes because this turn only asked for final structured output and no tool execution was performed. Please let me run commands to edit `internal/core/base62.go`.

codex's own rollout shows it built a normal agentic turn: `approval_policy: never`, `sandbox_policy: danger-full-access`, base instructions promising function calls, no `tools` array in the request. A strict `--output-schema` on the Responses wire returns one schema-shaped message and suppresses function calls, so the worker can never edit anything. The 0.147.0 fixtures were recorded against Ollama, where the same flag still allows tools, which is why tests never caught it.

## What changes

- New capability `SchemaSuppressesTools`; codex-cli declares it.
- `workerResultSchema` and `reviewSchemaFor` return nil for such an adapter, on both the build and prove paths. Every other adapter is unaffected.
- The delegated system prompt gains the verdict shape in words for those adapters, insisting the unit's work happens with tools first.
- No parsing change: codex already extracts the trailing JSON object from its final message.

Closes #716

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./internal/brain/... ./internal/gateway/...`, `make lint` all green. New tests cover the flag, both schema paths, codex's declaration, and the prompt contract.

Note the alpha.87 harness fixes all behaved correctly here: the empty-worktree DONE was caught and retried fresh rather than accepted, sessions were reset instead of resumed, the entry was never cooled, the prompt was 5.6 KB ending with the unit, and all four rollouts shared one codex home. The mission surfaced an honest BLOCKED instead of burning iterations on a 404.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791801140&installation_model_id=431401&pr_number=717&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F717&signature=29a17763067a52b8e9d95bba13d50fb037d2ced86d9e5e96a5dddd19c1217afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->