### PR TITLE
fix(missions): make every code harness finish a simple slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ via the existing `--env-file` Make targets.
 - Worker turns end on successful sentinel execution
   (`loop.Request.EndTurnTools`); never add a post-sentinel model call.
 - Harness-owned verification: `CheckArtifacts` runs BEFORE any
-  model-authored `verify_cmd`; `passes` flags flip only on harness
+  model-authored `check_cmd`; `passes` flags flip only on harness
   evidence, never on model claims.
 - Follow-up missions: terminal mission → new mission with
   `parent_mission_id`; parent outcome digest snapshotted into

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -276,7 +276,7 @@ func main() {
 		})
 	}
 
-	// Mission shell/verify_cmd execution always runs sandboxed via
+	// Mission shell/check_cmd execution always runs sandboxed via
 	// sandboxd (it holds the Docker socket, brain no longer touches it
 	// directly). Brain doesn't fail closed if sandboxd itself is
 	// unreachable at boot: that surfaces as a degraded health check
@@ -1095,7 +1095,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		}
 	}
 	// sandboxMgr routes model-authored command execution (the
-	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
+	// worker/reviewer shell, check_cmd) OUT of brain's own process,
 	// through sandboxd, into a per-mission Docker container.
 	// search_kb: nil-safe (mc is never nil, MEMORYD_URL always resolves
 	// to a default), same shape as chat's own SetKBSearch wiring:
@@ -1458,7 +1458,7 @@ const credResolveTimeout = 3 * time.Second
 
 // buildDelegatedRunner wraps native with missions.NewDelegatedRunner
 // when a sandbox manager is present: missions already require one for
-// the native shell/verify_cmd path, so its absence here would mean
+// the native shell/check_cmd path, so its absence here would mean
 // missions are disabled entirely (buildMissions already returned early
 // in that case). A nil secrets store still lets subscription-mode
 // executors run (the literal "subscription" credential_ref never

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -25,9 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Brain's shell tool needs /bin/sh; alpine provides busybox sh while
 # staying minimal. Select with build target runtime-shell. Everything
 # else keeps the distroless default (last stage). curl is installed
-# explicitly: busybox wget is present by default, but plan/verify_cmd
+# explicitly: busybox wget is present by default, but plan/check_cmd
 # content (model-authored) reaches for curl as the more common default,
-# and a missing binary fails a verify_cmd with a misleading exit code
+# and a missing binary fails a check_cmd with a misleading exit code
 # instead of a clear "not found". git is required by coding missions:
 # the missions engine execs `git worktree add`, `git diff`, rollback,
 # and teardown inside this container. openssh-keygen provides

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -153,7 +153,7 @@ services:
       # off) since whisper itself defaults off — see its service
       # comment.
       WHISPER_URL: ${WHISPER_URL:-}
-      # sandboxd's internal address — mission shell/verify_cmd execution
+      # sandboxd's internal address: mission shell/check_cmd execution
       # always runs there; brain never touches the Docker socket
       # directly.
       SANDBOXD_URL: http://sandboxd:8083

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       # off) since whisper itself defaults off — see its service
       # comment.
       WHISPER_URL: ${WHISPER_URL:-}
-      # sandboxd's internal address — mission shell/verify_cmd execution
+      # sandboxd's internal address: mission shell/check_cmd execution
       # always runs there; brain never touches the Docker socket
       # directly.
       SANDBOXD_URL: http://sandboxd:8083

--- a/deploy/sandbox-base.Dockerfile
+++ b/deploy/sandbox-base.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Mission sandbox base: the container model-authored shell commands
-# (mission worker/reviewer shell calls, verify_cmd) execute inside,
+# (mission worker/reviewer shell calls, check_cmd) execute inside,
 # instead of brain's own process — see internal/brain/sandbox. This is
 # a warm exec target (created once per mission, `sleep infinity` as
 # PID 1 under tini via --init at runtime, reused across a mission's

--- a/deploy/sandbox-go.Dockerfile
+++ b/deploy/sandbox-go.Dockerfile
@@ -2,7 +2,7 @@
 
 # Go environment variant (tag timothy-sandbox-go): adds the Go
 # toolchain to the base mission sandbox — missions writing Go need
-# `go build`/`go test` for their verify_cmd.
+# `go build`/`go test` for their check_cmd.
 ARG SANDBOX_BASE=timothy-sandbox-base:latest
 FROM golang:1.26.6 AS go-dist
 

--- a/internal/brain/missions/CLAUDE.md
+++ b/internal/brain/missions/CLAUDE.md
@@ -66,7 +66,7 @@ CLAUDE.md so other work does not pay for it every session.
   (`Driver.SetNameMission`) if still empty.
 - Harness-owned verification: `CheckArtifacts` (declared artifact paths
   must exist, non-empty, inside the workspace) runs BEFORE any
-  model-authored `verify_cmd`. `passes` flags flip only on harness
+  model-authored `check_cmd`. `passes` flags flip only on harness
   evidence, never on model claims.
 - Batch verification (D-094, issue #518): after every build turn
   `verifier.verifyAll` checks every unit (unverified ones fully,
@@ -112,7 +112,7 @@ CLAUDE.md so other work does not pay for it every session.
   `ExtraTools` that shadow base tools by name. Workers must create files
   with `write_file` only; shell redirects/heredocs classify destructive
   and park the turn.
-- Non-coding units whose artifacts + verify_cmd pass harness checks skip
+- Non-coding units whose artifacts + check_cmd pass harness checks skip
   LLM review entirely (`mission.review_skipped`).
 - Delegated reviewer (issue #582): a mission's opt-in `review_harness`
   runs the prove round as a read-only CLI (`executor.InvocationSpec.
@@ -130,9 +130,44 @@ CLAUDE.md so other work does not pay for it every session.
   invalid_request) surface as `ErrProviderRejected` and pause as infra.
 - A delegated DONE over an untouched worktree (WT summary clean) is a
   forced retry with `session_reset` on `executor.result` (issue #706);
-  `LastRunState` reads it and the next run starts fresh. Forced
-  retries never roll the worktree back; only a worker-declared RETRY
-  or a review rework does.
+  `LastRunState` reads it and the next run starts fresh. No retry of
+  any kind rolls the worktree back (issue #718: a RETRY reports
+  unfinished work); only a review rework does.
+- Delegated failure classes (issue #718): a result whose error text is
+  a provider rejection (`isProviderRejection`: billing, quota, 4xx/5xx,
+  "use the v1/responses endpoint") is never a verdict; `finish` records
+  it, cools the entry and returns `ExecutorUnavailableError` (infra
+  pause with `until`). A sandbox launch error (`isSandboxError`,
+  `sandboxclient:` prefix) pauses as infra for `sandboxRetryDelay` and
+  never cools a provider. The router marks a `harnessChatOnly` harness
+  (pi) unusable on a Responses-only catalog model, and any harness
+  entry that resolves to no model (`emptyModelSkip`: chain pins none,
+  provider row has no `default_model`) unusable instead of letting
+  `BuildInvocation` fail three retries later.
+- A tool result with no content (`git status --short` on a clean tree)
+  used to 400 every OpenAI Responses turn: the API rejects
+  `"output": ""` as missing, the continuation retry resends the full
+  history with the same item and fails again, and the log shows only
+  the second failure (`input[N].output`, N = the empty item's index in
+  the full map). `openairesponses.appendMessage` substitutes
+  `emptyToolOutput` ("(no output)"); the two-request shape is why the
+  index never pointed at a one-item continuation body (issue #718).
+- A run with zero tool calls did nothing (issue #718): `pollToVerdict`
+  marks the verdict `noWork`, `finish` sets `session_reset`, and
+  `RunWorker` relaunches once fresh (`executor.relaunched`,
+  `maxNoWorkRelaunch`) before the verdict reaches the driver; a BLOCKED
+  that names a plan defect is kept as information.
+- A plan unit whose every artifact belongs to an earlier unit (a
+  trailing "format and verify" unit) is rejected at plan acceptance
+  (`checkOwnArtifacts`): its commands belong in the producing units.
+- Plan defects travel back to the planner (issue #718): a worker
+  BLOCKED note that names the plan (`namesPlanDefect`: a gate,
+  criterion, artifact path, "cannot pass", "in isolation") is
+  `InputPlanDefect`, which spends the one automatic replan with the
+  note recorded as progress; once spent it parks like any block. A
+  replan keeps harness evidence: `restorePassedUnits` matches prior
+  verified units by title+check_cmd or by identical artifact set and
+  carries `harness_passed` (and `passes`) forward.
 - CLI session state lives in `<workspace>/executor/<harness>`
   (`InvocationSpec.StateDir`, issue #707): codex's CODEX_HOME is shared
   by every run of a mission so `codex exec resume` finds its rollout.
@@ -143,4 +178,13 @@ CLAUDE.md so other work does not pay for it every session.
   attachments, then the current unit last with artifacts and verify
   command. Parent digest and references are files under `runs/<id>/refs/`
   (returned as files, written by `launchRun`), never inline.
+- Plan gates (issue #718): a unit's `check_cmd` (renamed from
+  `verify_cmd`; `Plan.normalize` reads the old key until the
+  pending-alters rename runs) is a gate, never a proof. `acceptPlan`
+  rejects, with one planner recovery turn: the `| grep -q '^$'` idiom
+  (exits 1 on empty output), a coding unit with source artifacts and no
+  toolchain call (`checkCodeFloor`, per sandbox environment), and, via
+  a 60 s sandbox probe against the pre-work tree, a gate that already
+  exits 0 or names a command the environment lacks. Verifying that the
+  criteria are met is the reviewer's job, not the gate's.
 - `make canary` is the regression gate for any harness change.

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -759,9 +760,9 @@ func workerResultSchema(adapter executor.Adapter) json.RawMessage {
 // the structured status output instead of a mission_status tool call
 // (the harness has no such tool; ResultSchema is how it reports back),
 // and that DONE means every acceptance criterion is met even though the
-// harness-side verify_cmd/CheckArtifacts runs regardless of what it
+// harness-side check_cmd/CheckArtifacts runs regardless of what it
 // reports.
-const delegatedSystemAppend = " You are running as a delegated coding CLI, not through mission_status. End your turn by producing the required structured output with status DONE, RETRY, or BLOCKED and a short note. Only report DONE when every acceptance criterion for the current unit is genuinely met — the harness independently verifies your artifacts and verify_cmd regardless of what you report, so a false DONE only costs a wasted review round, never actually passes. The harness commits the unit's files itself after your turn, so never run git add, commit, reset, stash, or checkout."
+const delegatedSystemAppend = " You are running as a delegated coding CLI, not through mission_status. End your turn by producing the required structured output with status DONE, RETRY, or BLOCKED and a short note. Only report DONE when every acceptance criterion for the current unit is genuinely met: the harness independently verifies your artifacts and check_cmd regardless of what you report, so a false DONE only costs a wasted review round, never actually passes. The harness commits the unit's files itself after your turn, so never run git add, commit, reset, stash, or checkout."
 
 // delegatedVerdictShapeAppend spells out the result contract for an
 // adapter that cannot be sent a schema (issue #716). The object must
@@ -823,38 +824,59 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	}
 	run := workerRun(m, entry, adapter, authMode)
 
-	runID, err := newRunID()
-	if err != nil {
-		return WorkerVerdict{}, "", err
-	}
-	rdir := runDir(m.Workspace, runID)
-	system, user, refFiles := packet.RenderForDelegated(rdir)
-	system += delegatedSystemAppend
-	if adapter.Capabilities().SchemaSuppressesTools {
-		// No schema is sent (issue #716), so the shape has to be asked
-		// for in words; the adapter reads the trailing JSON object of
-		// the final message.
-		system += delegatedVerdictShapeAppend
-	}
-
 	decision := r.planSessionResume(ctx, m, workRoot, adapter)
+	for attempt := 0; ; attempt++ {
+		runID, err := newRunID()
+		if err != nil {
+			return WorkerVerdict{}, "", err
+		}
+		rdir := runDir(m.Workspace, runID)
+		system, user, refFiles := packet.RenderForDelegated(rdir)
+		system += delegatedSystemAppend
+		if adapter.Capabilities().SchemaSuppressesTools {
+			// No schema is sent (issue #716), so the shape has to be asked
+			// for in words; the adapter reads the trailing JSON object of
+			// the final message.
+			system += delegatedVerdictShapeAppend
+		}
 
-	spec := executor.InvocationSpec{
-		MissionID: m.ID, Workdir: workRoot,
-		PromptPath:   filepath.Join(rdir, "prompt.md"),
-		SystemAppend: system,
-		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
-		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
-		ResultSchema: workerResultSchema(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
-		ResumeSessionID: decision.sessionID,
-		StateDir:        executorStateDir(m.Workspace, m.Harness),
-	}
-	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, refFiles, decision); err != nil {
-		return WorkerVerdict{}, "", err
-	}
+		spec := executor.InvocationSpec{
+			MissionID: m.ID, Workdir: workRoot,
+			PromptPath:   filepath.Join(rdir, "prompt.md"),
+			SystemAppend: system,
+			Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
+			AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
+			ResultSchema: workerResultSchema(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
+			ResumeSessionID: decision.sessionID,
+			StateDir:        executorStateDir(m.Workspace, m.Harness),
+		}
+		if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, refFiles, decision); err != nil {
+			return WorkerVerdict{}, "", err
+		}
 
-	return r.pollToVerdict(ctx, m, run, workRoot, rdir, runID, 0)
+		verdict, text, err := r.pollToVerdict(ctx, m, run, workRoot, rdir, runID, 0)
+		if err != nil {
+			return verdict, text, err
+		}
+		// A run that made no tool call did not start the unit (issue
+		// #718: a resumed codex session answers with a verdict and
+		// nothing else). One fresh relaunch before it counts; a block
+		// that diagnoses the plan is kept, that is information, not
+		// idleness.
+		diagnosedPlan := verdict.Outcome == "blocked" && namesPlanDefect(verdict.Question, m.Plan)
+		if verdict.noWork && attempt < maxNoWorkRelaunch && !diagnosedPlan {
+			r.recordEventForce(ctx, m.ID, "executor.relaunched", map[string]any{"phase": run.phase, "run_id": runID, "reason": "no_tool_calls", "status": strings.ToUpper(verdict.Outcome)})
+			decision = resumeDecision{reason: resumeReasonSessionReset}
+			continue
+		}
+		return verdict, text, nil
+	}
 }
+
+// maxNoWorkRelaunch is how many fresh relaunches RunWorker grants a
+// turn whose runs make no tool call before the verdict reaches the
+// driver and costs an iteration.
+const maxNoWorkRelaunch = 1
 
 // launchRun builds the invocation, writes prompt.md (plus a Steerer's
 // prompt.jsonl/steer.jsonl), records executor.spawned and starts the
@@ -903,8 +925,15 @@ func (r *delegatedRunner) launchRun(ctx context.Context, m Mission, run cliRun, 
 	r.recordSpawned(ctx, m.ID, run, runID, rdir, decision)
 
 	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, spec.RunBudget, isSteerer); err != nil {
-		r.coolDown(run.harness, run.entry)
 		r.recordDied(ctx, m.ID, run.phase, "spawn_failed", nil, err.Error())
+		// A sandbox that cannot start the CLI (image missing, sandboxd
+		// down) says nothing about the provider (issue #718): pause as
+		// infra with a short retry and leave the entry alone. Anything
+		// else from launch is the CLI itself failing to start.
+		if isSandboxError(err) {
+			return &ExecutorUnavailableError{Harness: run.harness, Reason: "sandbox unavailable: " + err.Error(), Until: time.Now().Add(sandboxRetryDelay)}
+		}
+		r.coolDown(run.harness, run.entry)
 		return fmt.Errorf("delegated runner: launch: %w", err)
 	}
 	return nil
@@ -1164,7 +1193,12 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, run cliR
 	}
 	switch end {
 	case runEndResult:
-		return r.finish(ctx, m, run, st, start, exitCode)
+		v, text, err := r.finish(ctx, m, run, st, start, exitCode)
+		// noWork marks only a run that RAN and reported: an idle kill or
+		// a transport death has its own handling and must not be
+		// relaunched a second time on top of it (issue #718).
+		v.noWork = st.toolCalls == 0
+		return v, text, err
 	case runEndIdle:
 		v := forcedRetryVerdict("the executor produced no output for the idle timeout and was killed")
 		stampServed(&v, run, st)
@@ -1522,6 +1556,17 @@ func (r *delegatedRunner) killRun(ctx context.Context, missionID, environment, w
 // sentinel in the accumulated text; failing that, a forced retry noting
 // the executor never reported a status.
 func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int) (WorkerVerdict, string, error) {
+	// The provider ended the run (issue #718: a 429 for balance, a 404
+	// for a model the wire does not serve): nothing a worker retry can
+	// change, so it is never a verdict. Record the run, cool the entry,
+	// and hand the driver an infra pause that waits out the cooldown.
+	if e := st.resultEvent.Err; e != "" && !isAuthFailure(e) && isProviderRejection(e) {
+		if err := r.finishCommon(ctx, m, run, st, start, exitCode, "none", "REJECTED", false); err != nil {
+			return WorkerVerdict{}, st.textBuf.String(), err
+		}
+		r.coolDown(run.harness, run.entry)
+		return WorkerVerdict{}, st.textBuf.String(), &ExecutorUnavailableError{Harness: run.harness, Reason: "provider rejected the run: " + truncate(e, 300), Until: time.Now().Add(cooldownTTL)}
+	}
 	res, ok := run.adapter.ParseResult(st.resultEvent)
 	parseKind := "schema"
 	var verdict WorkerVerdict
@@ -1552,6 +1597,11 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st 
 	sessionReset := false
 	if ok && verdict.Outcome == "done" && st.worktree != nil && st.worktree.Untracked == 0 && st.worktree.Modified == 0 {
 		verdict = forcedRetryVerdict("executor reported DONE but changed nothing in the worktree; the unit is not done")
+		sessionReset = true
+	}
+	// A run with no tool call at all did nothing, whatever it said
+	// (issue #718): the session that produced it is not worth resuming.
+	if st.toolCalls == 0 {
 		sessionReset = true
 	}
 	stampServed(&verdict, run, st)
@@ -1666,6 +1716,54 @@ var authFailureSignatures = []string{
 	"please run /login",
 	"authentication_error",
 }
+
+// providerRejectionSignatures are the shapes a CLI's terminal error
+// takes when the provider, not the model, ended the run (issue #718):
+// billing, quota, a wire the model does not serve, a malformed
+// request. None of them is the worker's fault and none improves on a
+// retry of the same entry.
+var providerRejectionSignatures = []string{
+	"request rejected",
+	"insufficient balance",
+	"insufficient_quota",
+	"exceeded your current quota",
+	"rate limit",
+	"rate_limit",
+	"not supported in the v1/chat/completions endpoint",
+	"use the v1/responses endpoint",
+	"invalid_request_error",
+	"model_not_found",
+	"api error",
+}
+
+// providerStatusCode matches an HTTP status a CLI quotes in its error
+// text, in an HTTP shape only ("(429)", "404: {", "HTTP 503",
+// "status 502") so a bare number in a test failure never cools a
+// provider; 401/403 are left to isAuthFailure.
+var providerStatusCode = regexp.MustCompile(`(?i)(?:^|\(|\b(?:status|http|error)\b\D{0,4})(400|402|404|408|409|413|422|429|500|502|503|529)\b`)
+
+// isProviderRejection reports whether a result's error text is the
+// provider refusing the run.
+func isProviderRejection(text string) bool {
+	lower := strings.ToLower(text)
+	for _, sig := range providerRejectionSignatures {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return providerStatusCode.MatchString(text)
+}
+
+// isSandboxError reports whether err came from the sandbox client
+// rather than the CLI it was asked to start.
+func isSandboxError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "sandboxclient:")
+}
+
+// sandboxRetryDelay is how long an infra pause for a sandbox launch
+// failure asks the sweep to wait: long enough for an image pull or a
+// sandboxd restart, short enough not to stall a mission for a blip.
+const sandboxRetryDelay = 2 * time.Minute
 
 // sessionLostSignatures are the stderr lines a CLI prints when a
 // resume names a session it no longer has (codex, claude).

--- a/internal/brain/missions/delegated_classify_test.go
+++ b/internal/brain/missions/delegated_classify_test.go
@@ -1,0 +1,184 @@
+package missions
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+)
+
+// TestIsProviderRejection pins the classifier on the error texts the
+// eval produced (issue #718) and on texts that are not the provider's.
+func TestIsProviderRejection(t *testing.T) {
+	yes := []string{
+		"API Error: Request rejected (429) · [1113][Insufficient balance or no resource package. Please recharge.]",
+		`404: {"message":"This model is not supported in the v1/chat/completions endpoint. Use the v1/responses endpoint instead.","type":"invalid_request_error"}`,
+		"You exceeded your current quota, please check your plan and billing details.",
+		"http 503 service unavailable",
+		"status 502 from upstream",
+	}
+	for _, s := range yes {
+		if !isProviderRejection(s) {
+			t.Errorf("isProviderRejection missed %q", s)
+		}
+	}
+	no := []string{
+		"",
+		"the executor produced no output for the idle timeout and was killed",
+		"tests failed: 3 of 12",
+		"please run /login to authenticate",
+		"redirect_test.go:41: want 404 got 200",
+		"benchmark ran 500 iterations",
+	}
+	for _, s := range no {
+		if isProviderRejection(s) {
+			t.Errorf("isProviderRejection false positive on %q", s)
+		}
+	}
+}
+
+// noToolFixture is the claude schema fixture with only the assistant
+// tool-call turn and its result dropped: a run that still reports its
+// verdict, having called nothing. The init line stays (it carries the
+// session id, and its "tools" array is the offered surface, not a
+// call), as does the terminal result line.
+func noToolFixture(t *testing.T) [][]byte {
+	t.Helper()
+	var out [][]byte
+	for _, l := range loadDelegatedFixture(t, "schema.ndjson") {
+		if bytes.Contains(l, []byte(`"type":"tool_use"`)) || bytes.Contains(l, []byte(`"type":"tool_result"`)) {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+// TestDelegatedRunWorker_ProviderRejectionIsUnavailable (issue #718):
+// a result whose error is the provider refusing the run (billing here)
+// never becomes a worker verdict. The run is recorded, the entry
+// cooled, and the driver gets an ExecutorUnavailableError with until.
+func TestDelegatedRunWorker_ProviderRejectionIsUnavailable(t *testing.T) {
+	lines := noToolFixture(t)
+	for i, l := range lines {
+		if bytes.Contains(l, []byte(`"type":"result"`)) {
+			l = bytes.Replace(l, []byte(`"is_error":false`), []byte(`"is_error":true`), 1)
+			l = bytes.Replace(l, []byte(`"structured_output":{"status":"DONE","note":"Ready for task input."},`), nil, 1)
+			l = bytes.Replace(l, []byte(`"result":"{\"status\":\"DONE\",\"note\":\"Ready for task input.\"}"`),
+				[]byte(`"result":"API Error: Request rejected (429) · [1113][Insufficient balance or no resource package. Please recharge.]"`), 1)
+			lines[i] = l
+		}
+	}
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = lines
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	_, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	var unavailable *ExecutorUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want ExecutorUnavailableError", err)
+	}
+	if unavailable.Until.IsZero() || unavailable.Reason == "" {
+		t.Fatalf("unavailable = %+v, want a reason and an until", unavailable)
+	}
+	if events.count("executor.result") != 1 {
+		t.Fatalf("executor.result count = %d, want 1 (the rejected run is still recorded)", events.count("executor.result"))
+	}
+	if len(r.cooldown) != 1 {
+		t.Fatalf("cooldown entries = %d, want the rejecting entry cooled", len(r.cooldown))
+	}
+}
+
+// TestDelegatedRunWorker_SandboxLaunchErrorIsInfraNotCooldown (issue
+// #718): the sandbox failing to start the CLI (image missing) pauses as
+// infra with a short until and never cools the provider entry.
+func TestDelegatedRunWorker_SandboxLaunchErrorIsInfraNotCooldown(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.launchErr = errors.New("sandboxclient: sandbox: pull image timothy-sandbox-go:latest: Error response from daemon: not found")
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	_, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	var unavailable *ExecutorUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want ExecutorUnavailableError", err)
+	}
+	if len(r.cooldown) != 0 {
+		t.Fatalf("cooldown entries = %d, want none: a missing local image is not a provider signal", len(r.cooldown))
+	}
+	if events.count("executor.died") != 1 {
+		t.Fatalf("executor.died count = %d, want 1", events.count("executor.died"))
+	}
+}
+
+// TestDelegatedRunWorker_NoToolBlockNamingPlanIsKept (issue #718): a run
+// that calls no tool but blocks on a plan defect is a diagnosis, not
+// idleness: no relaunch, the verdict reaches the driver as is.
+func TestDelegatedRunWorker_NoToolBlockNamingPlanIsKept(t *testing.T) {
+	lines := noToolFixture(t)
+	for i, l := range lines {
+		if bytes.Contains(l, []byte(`"type":"result"`)) {
+			l = bytes.Replace(l, []byte(`"structured_output":{"status":"DONE","note":"Ready for task input."}`),
+				[]byte(`"structured_output":{"status":"BLOCKED","note":"The check_cmd cannot pass in isolation: it needs permute.go from a later unit."}`), 1)
+			lines[i] = l
+		}
+	}
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = lines
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	v, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.Outcome != "blocked" || !strings.Contains(v.Question, "check_cmd") {
+		t.Fatalf("verdict = %+v, want the BLOCKED diagnosis surfaced", v)
+	}
+	if sandbox.launches != 1 || events.count("executor.relaunched") != 0 {
+		t.Fatalf("launches = %d, relaunched = %d, want the diagnosis kept without a relaunch", sandbox.launches, events.count("executor.relaunched"))
+	}
+}
+
+// TestDelegatedRunWorker_NoToolCallsRelaunchesFresh (issue #718): a run
+// that reports a verdict without a single tool call is relaunched once
+// with a reset session before its verdict counts; the second run's
+// verdict is what RunWorker returns.
+func TestDelegatedRunWorker_NoToolCallsRelaunchesFresh(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = noToolFixture(t)
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	v, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if sandbox.launches != 2 {
+		t.Fatalf("launches = %d, want 2 (one relaunch after a no-tool run)", sandbox.launches)
+	}
+	if events.count("executor.relaunched") != 1 {
+		t.Fatalf("executor.relaunched count = %d, want 1", events.count("executor.relaunched"))
+	}
+	if events.count("executor.result") != 2 {
+		t.Fatalf("executor.result count = %d, want both runs recorded", events.count("executor.result"))
+	}
+	if !v.noWork {
+		t.Fatal("the surfaced verdict must still carry noWork for the driver's own accounting")
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -116,7 +117,7 @@ type Driver struct {
 	log       *slog.Logger
 	cfg       Config
 
-	// sandboxExec routes a plan unit's verify_cmd through the mission's
+	// sandboxExec routes a plan unit's check_cmd through the mission's
 	// sandbox container — the same backend nativeRunner uses for
 	// worker/reviewer shell calls. sandboxRemove tears the container
 	// down at a mission's terminal transition.
@@ -1455,7 +1456,7 @@ func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
 	}
 	if m.ReplanUsed {
 		// Carry forward prior harness evidence: a unit the new plan kept
-		// unchanged (same title, same verify_cmd) and that had already
+		// unchanged (same title, same check_cmd) and that had already
 		// passed stays passed -- the planner's own parsePlan forces every
 		// unit to passes=false, since it can't itself claim pre-verified.
 		restorePassedUnits(&plan, priorPlan)
@@ -1538,21 +1539,81 @@ func progressWithOperatorNotes(notes []ProgressNote, n int, render func(string) 
 	return b.String()
 }
 
-// restorePassedUnits re-marks plan's units passed when a prior unit
-// with the exact same title and verify_cmd had already passed — harness
-// evidence a replan must not silently erase for work it didn't touch.
+// restorePassedUnits carries harness evidence across a replan (issue
+// #718): a new unit that matches a prior verified unit, by title plus
+// check_cmd or by producing exactly the same artifacts, keeps that
+// unit's HarnessPassed. Reviewer approval (Passes) survives only the
+// exact match: a rewritten unit carries new criteria, so the reviewer
+// judges it again. A replan rewrites titles freely, so the artifact set
+// is the stable key; the worktree is untouched by a replan.
 func restorePassedUnits(plan *Plan, prior Plan) {
-	passed := make(map[string]bool, len(prior.Units))
+	byKey := make(map[string]PlanUnit, len(prior.Units))
+	byArtifacts := make(map[string]PlanUnit, len(prior.Units))
 	for _, u := range prior.Units {
-		if u.Passes {
-			passed[u.Title+"\x00"+u.VerifyCmd] = true
+		if !u.verified() {
+			continue
+		}
+		byKey[u.Title+"\x00"+u.CheckCmd] = u
+		if k := artifactKey(u.Artifacts); k != "" {
+			byArtifacts[k] = u
 		}
 	}
 	for i := range plan.Units {
-		if passed[plan.Units[i].Title+"\x00"+plan.Units[i].VerifyCmd] {
-			plan.Units[i].Passes, plan.Units[i].HarnessPassed = true, true
+		u := &plan.Units[i]
+		prev, ok := byKey[u.Title+"\x00"+u.CheckCmd]
+		exact := ok
+		if k := artifactKey(u.Artifacts); !ok && k != "" {
+			prev, ok = byArtifacts[k]
+		}
+		if !ok {
+			continue
+		}
+		u.HarnessPassed = true
+		u.Passes = exact && prev.Passes
+	}
+}
+
+// artifactKey is a unit's sorted, cleaned artifact list as one string;
+// empty when the unit declares none, which never matches.
+func artifactKey(artifacts []string) string {
+	if len(artifacts) == 0 {
+		return ""
+	}
+	clean := make([]string, 0, len(artifacts))
+	for _, a := range artifacts {
+		clean = append(clean, cleanArtifact(a))
+	}
+	sort.Strings(clean)
+	return strings.Join(clean, "\x00")
+}
+
+// planDefectMarkers are the phrases a worker uses when the thing it
+// cannot get past is the plan rather than the codebase or the operator.
+var planDefectMarkers = []string{
+	"check_cmd", "verify_cmd", "acceptance check", "acceptance criter", "criterion", "criteria",
+	"cannot pass", "can never pass", "can't pass", "in isolation", "this unit cannot", "unit cannot",
+	"later unit", "earlier unit", "another unit", "the gate", "verify command", "check command",
+}
+
+// namesPlanDefect reports whether a worker's BLOCKED note is about the
+// plan: it uses one of planDefectMarkers or names one of the plan's
+// artifacts. Anything else (a credential, an ambiguous goal, a design
+// choice) stays a question for the operator.
+func namesPlanDefect(question string, plan Plan) bool {
+	q := strings.ToLower(question)
+	for _, marker := range planDefectMarkers {
+		if strings.Contains(q, marker) {
+			return true
 		}
 	}
+	for _, u := range plan.Units {
+		for _, a := range u.Artifacts {
+			if a = strings.TrimSpace(a); a != "" && strings.Contains(q, strings.ToLower(a)) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // effectiveCommitStyle resolves the precedence destination override >
@@ -1661,18 +1722,25 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 		}
 		return in, nil
 	case "blocked":
+		// A block that names the plan itself (its gate, a criterion, an
+		// artifact, unit boundaries) is a diagnosis the planner can act
+		// on, not a question for the operator (issue #718): it goes back
+		// to planning with the worker's note, once. The note is recorded
+		// as progress so replanNotes carries it into the planner prompt.
+		if namesPlanDefect(verdict.Question, m.Plan) {
+			if err := d.store.AppendProgress(ctx, m.ID, "Worker blocked on a plan defect: "+truncate(verdict.Question, 500)); err != nil {
+				d.log.Warn("driver: record plan defect note failed", "mission_id", m.ID, "error", err)
+			}
+			return StepInput{Input: InputPlanDefect, Reason: truncate(verdict.Question, 500), Message: verdict.Question, Provider: verdict.Provider, Model: verdict.Model}, nil
+		}
 		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question, Provider: verdict.Provider, Model: verdict.Model}, nil
 	default: // "retry" or anything unrecognized
-		// Only a RETRY the worker itself declared rolls the tree back
-		// (issue #706): a forced retry comes from transport death, an
-		// idle or run-budget kill, or an unreadable result, none of
-		// which says the edits so far are wrong, and the retry works
-		// on top of them.
-		if wt := m.WorktreePath(); wt != "" && !verdict.Forced {
-			if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
-				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
-			}
-		}
+		// No rollback on a retry of any kind (issue #718): a worker's
+		// own RETRY reports unfinished work, not wrong work, and the next
+		// turn continues on the files it left (a delegated CLI wrote
+		// permute.go and its test, said RETRY to fix the inverse, and the
+		// old rollback deleted both). Only a review rework discards the
+		// tree (runReview).
 		in := StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500), Provider: verdict.Provider, Model: verdict.Model}
 		if verdict.Forced {
 			// Neither a tool call nor a text-form sentinel (runner.go's
@@ -1710,7 +1778,7 @@ func (d *Driver) routeVerified(ctx context.Context, m Mission, verified []UnitVe
 		}
 	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{
-		"units": pending, "reason": "artifacts and verify_cmd passed harness checks",
+		"units": pending, "reason": "artifacts and check_cmd passed harness checks",
 	}); err != nil {
 		d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
 	}

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -41,7 +41,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	}
 
 	runner := &scriptedRunner{
-		plans: []Plan{{Units: []PlanUnit{{Title: "add a file", VerifyCmd: "test -f new-file.txt"}}}},
+		plans: []Plan{{Units: []PlanUnit{{Title: "add a file", CheckCmd: "test -f new-file.txt"}}}},
 		workerVerdicts: []WorkerVerdict{
 			{Outcome: "done", Evidence: "created new-file.txt"},
 		},
@@ -50,7 +50,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	d := NewDriver(store, runner, workspace, nil, nil, nil, fakeSandboxExec, nil, log)
 
 	// The scripted worker "does the work" by actually creating the file
-	// the verify_cmd checks for — RunVerify runs for real against the
+	// the check_cmd checks for; RunVerify runs for real against the
 	// worktree, so the harness's own evidence must be genuine, not
 	// merely claimed.
 	if err := os.WriteFile(wt+"/new-file.txt", []byte("hello"), 0o644); err != nil {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -367,7 +367,7 @@ func (r *scriptedRunner) DiscoverSession(ctx context.Context, m Mission) (string
 }
 
 // fakeSandboxExec runs command via /bin/sh -c directly in workdir —
-// tests exercising verify_cmd need the real exit code/output a plan's
+// tests exercising check_cmd need the real exit code/output a plan's
 // check produces, not a mocked one, and don't care that it isn't
 // actually containerized.
 func fakeSandboxExec(ctx context.Context, missionID, environment, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
@@ -421,7 +421,7 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
-		plans:          []Plan{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
+		plans:          []Plan{{Units: []PlanUnit{{Title: "only unit", CheckCmd: ""}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
 		reviewVerdicts: []ReviewVerdict{{Approved: true}},
 	}
@@ -1256,7 +1256,7 @@ func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
 // TestDriverNoProveStillReviewsWithoutArtifacts confirms flow=no_prove
 // does NOT approve a unit directly when it has no declared artifacts:
 // routeVerified's skip mechanism requires real harness evidence
-// (artifacts + verify_cmd), same as an ordinary flow=full general
+// (artifacts + check_cmd), same as an ordinary flow=full general
 // mission (TestDriverNonLightDoneStillGoesThroughReview). no_prove
 // keeps discover/plan and a real plan's units; it is not a planless
 // flow, unlike discover_build.
@@ -1289,7 +1289,7 @@ func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "general", Flow: FlowNoProve, Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(),
-		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
+		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, CheckCmd: "echo done"}}},
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it (no it didn't)"}}}
 	d := testDriver(store, runner)
@@ -1502,9 +1502,9 @@ func TestDriverReworkUntouchedEvent(t *testing.T) {
 	requireGit(t)
 	finding := Finding{ID: "F1", Title: "missing validation", File: "x.go", Severity: SeverityBlocking, Status: FindingOpen, RoundOpened: 1}
 	cases := []struct {
-		name         string
-		touch        string
-		wantEvent    bool
+		name          string
+		touch         string
+		wantEvent     bool
 		wantUntouched int
 	}{
 		{"other file touched", "y.go", true, 1},
@@ -1559,18 +1559,17 @@ func TestDriverReworkUntouchedEvent(t *testing.T) {
 	}
 }
 
-// TestDriverRetryRollbackOnlyForWorkerDeclaredRetry (issue #706): a
-// forced retry (transport death, idle or run-budget kill, unreadable
-// result) keeps the worktree's edits; only a RETRY the worker declared
-// rolls them back.
-func TestDriverRetryRollbackOnlyForWorkerDeclaredRetry(t *testing.T) {
+// TestDriverRetryNeverRollsBack (issue #718): no retry discards the
+// worktree, forced or worker-declared; a RETRY reports unfinished work
+// and the next turn continues on it. Only a review rework rolls back.
+func TestDriverRetryNeverRollsBack(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		verdict  WorkerVerdict
 		wantKept bool
 	}{
 		{"forced retry keeps the tree", forcedRetryVerdict("executor process was lost"), true},
-		{"worker retry rolls back", WorkerVerdict{Outcome: "retry", Analysis: "wrong approach"}, false},
+		{"worker retry keeps the tree", WorkerVerdict{Outcome: "retry", Analysis: "not finished yet"}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -1927,7 +1926,7 @@ func TestDriverDriveIsSerializedPerMission(t *testing.T) {
 // TestDriverReviewApprovalContradictedByVerifyRoutesToRework
 // reproduces a real bug: the reviewer approves a unit whose evidence
 // doesn't hold up (e.g. a worker claiming a file exists when it never
-// wrote one) — the harness's own verify_cmd then fails. This must NOT
+// wrote one): the harness's own check_cmd then fails. This must NOT
 // be treated as an infra fault (which just parks the mission for a
 // human to blindly resume forever); it must route through rework,
 // back to execute, so the worker gets another attempt with the actual
@@ -1936,7 +1935,7 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8,
-		Plan: Plan{Units: []PlanUnit{{Title: "write summary.md", VerifyCmd: "test -f /nonexistent-verify-target"}}},
+		Plan: Plan{Units: []PlanUnit{{Title: "write summary.md", CheckCmd: "test -f /nonexistent-verify-target"}}},
 	})
 	d := testDriver(store, &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}})
 
@@ -1948,16 +1947,16 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 		t.Fatalf("mission phase = %q, want execute (rework path), not stuck on an infra pause", m.Phase)
 	}
 	if m.PauseReason == PauseInfra {
-		t.Fatal("a failed verify_cmd after approval must not be classified as an infra fault")
+		t.Fatal("a failed check_cmd after approval must not be classified as an infra fault")
 	}
 	if m.Iteration != 1 {
 		t.Fatalf("iteration = %d, want 1 (rework costs an iteration like any other rework)", m.Iteration)
 	}
-	if open := OpenFindings(m.ReviewFindings); len(open) != 1 || !strings.Contains(open[0].Title, "verify_cmd check failed for unit 1") {
-		t.Fatalf("open findings = %+v, want one harness-authored verify_cmd finding", open)
+	if open := OpenFindings(m.ReviewFindings); len(open) != 1 || !strings.Contains(open[0].Title, "check_cmd check failed for unit 1") {
+		t.Fatalf("open findings = %+v, want one harness-authored check_cmd finding", open)
 	}
-	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "verify_cmd" {
-		t.Fatalf("unit = %+v, want the failed verify_cmd check recorded on it for the next worker packet", u)
+	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "check_cmd" {
+		t.Fatalf("unit = %+v, want the failed check_cmd check recorded on it for the next worker packet", u)
 	}
 }
 
@@ -2709,7 +2708,7 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(),
-		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
+		Plan: Plan{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, CheckCmd: "echo done"}}},
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it (no it didn't)"}}}
 	d := testDriver(store, runner)
@@ -2893,8 +2892,8 @@ func TestDriverBatchVerifyPassesLaterUnitInSameTurn(t *testing.T) {
 		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "unit0", Artifacts: []string{"a.md"}, VerifyCmd: "grep -q content a.md"},
-			{Title: "unit1", Artifacts: []string{"b.md"}, VerifyCmd: "grep -q content b.md"},
+			{Title: "unit0", Artifacts: []string{"a.md"}, CheckCmd: "grep -q content a.md"},
+			{Title: "unit1", Artifacts: []string{"b.md"}, CheckCmd: "grep -q content b.md"},
 		}},
 	})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote both"}}}
@@ -2918,7 +2917,7 @@ func TestDriverBatchVerifyPassesLaterUnitInSameTurn(t *testing.T) {
 
 // TestDriverCodingVerifyFailureRetriesBeforeReview confirms a coding
 // mission's worker claim is harness-checked at the end of its turn
-// (D-094): a failing verify_cmd buys another worker turn with the
+// (D-094): a failing check_cmd buys another worker turn with the
 // excerpt on the unit, and no review round runs on failing work.
 func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 	root, base := codingWorktree(t)
@@ -2926,7 +2925,7 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseBuild, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root, BaseCommit: base,
-		Plan: Plan{Units: []PlanUnit{{Title: "add feature", VerifyCmd: "echo tests failed; exit 1"}}},
+		Plan: Plan{Units: []PlanUnit{{Title: "add feature", CheckCmd: "echo tests failed; exit 1"}}},
 	})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -2946,8 +2945,8 @@ func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
 	if len(runner.reviewCalls) != 0 {
 		t.Fatal("a review round ran on work the harness had already failed")
 	}
-	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "verify_cmd" || !strings.Contains(u.VerifyExcerpt, "tests failed") {
-		t.Fatalf("unit = %+v, want the verify_cmd failure and output recorded", u)
+	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "check_cmd" || !strings.Contains(u.VerifyExcerpt, "tests failed") {
+		t.Fatalf("unit = %+v, want the check_cmd failure and output recorded", u)
 	}
 	if m.LastGapFingerprint != "verify_failed:unit_0" {
 		t.Fatalf("fingerprint = %q, want verify_failed:unit_0 for the stall brake", m.LastGapFingerprint)
@@ -3055,7 +3054,7 @@ func TestDriverNoRegressionAdvancesNormally(t *testing.T) {
 
 // TestDriverReplanPreservesMatchingPassedUnitsResetsOthers confirms
 // runPlan's restorePassedUnits: after a replan, a unit whose title and
-// verify_cmd are unchanged from a previously-passed unit is re-marked
+// check_cmd are unchanged from a previously-passed unit is re-marked
 // passed (harness evidence carried forward); a unit the new plan
 // changed (or that is genuinely new) stays unverified, since
 // parsePlan's own zeroing is correct for anything actually different.
@@ -3065,13 +3064,13 @@ func TestDriverReplanPreservesMatchingPassedUnitsResetsOthers(t *testing.T) {
 		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusIdle,
 		MaxIterations: 8, ReplanUsed: true,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "unit0", VerifyCmd: "test -f a.md", Passes: true},
-			{Title: "unit1", VerifyCmd: "test -f b.md", Passes: false},
+			{Title: "unit0", CheckCmd: "test -f a.md", Passes: true},
+			{Title: "unit1", CheckCmd: "test -f b.md", Passes: false},
 		}},
 	})
 	runner := &scriptedRunner{plans: []Plan{{Units: []PlanUnit{
-		{Title: "unit0", VerifyCmd: "test -f a.md"}, // unchanged: must be restored to passed
-		{Title: "unit1", VerifyCmd: "test -f c.md"}, // verify_cmd changed: must stay unverified
+		{Title: "unit0", CheckCmd: "test -f a.md"}, // unchanged: must be restored to passed
+		{Title: "unit1", CheckCmd: "test -f c.md"}, // check_cmd changed: must stay unverified
 	}}}}
 	d := testDriver(store, runner)
 
@@ -3080,10 +3079,10 @@ func TestDriverReplanPreservesMatchingPassedUnitsResetsOthers(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	if !m.Plan.Units[0].Passes {
-		t.Fatal("unit0 (title+verify_cmd unchanged) should have been restored to passed")
+		t.Fatal("unit0 (title+check_cmd unchanged) should have been restored to passed")
 	}
 	if m.Plan.Units[1].Passes {
-		t.Fatal("unit1 (verify_cmd changed) must stay unverified")
+		t.Fatal("unit1 (check_cmd changed) must stay unverified")
 	}
 }
 

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -47,7 +47,7 @@ func TestOutcomeDigest(t *testing.T) {
 				Plan: Plan{Units: []PlanUnit{{Title: "only unit", Passes: true}}},
 			},
 			events: []Event{
-				{Kind: "mission.review_skipped", Payload: json.RawMessage(`{"unit":0,"reason":"artifacts and verify_cmd passed harness checks"}`)},
+				{Kind: "mission.review_skipped", Payload: json.RawMessage(`{"unit":0,"reason":"artifacts and check_cmd passed harness checks"}`)},
 			},
 			terminal:     PhaseDone,
 			wantContains: []string{"review: skipped"},

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -542,11 +542,19 @@ type PlanAssumption struct {
 // harness (RunVerify + CheckArtifacts), never by model output, and
 // only on that harness-run evidence.
 type PlanUnit struct {
-	Title     string `json:"title"`
-	VerifyCmd string `json:"verify_cmd"`
+	Title string `json:"title"`
+	// CheckCmd is the deterministic gate: a POSIX shell command the
+	// harness runs after every worker turn (issue #718 renamed it from
+	// verify_cmd: it checks mechanical facts such as tests passing, it
+	// never verifies that the criteria are met; the reviewer does that).
+	CheckCmd string `json:"check_cmd"`
+	// LegacyVerifyCmd reads plans stored before the rename; normalize
+	// folds it into CheckCmd and clears it, so it is never written.
+	// Drop once scripts/pending-alters.md's key rename has run everywhere.
+	LegacyVerifyCmd string `json:"verify_cmd,omitempty"`
 	// Artifacts are workspace-relative paths this unit must produce.
 	// The harness checks each exists and is non-empty BEFORE running
-	// verify_cmd — a tautological verify_cmd (echo 'done') can no
+	// check_cmd: a tautological check_cmd (echo 'done') can no
 	// longer fake completion when the declared artifact is missing.
 	Artifacts []string `json:"artifacts,omitempty"`
 	// Criteria (D-095, issue #520) are the unit's acceptance criteria,
@@ -563,11 +571,11 @@ type PlanUnit struct {
 	// HarnessPassed (legacy rows written before D-094 excepted).
 	Passes bool `json:"passes"`
 	// HarnessPassed (D-094, issue #518) is the batch verifier's own
-	// verdict: artifacts present and verify_cmd exit 0 after the last
+	// verdict: artifacts present and check_cmd exit 0 after the last
 	// worker turn. Cleared when a later turn regresses the unit.
 	HarnessPassed bool `json:"harness_passed"`
 	// VerifyCheck names the check that decided the last verification
-	// (artifacts, citations, verify_cmd, timeout); VerifyExcerpt is its
+	// (artifacts, citations, check_cmd, timeout); VerifyExcerpt is its
 	// trailing output, capped at verifyExcerptCap, rendered into the
 	// worker packet while the unit is failing.
 	VerifyCheck   string `json:"verify_check,omitempty"`
@@ -580,6 +588,18 @@ type PlanUnit struct {
 // verified reports whether the harness has passed this unit: Passes
 // implies it for rows written before HarnessPassed existed.
 func (u PlanUnit) verified() bool { return u.HarnessPassed || u.Passes }
+
+// normalize folds the pre-rename verify_cmd key into CheckCmd on every
+// unit (issue #718) so callers only ever read CheckCmd. Idempotent.
+func (p *Plan) normalize() {
+	for i := range p.Units {
+		u := &p.Units[i]
+		if u.CheckCmd == "" && u.LegacyVerifyCmd != "" {
+			u.CheckCmd = u.LegacyVerifyCmd
+		}
+		u.LegacyVerifyCmd = ""
+	}
+}
 
 // PendingInput is ask_user's park detail (D-088, issue #457): the
 // structured question a phase turn is waiting on the operator to

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -34,11 +34,11 @@ type WorkPacket struct {
 	// system prompt, same instructions a chat session with that agent
 	// would get.
 	PromptOverlay string
-	// ExecEnvironmentNote describes what shell/verify_cmd commands
+	// ExecEnvironmentNote describes what shell/check_cmd commands
 	// actually run against (sandbox container vs the minimal in-process
 	// shell) — without this a worker has no way to know whether e.g.
 	// python3 exists, and can report "done" on a step whose own
-	// verify_cmd will fail for want of a runtime that was never there.
+	// check_cmd will fail for want of a runtime that was never there.
 	ExecEnvironmentNote string
 	// ParentContext is the parent mission's outcome digest, set only
 	// for a follow-up mission (Mission.ParentContext()) -- gives the
@@ -229,8 +229,8 @@ func (p WorkPacket) RenderForDelegated(runDir string) (system, user string, file
 			for _, a := range unit.Artifacts {
 				fmt.Fprintf(&b, "  must produce (exact path): %s\n", NeutralizeSlot(a))
 			}
-			if unit.VerifyCmd != "" {
-				fmt.Fprintf(&b, "  verified by: %s\n", NeutralizeSlot(unit.VerifyCmd))
+			if unit.CheckCmd != "" {
+				fmt.Fprintf(&b, "  checked by: %s\n", NeutralizeSlot(unit.CheckCmd))
 			}
 			b.WriteString("Do this unit now.\n")
 		}
@@ -337,8 +337,8 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 			for _, a := range u.Artifacts {
 				fmt.Fprintf(&b, "  must produce (exact path): %s\n", NeutralizeSlot(a))
 			}
-			if u.VerifyCmd != "" {
-				fmt.Fprintf(&b, "  verified by: %s\n", NeutralizeSlot(u.VerifyCmd))
+			if u.CheckCmd != "" {
+				fmt.Fprintf(&b, "  checked by: %s\n", NeutralizeSlot(u.CheckCmd))
 			}
 		}
 		b.WriteString("\n")
@@ -444,7 +444,7 @@ func renderOpenFindings(findings []Finding, round, maxRounds int) string {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString("Do not re-verify the whole project. Change code, run the affected unit's verify_cmd, commit, and report per finding what changed.\n\n")
+	b.WriteString("Do not re-verify the whole project. Change code, run the affected unit's check_cmd, commit, and report per finding what changed.\n\n")
 	return b.String()
 }
 

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -48,17 +48,17 @@ func TestWorkPacketRenderUnitFailure(t *testing.T) {
 		Goal: "Write the report",
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "Outline", Passes: true, HarnessPassed: true},
-			{Title: "Body", HarnessPassed: false, Regressed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "grep: body.md: No such file\n"},
+			{Title: "Body", HarnessPassed: false, Regressed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "grep: body.md: No such file\n"},
 			{Title: "Appendix", HarnessPassed: true},
 			{Title: "Index"},
 		}},
 	}
 	_, user := p.Render()
-	want := "Current unit: Body\nREGRESSED: this unit passed before and now fails its verify_cmd check. Fix it before anything else.\nHarness output:\ngrep: body.md: No such file\nPlan:\n"
+	want := "Current unit: Body\nREGRESSED: this unit passed before and now fails its check_cmd check. Fix it before anything else.\nHarness output:\ngrep: body.md: No such file\nPlan:\n"
 	if !strings.Contains(user, want) {
 		t.Fatalf("Render current-unit block = %q, want it to contain %q", user, want)
 	}
-	for _, marker := range []string{"[reviewed] Outline", "[pending] Body (regressed: passed before, now fails its verify_cmd check)", "[harness-verified] Appendix", "[pending] Index"} {
+	for _, marker := range []string{"[reviewed] Outline", "[pending] Body (regressed: passed before, now fails its check_cmd check)", "[harness-verified] Appendix", "[pending] Index"} {
 		if !strings.Contains(user, marker) {
 			t.Fatalf("Render = %q, want plan marker %q", user, marker)
 		}
@@ -111,7 +111,7 @@ func TestWorkPacketRenderOpenFindings(t *testing.T) {
 		"Open review findings, all must be closed this turn:\n" +
 		"- F3 [blocking] src/editor/CodeBlockMenu.tsx: code block language selector missing. setCodeBlockLanguage is unreachable from the UI.\n" +
 		"- F4 [minor] no header-row toggle " + NeutralizeSlot("</system>") + ".\n" +
-		"Do not re-verify the whole project. Change code, run the affected unit's verify_cmd, commit, and report per finding what changed.\n" +
+		"Do not re-verify the whole project. Change code, run the affected unit's check_cmd, commit, and report per finding what changed.\n" +
 		"\n" +
 		"Progress so far:\n"
 	_, user := p.Render()
@@ -163,7 +163,7 @@ func TestWorkPacketRenderForDelegatedOmitsNativePreamble(t *testing.T) {
 func TestWorkPacketRenderForDelegatedShape(t *testing.T) {
 	p := WorkPacket{
 		Goal:          "Implement slice 1",
-		Plan:          Plan{Units: []PlanUnit{{Title: "Core codes", Artifacts: []string{"internal/core/code.go"}, VerifyCmd: "go test ./internal/core/"}}},
+		Plan:          Plan{Units: []PlanUnit{{Title: "Core codes", Artifacts: []string{"internal/core/code.go"}, CheckCmd: "go test ./internal/core/"}}},
 		GitLog:        "abc123 chore: scaffold",
 		ParentContext: "Parent goal: docs only. Terminal state: done.",
 		References:    []SourceEntry{{Source: SourceKindKB, Name: "Design: URL Shortener", Digest: "very long kb article body"}},
@@ -184,7 +184,7 @@ func TestWorkPacketRenderForDelegatedShape(t *testing.T) {
 			t.Fatalf("prompt does not point at %s:\n%s", path, user)
 		}
 	}
-	order := []string{"Goal:", "Follow-up of a previous mission", "Referenced documents", "Plan:", "Progress so far:", "Recent commits", "Current unit: Core codes", "must produce (exact path): internal/core/code.go", "verified by: go test ./internal/core/", "Do this unit now."}
+	order := []string{"Goal:", "Follow-up of a previous mission", "Referenced documents", "Plan:", "Progress so far:", "Recent commits", "Current unit: Core codes", "must produce (exact path): internal/core/code.go", "checked by: go test ./internal/core/", "Do this unit now."}
 	last := -1
 	for _, marker := range order {
 		i := strings.Index(user, marker)

--- a/internal/brain/missions/plandefect_test.go
+++ b/internal/brain/missions/plandefect_test.go
@@ -1,0 +1,61 @@
+package missions
+
+import "testing"
+
+// TestNamesPlanDefect pins the classifier on the real BLOCKED notes
+// from the five-harness eval (issue #718) and on questions that must
+// still reach the operator.
+func TestNamesPlanDefect(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{{Title: "u", Artifacts: []string{"internal/core/permute.go"}}}}
+	defects := []string{
+		"The benchmark acceptance check depends on `Permute`, so this unit cannot pass in isolation without adding `internal/core/permute.go`.",
+		"The verify_cmd cannot pass as written: its first stage 'gofmt -l <files> | grep -q '^$'' exits 1 whenever gofmt output is empty.",
+		"Slice 1 is fully implemented; the only remaining failure is the check_cmd's first stage.",
+		"Criterion 3 asks for a benchmark the plan places in a later unit.",
+	}
+	for _, q := range defects {
+		if !namesPlanDefect(q, plan) {
+			t.Errorf("namesPlanDefect missed a plan diagnosis: %q", q)
+		}
+	}
+	operator := []string{
+		"Which OAuth scopes should the connector request?",
+		"The repository requires a GitHub token I do not have.",
+		"Should aliases be case sensitive? The design document does not say.",
+		"Should aliases be case sensitive? The plan does not say.",
+	}
+	for _, q := range operator {
+		if namesPlanDefect(q, plan) {
+			t.Errorf("namesPlanDefect took an operator question for a plan defect: %q", q)
+		}
+	}
+}
+
+// TestRestorePassedUnitsKeepsHarnessEvidence (issue #718): a replan
+// that renames a unit but produces the same artifacts keeps its
+// harness verdict and loses reviewer approval; an unverified unit and a
+// unit with new artifacts start clean; approval survives only the exact
+// title plus check_cmd match.
+func TestRestorePassedUnitsKeepsHarnessEvidence(t *testing.T) {
+	prior := Plan{Units: []PlanUnit{
+		{Title: "Implement Base62 encoding and decoding with table tests", Artifacts: []string{"internal/core/base62.go", "internal/core/base62_test.go"}, HarnessPassed: true, Passes: true},
+		{Title: "Keyed permutation", CheckCmd: "go test ./internal/core/ -run TestPermute", Artifacts: []string{"internal/core/permute.go", "internal/core/permute_test.go"}, HarnessPassed: true, Passes: true},
+		{Title: "Validation", Artifacts: []string{"internal/core/validate.go"}},
+	}}
+	next := Plan{Units: []PlanUnit{
+		{Title: "Implement Base62 core and table tests", Artifacts: []string{"internal/core/base62_test.go", "internal/core/base62.go"}},
+		{Title: "Keyed permutation", CheckCmd: "go test ./internal/core/ -run TestPermute", Artifacts: []string{"internal/core/permute.go", "internal/core/permute_test.go"}},
+		{Title: "Validation", Artifacts: []string{"internal/core/validate.go"}},
+		{Title: "Redirect", Artifacts: []string{"internal/core/redirect.go"}},
+	}}
+	restorePassedUnits(&next, prior)
+	if !next.Units[0].HarnessPassed || next.Units[0].Passes {
+		t.Fatalf("renamed base62 unit = %+v, want harness_passed carried by artifact match, passes dropped for a fresh review", next.Units[0])
+	}
+	if !next.Units[1].HarnessPassed || !next.Units[1].Passes {
+		t.Fatalf("permutation unit = %+v, want both flags carried by title+check_cmd match", next.Units[1])
+	}
+	if next.Units[2].HarnessPassed || next.Units[3].HarnessPassed {
+		t.Fatalf("unverified and new units must start clean: %+v %+v", next.Units[2], next.Units[3])
+	}
+}

--- a/internal/brain/missions/plangate.go
+++ b/internal/brain/missions/plangate.go
@@ -1,0 +1,239 @@
+package missions
+
+// Plan gate checks (issue #718): run at plan acceptance, before any
+// worker turn, and reject a plan whose check_cmd cannot exit 0, always
+// exits 0, or never exercises the code it guards. The planner's
+// recovery turn sees the exact defect.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// emptyOutputIdiom matches `| grep -q '^$'` in any quoting: the wrong
+// spelling of "prints nothing". grep finds no empty line in empty
+// input, so the pipeline fails on clean output too.
+var emptyOutputIdiom = regexp.MustCompile(`\|\s*grep(\s+-\w+)*\s+(['"]?)\^\$(['"]?)(\s|$)`)
+
+// emptyOutputHint is the sanctioned spelling, matching the awk form the
+// planner rules already use for line counts (command substitution is
+// banned, so `[ -z "$(...)" ]` is not available to it).
+const emptyOutputHint = "awk 'END{exit NR>0}'"
+
+// codeExtensions marks artifacts a check_cmd must build, test or run
+// rather than only grep.
+var codeExtensions = map[string]bool{
+	".go": true, ".py": true,
+	".js": true, ".mjs": true, ".cjs": true, ".jsx": true, ".ts": true, ".tsx": true,
+}
+
+// toolchainByEnv recognises an invocation of the environment's own
+// toolchain (sandboxd's go/node/python variants). The alternation is a
+// floor, not a full grammar: any one match satisfies checkCodeFloor.
+var toolchainByEnv = map[string]*regexp.Regexp{
+	"go":     regexp.MustCompile(`(^|[\s;&|(])go\s+(test|vet|build|run)\b`),
+	"python": regexp.MustCompile(`(^|[\s;&|(])(pytest\b|python3?\s+(-m\s+(pytest|unittest)\b|\S+\.py\b))`),
+	"node":   regexp.MustCompile(`(^|[\s;&|(])(npm\s+(run\s+)?test\b|npx\s+(vitest|jest|mocha|tsc)\b|node\s+(--test\b|\S+\.[cm]?js\b)|(yarn|pnpm)\s+test\b|tsc\b)`),
+}
+
+// toolchainExample is what the rejection tells the planner to reach for.
+var toolchainExample = map[string]string{
+	"go":     "go test ./<package>/...",
+	"python": "python3 -m pytest <tests>",
+	"node":   "npm test",
+}
+
+// anchorExample is the "fails before, passes after" shape for a unit
+// that adds tests: the toolchain call alone exits 0 while the test file
+// is still missing (`go test -run X` matches nothing, pytest collects
+// nothing), so a grep for a symbol the unit adds goes first.
+var anchorExample = map[string]string{
+	"go":     "grep -q 'func TestXxx' <pkg>/xxx_test.go && go test ./<pkg>/ -run TestXxx",
+	"python": "grep -q 'def test_xxx' tests/test_xxx.py && python3 -m pytest tests/test_xxx.py -q",
+	"node":   "grep -q 'test(' src/xxx.test.ts && npx vitest run src/xxx.test.ts",
+}
+
+// checkPlanGates runs the static gate checks parsePlan cannot: they
+// need the mission's kind and environment.
+func checkPlanGates(plan Plan, m Mission) error {
+	for _, u := range plan.Units {
+		if emptyOutputIdiom.MatchString(u.CheckCmd) {
+			return fmt.Errorf("mission runner: unit %q check_cmd pipes into grep -q '^$', which exits 1 on empty output as well as on filenames, so it can never pass; to assert a command prints nothing pipe it into %s instead", u.Title, emptyOutputHint)
+		}
+	}
+	if err := checkOwnArtifacts(plan); err != nil {
+		return err
+	}
+	if m.Kind != KindCoding {
+		return nil
+	}
+	return checkCodeFloor(plan, m.Environment)
+}
+
+// checkOwnArtifacts rejects a unit whose every artifact is already
+// produced by an earlier unit: a trailing "format and verify" unit.
+// Such a unit adds nothing the gate can key on, so its check_cmd
+// either already passes (tautology) or waits on work the earlier units
+// own; its commands belong in those units' check_cmds. Five eval arms
+// produced one, four died on it.
+func checkOwnArtifacts(plan Plan) error {
+	seen := map[string]bool{}
+	for _, u := range plan.Units {
+		if len(u.Artifacts) > 0 {
+			own := false
+			for _, a := range u.Artifacts {
+				if !seen[cleanArtifact(a)] {
+					own = true
+					break
+				}
+			}
+			if !own {
+				return fmt.Errorf("mission runner: unit %q adds no artifact of its own (every file it lists is produced by an earlier unit), so no check_cmd can tell whether it is done; remove the unit and put its commands into the check_cmds of the units that produce those files", u.Title)
+			}
+		}
+		for _, a := range u.Artifacts {
+			seen[cleanArtifact(a)] = true
+		}
+	}
+	return nil
+}
+
+func cleanArtifact(a string) string {
+	return path.Clean(filepath.ToSlash(strings.TrimSpace(a)))
+}
+
+// checkCodeFloor requires every unit that produces source files to
+// build, test or run them in its check_cmd. Grep against source proves
+// text is present, never that code works; a worker can satisfy it by
+// adding a comment, and one did.
+func checkCodeFloor(plan Plan, environment string) error {
+	for _, u := range plan.Units {
+		if !producesCode(u.Artifacts) {
+			continue
+		}
+		if invokesToolchain(u.CheckCmd, environment) {
+			continue
+		}
+		example := toolchainExample[environment]
+		if example == "" {
+			example = "the environment's test command"
+		}
+		return fmt.Errorf("mission runner: unit %q produces source files but its check_cmd never builds, tests or runs them; start it with %s (greps may follow, they never stand alone)", u.Title, example)
+	}
+	return nil
+}
+
+func producesCode(artifacts []string) bool {
+	for _, a := range artifacts {
+		if codeExtensions[strings.ToLower(filepath.Ext(strings.TrimSpace(a)))] {
+			return true
+		}
+	}
+	return false
+}
+
+// invokesToolchain accepts the environment's own toolchain, or any
+// known one when the environment is unset or unknown.
+func invokesToolchain(cmd, environment string) bool {
+	if re, ok := toolchainByEnv[environment]; ok {
+		return re.MatchString(cmd)
+	}
+	for _, re := range toolchainByEnv {
+		if re.MatchString(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeTimeout bounds one plan-time probe. Far below verifyTimeout: a
+// probe that runs this long is inconclusive, never a rejection.
+const probeTimeout = 60 * time.Second
+
+// probeCheckCmds runs every unit's check_cmd once against the tree as
+// it stands before any work, in the mission sandbox. Two outcomes
+// reject the plan: exit 0 (the gate cannot tell done from not done) and
+// a missing command (exit 127, or the shell's "not found" line). Any
+// other failure is the expected state of a gate whose artifacts do not
+// exist yet; a timeout or an exec error is inconclusive and accepted.
+func (r *nativeRunner) probeCheckCmds(ctx context.Context, m Mission, plan Plan) error {
+	if r.sandbox == nil {
+		return nil
+	}
+	workRoot := m.WorkRoot()
+	backend := func(ctx context.Context, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
+		return r.sandbox(ctx, m.ID, m.Environment, workdir, command, timeout, out)
+	}
+	for _, u := range plan.Units {
+		if strings.TrimSpace(u.CheckCmd) == "" {
+			continue
+		}
+		res, err := runVerifyTimed(ctx, backend, workRoot, u.CheckCmd, probeTimeout)
+		if err != nil {
+			r.log.Warn("mission planner: check_cmd probe failed to run", "mission_id", m.ID, "unit", u.Title, "error", err)
+			continue
+		}
+		if res.TimedOut {
+			r.log.Warn("mission planner: check_cmd probe timed out", "mission_id", m.ID, "unit", u.Title)
+			continue
+		}
+		switch {
+		case res.Passed:
+			anchor := anchorExample[m.Environment]
+			if anchor == "" {
+				anchor = "grep -q '<symbol the unit adds>' <artifact> && <toolchain call>"
+			}
+			return fmt.Errorf("mission runner: unit %q check_cmd `%s` already exits 0 before any work was done, so it cannot tell done from not done. A toolchain call alone passes while the files are still missing (go test -run X matches nothing, gofmt -l prints nothing for absent files), so anchor the gate on content the unit adds, e.g. %s. A unit that adds no new content (a final format/verify unit) can have no such gate: remove it and put its commands into the code units' check_cmds", u.Title, u.CheckCmd, anchor)
+		case res.ExitCode == 127 || shellNotFound.MatchString(lastLine(res.Excerpt)):
+			env := m.Environment
+			if env == "" {
+				env = "sandbox"
+			}
+			return fmt.Errorf("mission runner: unit %q check_cmd `%s` uses a command the %s environment does not have: %s", u.Title, u.CheckCmd, env, strings.TrimSpace(lastLine(res.Excerpt)))
+		}
+	}
+	return nil
+}
+
+// shellNotFound matches the shell's own report of a missing command
+// ("sh: 1: pytest: not found", "bash: pytest: command not found"),
+// never a program's (go prints "directory not found" with exit 1).
+var shellNotFound = regexp.MustCompile(`^(?:/bin/)?(?:sh|bash|dash): (?:\d+: )?[^:]+: (?:command )?not found$`)
+
+// lastLine returns the final non-empty line of s.
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if l := strings.TrimSpace(lines[i]); l != "" {
+			return l
+		}
+	}
+	return ""
+}
+
+// acceptPlan is parsePlan plus the gate checks that need the mission
+// (kind, environment, sandbox). PlanSession's recovery turn quotes the
+// returned error to the planner, so every message names the unit and
+// the fix.
+func (r *nativeRunner) acceptPlan(ctx context.Context, m Mission, raw string) (Plan, error) {
+	plan, err := parsePlan(raw)
+	if err != nil {
+		return Plan{}, err
+	}
+	if plan.Infeasible {
+		return plan, nil
+	}
+	if err := checkPlanGates(plan, m); err != nil {
+		return Plan{}, err
+	}
+	if err := r.probeCheckCmds(ctx, m, plan); err != nil {
+		return Plan{}, err
+	}
+	return plan, nil
+}

--- a/internal/brain/missions/plangate_test.go
+++ b/internal/brain/missions/plangate_test.go
@@ -1,0 +1,216 @@
+package missions
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// TestEmptyOutputIdiom pins the regex on the spellings the planner
+// actually produced and on look-alikes it must leave alone.
+func TestEmptyOutputIdiom(t *testing.T) {
+	match := []string{
+		`gofmt -l a.go | grep -q '^$'`,
+		`gofmt -l . | grep -q "^$" && go vet ./...`,
+		`gofmt -l a.go|grep -q ^$`,
+		`gofmt -l a.go | grep -qx '^$'`,
+		`GOTOOLCHAIN=auto gofmt -l a.go b.go | grep -q '^$' && GOTOOLCHAIN=auto go test ./...`,
+	}
+	for _, c := range match {
+		if !emptyOutputIdiom.MatchString(c) {
+			t.Errorf("emptyOutputIdiom missed %q", c)
+		}
+	}
+	noMatch := []string{
+		`grep -q '^$ok' out.md`,
+		`grep -q 'x' out.md`,
+		`gofmt -l a.go | awk 'END{exit NR>0}'`,
+		`grep -c '^$' out.md`,
+	}
+	for _, c := range noMatch {
+		if emptyOutputIdiom.MatchString(c) {
+			t.Errorf("emptyOutputIdiom false positive on %q", c)
+		}
+	}
+}
+
+// TestCheckCodeFloor covers the toolchain requirement per environment:
+// a unit that produces source must build, test or run it; document
+// units and unknown environments stay permissive.
+func TestCheckCodeFloor(t *testing.T) {
+	cases := []struct {
+		name      string
+		env       string
+		artifacts []string
+		cmd       string
+		wantErr   string
+	}{
+		{"go grep only", "go", []string{"internal/core/a.go"}, `grep -q 'func Foo' internal/core/a.go`, "never builds, tests or runs"},
+		{"go test first", "go", []string{"internal/core/a.go"}, `go test ./internal/core/... && grep -q Foo internal/core/a.go`, ""},
+		{"go vet counts", "go", []string{"a.go"}, `GOTOOLCHAIN=auto go vet ./... && grep -q x a.go`, ""},
+		{"go doc unit", "go", []string{"docs/DESIGN.md"}, `grep -q '## Scheme' docs/DESIGN.md`, ""},
+		{"python grep only", "python", []string{"app/a.py"}, `grep -q 'def main' app/a.py`, "never builds, tests or runs"},
+		{"python pytest", "python", []string{"app/a.py"}, `python3 -m pytest tests/ -q`, ""},
+		{"node vitest", "node", []string{"src/a.ts"}, `npx vitest run src`, ""},
+		{"node grep only", "node", []string{"src/a.ts"}, `grep -q export src/a.ts`, "never builds, tests or runs"},
+		{"unknown env accepts any toolchain", "", []string{"a.py"}, `pytest tests`, ""},
+		{"unknown env still needs one", "", []string{"a.py"}, `grep -q def a.py`, "never builds, tests or runs"},
+		{"wrong env toolchain rejected", "go", []string{"a.go"}, `npm test`, "never builds, tests or runs"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := Plan{Units: []PlanUnit{{Title: "u", Artifacts: tc.artifacts, CheckCmd: tc.cmd}}}
+			err := checkCodeFloor(plan, tc.env)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkCodeFloor: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("checkCodeFloor = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestCheckPlanGatesGeneralKindSkipsFloor: a general mission's units
+// are documents; the toolchain floor is a coding rule only. The empty
+// output idiom is rejected for every kind.
+func TestCheckPlanGatesGeneralKindSkipsFloor(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{{Title: "u", Artifacts: []string{"a.go"}, CheckCmd: `grep -q x a.go`}}}
+	if err := checkPlanGates(plan, Mission{Kind: KindGeneral}); err != nil {
+		t.Fatalf("general mission hit the code floor: %v", err)
+	}
+	plan.Units[0].CheckCmd = `ls | grep -q '^$'`
+	if err := checkPlanGates(plan, Mission{Kind: KindGeneral}); err == nil {
+		t.Fatal("empty-output idiom accepted on a general mission")
+	}
+}
+
+// scriptedSandbox is a sandboxExec whose exit code is chosen by the
+// command text, so a probe test can stage each outcome.
+func scriptedSandbox(codes map[string]int, output string) sandboxExec {
+	return func(_ context.Context, _, _, _, command string, _ time.Duration, out io.Writer) (int, error) {
+		_, _ = fmt.Fprint(out, output)
+		return codes[command], nil
+	}
+}
+
+// TestProbeCheckCmds covers the three probe outcomes: a gate that
+// already passes is rejected, a missing command is rejected, an
+// ordinary failure (artifacts not there yet) is the expected state.
+func TestProbeCheckCmds(t *testing.T) {
+	m := Mission{ID: "m1", Kind: KindCoding, Environment: "go"}
+	mk := func(cmd string) Plan {
+		return Plan{Units: []PlanUnit{{Title: "u", Artifacts: []string{"a.go"}, CheckCmd: cmd}}}
+	}
+	t.Run("already passes", func(t *testing.T) {
+		r := &nativeRunner{log: slog.Default(), sandbox: scriptedSandbox(map[string]int{"go test ./...": 0}, "ok")}
+		err := r.probeCheckCmds(context.Background(), m, mk("go test ./..."))
+		if err == nil || !strings.Contains(err.Error(), "already exits 0") {
+			t.Fatalf("probe = %v, want tautology rejection", err)
+		}
+		if !strings.Contains(err.Error(), "`go test ./...`") || !strings.Contains(err.Error(), "func TestXxx") {
+			t.Fatalf("rejection must quote the gate and give the go anchor recipe, got %v", err)
+		}
+	})
+	t.Run("missing command", func(t *testing.T) {
+		r := &nativeRunner{log: slog.Default(), sandbox: scriptedSandbox(map[string]int{"pytest tests": 127}, "sh: pytest: not found\n")}
+		err := r.probeCheckCmds(context.Background(), m, mk("pytest tests"))
+		if err == nil || !strings.Contains(err.Error(), "does not have") || !strings.Contains(err.Error(), "pytest: not found") {
+			t.Fatalf("probe = %v, want missing-command rejection quoting the shell", err)
+		}
+	})
+	t.Run("program not found is not a missing command", func(t *testing.T) {
+		r := &nativeRunner{log: slog.Default(), sandbox: scriptedSandbox(map[string]int{"go test ./internal/core/ -run TestX": 1}, "stat /src/internal/core: directory not found\nFAIL\n")}
+		if err := r.probeCheckCmds(context.Background(), m, mk("go test ./internal/core/ -run TestX")); err != nil {
+			t.Fatalf("go's own not-found on an absent package must be the expected pre-work failure: %v", err)
+		}
+	})
+	t.Run("expected failure accepted", func(t *testing.T) {
+		r := &nativeRunner{log: slog.Default(), sandbox: scriptedSandbox(map[string]int{"go test ./...": 1}, "no Go files")}
+		if err := r.probeCheckCmds(context.Background(), m, mk("go test ./...")); err != nil {
+			t.Fatalf("probe rejected an ordinary pre-work failure: %v", err)
+		}
+	})
+	t.Run("no sandbox skips", func(t *testing.T) {
+		r := &nativeRunner{log: slog.Default()}
+		if err := r.probeCheckCmds(context.Background(), m, mk("go test ./...")); err != nil {
+			t.Fatalf("probe without a sandbox must be a no-op: %v", err)
+		}
+	})
+}
+
+// TestPlanSessionRejectsEmptyOutputGate replays the exact gate that
+// killed four of five eval arms (issue #718): the first plan is
+// rejected with a message naming the idiom and the fix, the recovery
+// turn's corrected plan is accepted.
+func TestPlanSessionRejectsEmptyOutputGate(t *testing.T) {
+	bad := `{"units":[{"title":"Format and verify","artifacts":["internal/core/a.go"],"criteria":["c1","c2"],"check_cmd":"GOTOOLCHAIN=auto gofmt -l internal/core/a.go | grep -q '^$' && go vet ./... && go test ./internal/core/..."}]}`
+	good := `{"units":[{"title":"Format and verify","artifacts":["internal/core/a.go"],"criteria":["c1","c2"],"check_cmd":"gofmt -l internal/core/a.go | awk 'END{exit NR>0}' && go test ./internal/core/..."}]}`
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, bad)},
+		{toolEndEvent(planToolName, good)},
+	}}
+	r := newTestRunner(agent)
+	plan, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Kind: KindCoding, Environment: "go"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected a recovery turn, got %d turns", agent.call)
+	}
+	if got := plan.Units[0].CheckCmd; !strings.Contains(got, "awk") {
+		t.Fatalf("accepted plan check_cmd = %q, want the corrected gate", got)
+	}
+	req := agent.requests[1]
+	last := req.Messages[len(req.Messages)-1].Content
+	if !strings.Contains(last, "grep -q '^$'") || !strings.Contains(last, emptyOutputHint) {
+		t.Fatalf("recovery message must name the idiom and the fix, got %q", last)
+	}
+}
+
+// TestPlanSessionRejectsGrepOnlyCodeGate: a coding unit gated by greps
+// alone is sent back for a toolchain call.
+func TestPlanSessionRejectsGrepOnlyCodeGate(t *testing.T) {
+	bad := `{"units":[{"title":"Implement Base62","artifacts":["internal/core/base62.go"],"criteria":["c1","c2"],"check_cmd":"grep -q 'package core' internal/core/base62.go && grep -q 'func .*Encode' internal/core/base62.go"}]}`
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, bad)},
+		{toolEndEvent(planToolName, bad)},
+	}}
+	r := newTestRunner(agent)
+	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Kind: KindCoding, Environment: "go"}, "")
+	if err == nil || !strings.Contains(err.Error(), "go test") {
+		t.Fatalf("PlanSession = %v, want a rejection pointing at go test", err)
+	}
+}
+
+// TestCheckOwnArtifacts (issue #718): a unit whose every artifact is
+// produced by an earlier unit is the trailing "format and verify" unit
+// four eval arms died on; a unit that adds at least one file of its own
+// passes even when it also lists an earlier unit's file.
+func TestCheckOwnArtifacts(t *testing.T) {
+	bad := Plan{Units: []PlanUnit{
+		{Title: "base62", Artifacts: []string{"internal/core/base62.go", "internal/core/base62_test.go"}},
+		{Title: "permute", Artifacts: []string{"internal/core/permute.go"}},
+		{Title: "Verify and finalize", Artifacts: []string{"internal/core/base62.go", "./internal/core/permute.go"}},
+	}}
+	err := checkOwnArtifacts(bad)
+	if err == nil || !strings.Contains(err.Error(), `"Verify and finalize"`) || !strings.Contains(err.Error(), "no artifact of its own") {
+		t.Fatalf("checkOwnArtifacts = %v, want the trailing unit rejected", err)
+	}
+	good := Plan{Units: []PlanUnit{
+		{Title: "base62", Artifacts: []string{"internal/core/base62.go"}},
+		{Title: "wire base62 into the encoder", Artifacts: []string{"internal/core/base62.go", "internal/core/encoder.go"}},
+	}}
+	if err := checkOwnArtifacts(good); err != nil {
+		t.Fatalf("checkOwnArtifacts rejected a unit that adds encoder.go: %v", err)
+	}
+}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -734,7 +734,7 @@ func (s *kbRefSink) all() []string {
 // mission's OWN directory (worktree for coding, workspace otherwise):
 // a shell that replaces the global workspace-rooted one for the turn:
 // the root cause of a whole failure family was workers writing into
-// the shared root while verify_cmd and the reviewer looked in the
+// the shared root while check_cmd and the reviewer looked in the
 // per-mission directory: and write_file, so artifact writes never go
 // through destructive-classified shell redirects. The shell's Runner
 // routes commands into the mission's own Docker container (see
@@ -1124,10 +1124,10 @@ const kbSearchNoHits = "no matching passages found"
 // document id and its fused score together.
 var kbSearchSourceLine = regexp.MustCompile(`^Source: kb://(\S+) \(score ([-\d.]+)\)$`)
 
-// verifyCmdGitInvocation matches a git invocation as a shell word: at the
+// checkCmdGitInvocation matches a git invocation as a shell word: at the
 // start of the command or after a non-word character, so it catches
 // "git status" and "&& git diff" but not "digit" or "widget.md".
-var verifyCmdGitInvocation = regexp.MustCompile(`(^|\W)git\s`)
+var checkCmdGitInvocation = regexp.MustCompile(`(^|\W)git\s`)
 
 // kbSearchHitTrace pulls document ids, titles, and fused scores out of
 // search_kb's rendered result (kbsearch.go's formatKBHits), the same
@@ -1356,7 +1356,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	// non-frontier models (GLM-5.2's XML-ish self-closing tag, qwen3:30b's
 	// bare "mission_status" token followed by a JSON object). A text-form
 	// verdict is trust-equivalent to the tool-call form: both are the
-	// model's own self-report, and the harness's own verify_cmd/
+	// model's own self-report, and the harness's own check_cmd/
 	// CheckArtifacts evidence: never model output: is what actually
 	// gates a unit's Passes flag. This is strictly a fallback: the
 	// tool-call path above always wins when it succeeds.
@@ -1812,7 +1812,9 @@ func renderReviewContent(p ReviewPacket) string {
 			b.WriteString(progressWithOperatorNotes(p.Progress, progressRenderCap, NeutralizeSlot))
 		}
 	}
-	if p.Evidence != "" {
+	// A delegated worker's report is also its last progress note; the
+	// block is skipped when the note above already carries it verbatim.
+	if p.Evidence != "" && !reportInProgress(p) {
 		b.WriteString("\nWorker's own report (verify against the artifacts above, do not take at face value):\n")
 		b.WriteString(NeutralizeSlot(p.Evidence))
 		b.WriteString("\n")
@@ -1820,15 +1822,24 @@ func renderReviewContent(p ReviewPacket) string {
 	return b.String()
 }
 
+// reportInProgress reports whether the packet's last rendered progress
+// note is the worker's report itself.
+func reportInProgress(p ReviewPacket) bool {
+	if len(p.Progress) == 0 || p.FindingsOnly {
+		return false
+	}
+	return strings.TrimSpace(p.Progress[len(p.Progress)-1].Note) == strings.TrimSpace(p.Evidence)
+}
+
 // planUnitShapeRules is the unit-shape contract every plan must
 // satisfy regardless of how it was derived (designed from scratch or
 // transcribed from an operator-supplied plan, D-102): artifacts,
-// criteria, scope, verify_cmd's POSIX-shell/no-substitution/content-
+// criteria, scope, check_cmd's POSIX-shell/no-substitution/content-
 // check rules, workspace-relative paths, the infeasible escape hatch
 // (D-077), and assumptions. Kept as one shared string so
 // build/prove's unit parsing (parsePlan) never has to distinguish
 // which mode produced a plan.
-const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. The harness commits each unit's files itself after the worker turn, so criteria and verify_cmd must judge file CONTENT only, never git status, staging, untracked, or uncommitted state. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
+const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). check_cmd is executed literally as `/bin/sh -c \"<check_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command). It is a gate, not a proof: it must FAIL against the workspace as it stands now and PASS once the unit's work exists, and the harness runs it once at plan acceptance to confirm the first half, rejecting a gate that already passes. For a unit whose artifacts are source files it must build, test or run them with the environment's toolchain (`go test ./pkg/...`, `python3 -m pytest tests/`, `npm test`); a grep against source only proves text is present, so greps may accompany the toolchain call but never stand alone. A toolchain call alone passes while the unit's files are still missing (`go test ./pkg/ -run TestX` exits 0 when no test file exists, `gofmt -l` prints nothing for absent files, pytest collects nothing), so anchor each code unit's check_cmd on a symbol the unit adds, e.g. `grep -q 'func TestBase62' internal/core/base62_test.go && go test ./internal/core/ -run TestBase62`. For document artifacts check CONTENT (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in check_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`; to assert a command prints nothing (gofmt -l, a linter) pipe it into `awk 'END{exit NR>0}'`, NEVER `grep -q '^$'`, which exits 1 on empty input. Do not add a separate final \"format and verify\" unit: put the toolchain call in every code unit's own check_cmd. The harness commits each unit's files itself after the worker turn, so criteria and check_cmd must judge file CONTENT only, never git status, staging, untracked, or uncommitted state. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
 
 // planSystemPrompt builds PlanSession's system prompt: the design-mode
 // opening (break the goal into units from scratch) or, when hasPlan is
@@ -1921,7 +1932,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		return Plan{}, ErrAskedUser
 	}
 	if len(args) > 0 {
-		if plan, planErr := parsePlan(string(args)); planErr == nil {
+		if plan, planErr := r.acceptPlan(ctx, m, string(args)); planErr == nil {
 			plan.Provider, plan.Model = res.provider, res.model
 			return plan, nil
 		}
@@ -1935,7 +1946,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 	var recoverReason string
 	if len(args) == 0 {
 		recoverReason = "you did not call submit_plan"
-	} else if _, planErr := parsePlan(string(args)); planErr != nil {
+	} else if _, planErr := r.acceptPlan(ctx, m, string(args)); planErr != nil {
 		recoverReason = planErr.Error()
 	}
 	recoverReq := req
@@ -1952,7 +1963,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		r.log.Warn("mission planner ended without a submit_plan call", "mission_id", m.ID, "route", oversightRoute(m), "text", text, "recover_text", recoverText)
 		return Plan{}, fmt.Errorf("mission runner: planner ended without a submit_plan call")
 	}
-	plan, err := parsePlan(string(recoverArgs))
+	plan, err := r.acceptPlan(ctx, m, string(recoverArgs))
 	if err != nil {
 		r.log.Warn("mission planner submitted an invalid plan twice", "mission_id", m.ID, "route", oversightRoute(m), "text", text, "recover_text", recoverText, "error", err)
 		return Plan{}, err
@@ -1962,10 +1973,10 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 }
 
 // execEnvironmentNote tells the planner what execution environment
-// verify_cmd and shell commands actually run in: without this, a
+// check_cmd and shell commands actually run in: without this, a
 // planner with no sandbox has no way to know whether e.g. python3
-// exists, and can author a verify_cmd for a runtime that was never
-// there (the root cause of a real stuck mission: a plan's verify_cmd
+// exists, and can author a check_cmd for a runtime that was never
+// there (the root cause of a real stuck mission: a plan's check_cmd
 // assumed Python in an environment that had none). WorkPacket.Render
 // carries the same text to the worker via ExecEnvironmentNote.
 func (r *nativeRunner) execEnvironmentNote(ctx context.Context) string {
@@ -2010,6 +2021,7 @@ func parsePlan(raw string) (Plan, error) {
 	if err := dec.Decode(&plan); err != nil {
 		return Plan{}, fmt.Errorf("mission runner: invalid plan JSON: %w", err)
 	}
+	plan.normalize()
 	// D-077: the schema itself no longer requires units (infeasible=true
 	// needs none), so the units-empty/infeasible split is validated here.
 	if plan.Infeasible {
@@ -2021,11 +2033,11 @@ func parsePlan(raw string) (Plan, error) {
 	if len(plan.Units) == 0 {
 		return Plan{}, fmt.Errorf("mission runner: plan has no units")
 	}
-	// verify_cmd runs through RunVerify (a plain /bin/sh -c): harness-
+	// check_cmd runs through RunVerify (a plain /bin/sh -c): harness-
 	// side, outside the permission chain entirely, so D-050's sandbox
 	// relaxation (which only changes how a worker/reviewer's own shell
 	// TOOL CALL is classified) has no bearing here. The rejection below
-	// is a determinism concern, not a permission one: verify_cmd must
+	// is a determinism concern, not a permission one: check_cmd must
 	// check the CONTENT of declared artifacts reproducibly, and command
 	// substitution invites exactly the kind of "prove nothing" or
 	// environment-dependent check (e.g. $(date) in the expected value)
@@ -2033,16 +2045,16 @@ func parsePlan(raw string) (Plan, error) {
 	// empty-plan check already rejects a bad plan, so the planner's
 	// retry loop sees the real problem immediately.
 	for _, u := range plan.Units {
-		if strings.Contains(u.VerifyCmd, "$(") || strings.Contains(u.VerifyCmd, "`") {
-			return Plan{}, fmt.Errorf("mission runner: verify_cmd must not use command substitution ($(...) or backticks), write the direct command instead")
+		if strings.Contains(u.CheckCmd, "$(") || strings.Contains(u.CheckCmd, "`") {
+			return Plan{}, fmt.Errorf("mission runner: check_cmd must not use command substitution ($(...) or backticks), write the direct command instead")
 		}
 	}
 	// The harness commits every unit's files itself after the worker turn
-	// (Workspace.CommitUnit), so a verify_cmd that runs git always checks
+	// (Workspace.CommitUnit), so a check_cmd that runs git always checks
 	// a stale or wrong assumption about working-tree state.
 	for _, u := range plan.Units {
-		if verifyCmdGitInvocation.MatchString(u.VerifyCmd) {
-			return Plan{}, fmt.Errorf("mission runner: unit %q verify_cmd must not run git: the harness commits each unit itself, check artifact content instead", u.Title)
+		if checkCmdGitInvocation.MatchString(u.CheckCmd) {
+			return Plan{}, fmt.Errorf("mission runner: unit %q check_cmd must not run git: the harness commits each unit itself, check artifact content instead", u.Title)
 		}
 	}
 	// D-068: every unit must declare at least one artifact so the
@@ -2066,13 +2078,13 @@ func parsePlan(raw string) (Plan, error) {
 			u.Scope = defaultScope(u.Artifacts)
 		}
 	}
-	// D-068: reject verify_cmds that succeed regardless of outcome.
+	// D-068: reject check_cmds that succeed regardless of outcome.
 	// Deny-set on the first shell word only, deliberately not a shell
 	// parser; a no-op buried after && is out of scope.
 	for _, u := range plan.Units {
-		cmd := strings.TrimSpace(u.VerifyCmd)
+		cmd := strings.TrimSpace(u.CheckCmd)
 		if cmd == "" {
-			return Plan{}, fmt.Errorf("mission runner: unit %q must have a verify_cmd that checks the CONTENT of its artifacts (e.g. grep), a bare echo, true, :, or printf proves nothing", u.Title)
+			return Plan{}, fmt.Errorf("mission runner: unit %q must have a check_cmd that checks the CONTENT of its artifacts (e.g. grep), a bare echo, true, :, or printf proves nothing", u.Title)
 		}
 		firstWord := cmd
 		if i := strings.IndexAny(cmd, " \t"); i >= 0 {
@@ -2080,22 +2092,22 @@ func parsePlan(raw string) (Plan, error) {
 		}
 		switch firstWord {
 		case "echo", "true", ":", "printf":
-			return Plan{}, fmt.Errorf("mission runner: unit %q verify_cmd must check the CONTENT of its artifacts (e.g. grep), a bare echo, true, :, or printf proves nothing", u.Title)
+			return Plan{}, fmt.Errorf("mission runner: unit %q check_cmd must check the CONTENT of its artifacts (e.g. grep), a bare echo, true, :, or printf proves nothing", u.Title)
 		}
 	}
-	// D-068: verify_cmd must parse as POSIX shell (-n never executes).
+	// D-068: check_cmd must parse as POSIX shell (-n never executes).
 	// Skip silently if /bin/sh is missing so tests stay hermetic.
 	if shPath, err := exec.LookPath("/bin/sh"); err == nil {
 		for _, u := range plan.Units {
 			shCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			out, err := exec.CommandContext(shCtx, shPath, "-n", "-c", u.VerifyCmd).CombinedOutput() //nolint:gosec // G204: shPath is LookPath("/bin/sh"); -n parses only, never executes
+			out, err := exec.CommandContext(shCtx, shPath, "-n", "-c", u.CheckCmd).CombinedOutput() //nolint:gosec // G204: shPath is LookPath("/bin/sh"); -n parses only, never executes
 			cancel()
 			if err != nil {
 				stderr := strings.TrimSpace(string(out))
 				if len(stderr) > 200 {
 					stderr = stderr[:200]
 				}
-				return Plan{}, fmt.Errorf("mission runner: unit %q verify_cmd does not parse as POSIX shell: %s", u.Title, stderr)
+				return Plan{}, fmt.Errorf("mission runner: unit %q check_cmd does not parse as POSIX shell: %s", u.Title, stderr)
 			}
 		}
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -363,6 +363,21 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 // TestRenderReviewContentPlanMarkers pins the D-099 markers in the
 // reviewer packet: reviewed, harness-verified, pending; a regressed unit
 // is pending with the regressed note; no bare verified marker.
+// TestRenderReviewContentSkipsDuplicateReport: a delegated worker's
+// report is its last progress note, so the report block renders only
+// when it says something the notes do not.
+func TestRenderReviewContentSkipsDuplicateReport(t *testing.T) {
+	notes := []ProgressNote{{Note: "wrote base62.go"}, {Note: "wrote redirect.go and its tests"}}
+	same := renderReviewContent(ReviewPacket{Goal: "g", Progress: notes, Evidence: "wrote redirect.go and its tests\n"})
+	if strings.Contains(same, "Worker's own report") || strings.Count(same, "wrote redirect.go and its tests") != 1 {
+		t.Fatalf("report duplicated the last progress note:\n%s", same)
+	}
+	other := renderReviewContent(ReviewPacket{Goal: "g", Progress: notes, Evidence: "all four units done"})
+	if !strings.Contains(other, "Worker's own report") || !strings.Contains(other, "all four units done") {
+		t.Fatalf("distinct report dropped:\n%s", other)
+	}
+}
+
 func TestRenderReviewContentPlanMarkers(t *testing.T) {
 	units := []PlanUnit{
 		{Title: "approved", Passes: true, HarnessPassed: true},
@@ -398,7 +413,7 @@ func TestRenderReviewContentPlanMarkers(t *testing.T) {
 func TestRenderReviewContentFindingsOnly(t *testing.T) {
 	content := renderReviewContent(ReviewPacket{
 		FindingsOnly: true,
-		Units:        []PlanUnit{{Title: "write code", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok\n"}},
+		Units:        []PlanUnit{{Title: "write code", HarnessPassed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "ok\n"}},
 		OpenFindings: []Finding{{ID: "F1", Unit: 0, Title: "missing validation", File: "src/main.go", Detail: "no input check", Evidence: "+func main()", Severity: SeverityBlocking, Status: FindingOpen}},
 		Files:        map[string]string{"src/main.go": "package main\n"},
 		ScopeCreep:   []string{"docs/notes.md"},
@@ -412,7 +427,7 @@ func TestRenderReviewContentFindingsOnly(t *testing.T) {
 		"Re-review of open findings only.",
 		"Affected units (harness state):",
 		"### write code [harness-verified]",
-		"Harness verify_cmd check: passed",
+		"Harness check_cmd check: passed",
 		"- F1 [blocking] (unit 1) src/main.go: missing validation",
 		"  detail: no input check",
 		"  evidence: +func main()",
@@ -439,7 +454,7 @@ func TestRenderReviewContentFindingsOnly(t *testing.T) {
 func TestRenderReviewContentFindingsOnlyEmptyDelta(t *testing.T) {
 	content := renderReviewContent(ReviewPacket{
 		FindingsOnly: true,
-		Units:        []PlanUnit{{Title: "add changelog", HarnessPassed: true, VerifyCheck: "verify_cmd"}},
+		Units:        []PlanUnit{{Title: "add changelog", HarnessPassed: true, VerifyCheck: "check_cmd"}},
 		OpenFindings: []Finding{{ID: "F1", Unit: 0, Title: "other root files modified", File: "CHANGELOG.md", Evidence: " CONTRIBUTING.md | 3 +++", Severity: SeverityBlocking, Status: FindingOpen}},
 		Files:        map[string]string{"CHANGELOG.md": "# Changelog\n"},
 		Progress:     []ProgressNote{{Note: "F1 does not match the repository: this unit's commit touched CHANGELOG.md only"}},
@@ -447,7 +462,7 @@ func TestRenderReviewContentFindingsOnlyEmptyDelta(t *testing.T) {
 	for _, want := range []string{
 		"Mark a finding resolved when the current state does not show the described gap, whether or not the diff since the last review changed it",
 		"### add changelog [harness-verified]",
-		"Harness verify_cmd check: passed",
+		"Harness check_cmd check: passed",
 		"Files named by the findings (read from disk by the harness):\n\n--- CHANGELOG.md ---\n# Changelog",
 		"Worker notes since the last review round (its own account of the rework; verify against the files above):\n- F1 does not match the repository",
 	} {
@@ -729,7 +744,7 @@ func TestRunReviewFallsBackToTokenJSONTextSentinel(t *testing.T) {
 
 func TestPlanSessionParsesSpec(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -763,17 +778,17 @@ func TestPlanSessionParsesAssumptions(t *testing.T) {
 	}{
 		{
 			name: "omitted",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./..."}]}`,
 			want: nil,
 		},
 		{
 			name: "empty",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}],"assumptions":[]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./..."}],"assumptions":[]}`,
 			want: nil,
 		},
 		{
 			name: "populated",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}],"assumptions":[{"assumption":"no language version was specified","default":"Python 3.12"}]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./..."}],"assumptions":[{"assumption":"no language version was specified","default":"Python 3.12"}]}`,
 			want: []PlanAssumption{{Assumption: "no language version was specified", Default: "Python 3.12"}},
 		},
 	}
@@ -804,7 +819,7 @@ func TestPlanSessionParsesAssumptions(t *testing.T) {
 // into one unit and truncated on a long model stream, twice).
 func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -820,11 +835,11 @@ func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 // with HasPlan=true gets the transcribe-mode system prompt (told the
 // goal already carries the plan, must not redesign or add scope)
 // instead of the design-from-scratch opening, while the shared
-// unit-shape rules (artifacts/criteria/verify_cmd/infeasible) still
+// unit-shape rules (artifacts/criteria/check_cmd/infeasible) still
 // apply either way so build/prove need no changes.
 func TestPlanSessionTranscribeMode(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "1. do a\n2. do b", HasPlan: true}
@@ -842,7 +857,7 @@ func TestPlanSessionTranscribeMode(t *testing.T) {
 		t.Fatalf("planner system prompt still carries the design-from-scratch opening: %s", system)
 	}
 	// The unit-shape contract must be unchanged: same artifacts/
-	// criteria/verify_cmd/infeasible rules regardless of mode.
+	// criteria/check_cmd/infeasible rules regardless of mode.
 	if !strings.Contains(system, "Every unit must list at least one artifact") ||
 		!strings.Contains(system, "2 to 6 acceptance criteria") ||
 		!strings.Contains(system, "infeasible=true") {
@@ -854,7 +869,7 @@ func TestPlanSessionTranscribeMode(t *testing.T) {
 // default, omitted) keeps the pre-D-102 design-from-scratch opening.
 func TestPlanSessionDesignModeByDefault(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "fix bug"}
@@ -874,7 +889,7 @@ func TestPlanSessionDesignModeByDefault(t *testing.T) {
 // planning turn's sole tool, the request forces it.
 func TestPlanSessionForcesPlanTool(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -890,7 +905,7 @@ func TestPlanSessionForcesPlanTool(t *testing.T) {
 // turn, so forcing submit_plan would make consulting them impossible.
 func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	r.kbSearch = func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
@@ -909,7 +924,7 @@ func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 // PlanRoute when set, instead of Route.
 func TestPlanSessionUsesPlanRoute(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "mini", PlanRoute: "strong", Goal: "fix bug"}
@@ -925,7 +940,7 @@ func TestPlanSessionUsesPlanRoute(t *testing.T) {
 // prior outcome digest reaches the planner's user prompt.
 func TestPlanSessionIncludesParentContext(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{
@@ -947,7 +962,7 @@ func TestPlanSessionIncludesParentContext(t *testing.T) {
 // additive to (not instead of) ParentContext.
 func TestPlanSessionIncludesReferencedContext(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{
@@ -974,7 +989,7 @@ func TestPlanSessionIncludesReferencedContext(t *testing.T) {
 // attachment's markdown reaches the planner's user prompt.
 func TestPlanSessionIncludesAttachments(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "fix bug", Sources: []SourceEntry{
@@ -1038,22 +1053,22 @@ func TestPlanSessionRejectsInfeasibleWithoutReason(t *testing.T) {
 }
 
 // TestPlanSessionRejectsCommandSubstitution guards parsePlan's
-// determinism rule: verify_cmd runs harness-side via RunVerify,
+// determinism rule: check_cmd runs harness-side via RunVerify,
 // outside the permission chain (D-050's sandbox relaxation for a
 // worker/reviewer shell CALL does not apply here): a planner-authored
-// verify_cmd containing $(...) is rejected because command
+// check_cmd containing $(...) is rejected because command
 // substitution undermines a reproducible content check, not because of
 // any permission concern. The plan should be rejected here, at
 // submission, with feedback the planner can act on immediately.
 func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 	if err == nil {
-		t.Fatal("PlanSession accepted a verify_cmd containing command substitution")
+		t.Fatal("PlanSession accepted a check_cmd containing command substitution")
 	}
 	if !strings.Contains(err.Error(), "command substitution") {
 		t.Fatalf("PlanSession error = %q, want it to name command substitution", err.Error())
@@ -1064,63 +1079,63 @@ func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
 // other opaque-form spelling of command substitution.
 func TestPlanSessionRejectsBackticks(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
-		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"check_cmd\":\"test `cat out.md` = ok\"}]}")},
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"check_cmd\":\"test `cat out.md` = ok\"}]}")},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 	if err == nil {
-		t.Fatal("PlanSession accepted a verify_cmd containing backticks")
+		t.Fatal("PlanSession accepted a check_cmd containing backticks")
 	}
 	if !strings.Contains(err.Error(), "command substitution") {
 		t.Fatalf("PlanSession error = %q, want it to name command substitution", err.Error())
 	}
 }
 
-// TestPlanSessionRejectsGitStatusVerifyCmd guards issue #567: the
+// TestPlanSessionRejectsGitStatusCheckCmd guards issue #567: the
 // harness commits every unit's files itself after the worker turn, so
-// a verify_cmd asserting on git status always checks a stale
+// a check_cmd asserting on git status always checks a stale
 // assumption about working-tree state.
-func TestPlanSessionRejectsGitStatusVerifyCmd(t *testing.T) {
+func TestPlanSessionRejectsGitStatusCheckCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"git status --porcelain | grep -qxF '?? out.md'"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"git status --porcelain | grep -qxF '?? out.md'"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"git status --porcelain | grep -qxF '?? out.md'"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"git status --porcelain | grep -qxF '?? out.md'"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 	if err == nil {
-		t.Fatal("PlanSession accepted a verify_cmd asserting on git status")
+		t.Fatal("PlanSession accepted a check_cmd asserting on git status")
 	}
 	if !strings.Contains(err.Error(), "must not run git") {
 		t.Fatalf("PlanSession error = %q, want it to name the git rejection", err.Error())
 	}
 }
 
-// TestPlanSessionRejectsGitDiffVerifyCmd mirrors the git status case
+// TestPlanSessionRejectsGitDiffCheckCmd mirrors the git status case
 // for git diff, another common working-tree-state assertion.
-func TestPlanSessionRejectsGitDiffVerifyCmd(t *testing.T) {
+func TestPlanSessionRejectsGitDiffCheckCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"git diff --exit-code out.md"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"git diff --exit-code out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"git diff --exit-code out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add smoke file","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"git diff --exit-code out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 	if err == nil {
-		t.Fatal("PlanSession accepted a verify_cmd asserting on git diff")
+		t.Fatal("PlanSession accepted a check_cmd asserting on git diff")
 	}
 	if !strings.Contains(err.Error(), "must not run git") {
 		t.Fatalf("PlanSession error = %q, want it to name the git rejection", err.Error())
 	}
 }
 
-// TestPlanSessionAcceptsVerifyCmdNotMatchingGitWord confirms the git
+// TestPlanSessionAcceptsCheckCmdNotMatchingGitWord confirms the git
 // guard is word-bounded: neither a substring like "digit" nor a path
 // like widget.md false-positives as a git invocation.
-func TestPlanSessionAcceptsVerifyCmdNotMatchingGitWord(t *testing.T) {
+func TestPlanSessionAcceptsCheckCmdNotMatchingGitWord(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check digit count","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi '[0-9] digit' out.md"},`+
-			`{"title":"Check widget file","artifacts":["widget.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi 'ok' widget.md"}`+
+			`{"title":"Check digit count","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi '[0-9] digit' out.md"},`+
+			`{"title":"Check widget file","artifacts":["widget.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi 'ok' widget.md"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -1142,15 +1157,15 @@ func TestPlanSessionAcceptsVerifyCmdNotMatchingGitWord(t *testing.T) {
 // what was wrong and a corrected plan on the next turn is accepted.
 func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
 	if err != nil {
 		t.Fatalf("PlanSession: %v", err)
 	}
-	if len(spec.Units) != 1 || spec.Units[0].VerifyCmd != "grep -qi ok out.md" {
+	if len(spec.Units) != 1 || spec.Units[0].CheckCmd != "grep -qi ok out.md" {
 		t.Fatalf("PlanSession spec = %+v", spec)
 	}
 	if agent.call != 2 {
@@ -1158,17 +1173,17 @@ func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 	}
 }
 
-// TestPlanSessionAcceptsLegitimateVerifyCmd confirms the substitution
+// TestPlanSessionAcceptsLegitimateCheckCmd confirms the substitution
 // guard doesn't false-positive on real verification commands: a
-// content-checking verify_cmd (the existing tautology guard's whole
+// content-checking check_cmd (the existing tautology guard's whole
 // point: never a bare echo) and a legitimate input redirect (<, which
 // must stay legal: only substitution is banned) both parse cleanly
 // in a single turn, no recovery needed.
-func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
+func TestPlanSessionAcceptsLegitimateCheckCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check content","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi 'foo' out.md"},`+
-			`{"title":"Check line count","artifacts":["x"],"criteria":["c1","c2"],"verify_cmd":"test -f x && wc -l < x"}`+
+			`{"title":"Check content","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi 'foo' out.md"},`+
+			`{"title":"Check line count","artifacts":["x"],"criteria":["c1","c2"],"check_cmd":"test -f x && wc -l < x"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -1179,7 +1194,7 @@ func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 	if len(spec.Units) != 2 {
 		t.Fatalf("PlanSession spec = %+v", spec)
 	}
-	if spec.Units[0].VerifyCmd != "grep -qi 'foo' out.md" || spec.Units[1].VerifyCmd != "test -f x && wc -l < x" {
+	if spec.Units[0].CheckCmd != "grep -qi 'foo' out.md" || spec.Units[1].CheckCmd != "test -f x && wc -l < x" {
 		t.Fatalf("PlanSession spec units = %+v", spec.Units)
 	}
 	if agent.call != 1 {
@@ -1190,12 +1205,12 @@ func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 // TestPlanSessionRejectsUnitWithNoArtifacts guards D-068: a unit that
 // declares zero artifacts leaves the harness nothing to check, which
 // is exactly what let amazon.nova-2-lite's empty-contract unit
-// "succeed" on a verify_cmd that always exits 0. Recovery with an
+// "succeed" on a check_cmd that always exits 0. Recovery with an
 // artifact added must succeed.
 func TestPlanSessionRejectsUnitWithNoArtifacts(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","verify_cmd":"grep -qi ok out.md"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","check_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -1215,15 +1230,15 @@ func TestPlanSessionRejectsUnitWithNoArtifacts(t *testing.T) {
 	}
 }
 
-// TestPlanSessionRejectsNoOpVerifyCmd guards D-068's deny-set on the
-// verify_cmd's first shell word: echo/true/:/printf always exit 0
+// TestPlanSessionRejectsNoOpCheckCmd guards D-068's deny-set on the
+// check_cmd's first shell word: echo/true/:/printf always exit 0
 // regardless of content, which is exactly the shape of the real
-// amazon.nova-2-lite incident (verify_cmd `echo 'Gmail API integration
+// amazon.nova-2-lite incident (check_cmd `echo 'Gmail API integration
 // required for actual execution'`, always passing, proving nothing).
 // A command that merely CONTAINS one of those words: as an argument,
 // or after &&: must still be accepted; the deny-set only looks at
 // the first token, by design (see the scoping comment in parsePlan).
-func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
+func TestPlanSessionRejectsNoOpCheckCmd(t *testing.T) {
 	cases := []struct {
 		name string
 		cmd  string
@@ -1235,7 +1250,7 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			plan := fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, tc.cmd)
+			plan := fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":%q}]}`, tc.cmd)
 			agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 				{toolEndEvent(planToolName, plan)},
 				{toolEndEvent(planToolName, plan)},
@@ -1243,7 +1258,7 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 			r := newTestRunner(agent)
 			_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 			if err == nil {
-				t.Fatalf("PlanSession accepted a no-op verify_cmd %q", tc.cmd)
+				t.Fatalf("PlanSession accepted a no-op check_cmd %q", tc.cmd)
 			}
 			if !strings.Contains(err.Error(), "CONTENT") {
 				t.Fatalf("PlanSession error = %q, want it to demand a content check", err.Error())
@@ -1252,15 +1267,15 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 	}
 }
 
-// TestPlanSessionAcceptsVerifyCmdContainingEchoWord confirms the
-// no-op deny-set only inspects the verify_cmd's FIRST shell word: a
+// TestPlanSessionAcceptsCheckCmdContainingEchoWord confirms the
+// no-op deny-set only inspects the check_cmd's FIRST shell word: a
 // real content check that happens to contain the word "echo" as an
 // argument, or a command containing "echo" later after &&, must pass.
-func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
+func TestPlanSessionAcceptsCheckCmdContainingEchoWord(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check literal word","artifacts":["file.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q echo file.md"},`+
-			`{"title":"Check then echo","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":"test -s report.md && grep -q x report.md"}`+
+			`{"title":"Check literal word","artifacts":["file.md"],"criteria":["c1","c2"],"check_cmd":"grep -q echo file.md"},`+
+			`{"title":"Check then echo","artifacts":["report.md"],"criteria":["c1","c2"],"check_cmd":"test -s report.md && grep -q x report.md"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -1277,7 +1292,7 @@ func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
 }
 
 // TestPlanSessionRejectsUnterminatedQuote guards D-068's POSIX shell
-// syntax gate: verify_cmd is run through the REAL /bin/sh -n (per this
+// syntax gate: check_cmd is run through the REAL /bin/sh -n (per this
 // repo's real-shell-tests convention: a fake shell would forgive
 // exactly the quoting bugs this check exists to catch). This mirrors
 // the real amazon.nova-lite incident, whose unterminated quote burned
@@ -1289,13 +1304,13 @@ func TestPlanSessionRejectsUnterminatedQuote(t *testing.T) {
 	}
 	bad := `grep -q "unterminated report.md`
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, bad))},
-		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, bad))},
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"check_cmd":%q}]}`, bad))},
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"check_cmd":%q}]}`, bad))},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
 	if err == nil {
-		t.Fatal("PlanSession accepted a verify_cmd with an unterminated quote")
+		t.Fatal("PlanSession accepted a check_cmd with an unterminated quote")
 	}
 	if !strings.Contains(err.Error(), "does not parse as POSIX shell") {
 		t.Fatalf("PlanSession error = %q, want it to name the shell parse failure", err.Error())
@@ -1303,13 +1318,13 @@ func TestPlanSessionRejectsUnterminatedQuote(t *testing.T) {
 }
 
 // TestPlanSessionAcceptsValidQuoting confirms the /bin/sh -n gate
-// doesn't false-positive on real, properly quoted verify_cmds.
+// doesn't false-positive on real, properly quoted check_cmds.
 func TestPlanSessionAcceptsValidQuoting(t *testing.T) {
 	if _, err := exec.LookPath("/bin/sh"); err != nil {
 		t.Skip("no /bin/sh on this machine")
 	}
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi 'retry-after' report.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi 'retry-after' report.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -1346,7 +1361,7 @@ func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 func TestPlanSessionRecoversWithFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("here's my plan in prose, no tool call")},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -2563,7 +2578,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 	}
 
 	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"do it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"do it","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r = newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -3197,7 +3212,7 @@ func TestDiscoverSessionWiresSteeringFromProgressReader(t *testing.T) {
 // (D-089, issue #458).
 func TestPlanSessionWiresSteeringFromProgressReader(t *testing.T) {
 	batch := [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"go test ./...","passes":true}]}`)},
 	}
 
 	t.Run("wired", func(t *testing.T) {
@@ -3262,7 +3277,7 @@ func TestRunReviewWiresSteeringFromProgressReader(t *testing.T) {
 // file itself at the workspace root) unless the planner sets it.
 func TestParsePlanCriteriaAndScope(t *testing.T) {
 	unit := func(extra string) string {
-		return `{"units":[{"title":"Write it","artifacts":["src/a.go","report.md","src/b.go"],"verify_cmd":"grep -q x report.md"` + extra + `}]}`
+		return `{"units":[{"title":"Write it","artifacts":["src/a.go","report.md","src/b.go"],"check_cmd":"grep -q x report.md"` + extra + `}]}`
 	}
 	tests := []struct {
 		name      string
@@ -3306,8 +3321,8 @@ func TestParsePlanCriteriaAndScope(t *testing.T) {
 // plan_invalid error, and a corrected plan on that turn is accepted.
 func TestPlanSessionRetriesWithCriteriaError(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"verify_cmd":"grep -q x out.md"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"criteria":["a","b"],"verify_cmd":"grep -q x out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"check_cmd":"grep -q x out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"criteria":["a","b"],"check_cmd":"grep -q x out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	plan, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "g"}, "")
@@ -3332,7 +3347,7 @@ func TestRenderReviewContentCriteriaReplaceGoal(t *testing.T) {
 	p := ReviewPacket{
 		Units: []PlanUnit{{
 			Title: "Write summary", Criteria: []string{"summary.md names RFC 6585", "under 200 words"},
-			HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "grep ok\n",
+			HarnessPassed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "grep ok\n",
 		}},
 		DiffStat: " summary.md | 3 +++\n 1 file changed",
 		Diff:     "diff --git a/summary.md b/summary.md\n+429",
@@ -3343,7 +3358,7 @@ func TestRenderReviewContentCriteriaReplaceGoal(t *testing.T) {
 		"### Write summary [harness-verified]",
 		"- summary.md names RFC 6585",
 		"- under 200 words",
-		"Harness verify_cmd check: passed",
+		"Harness check_cmd check: passed",
 		"Verify output:\ngrep ok\n",
 		"Changed files (whole change):\n summary.md | 3 +++",
 		"Diff to review (restricted to the reviewed units' scope):\ndiff --git",
@@ -3386,7 +3401,7 @@ func TestSkillsIndexReachesDiscoverAndPlan(t *testing.T) {
 	}
 
 	planAgent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -q done out.md"}]}`)},
 	}}
 	pr := newTestRunner(planAgent)
 	pr.SetSkillsIndex(resolver)
@@ -3472,7 +3487,7 @@ func TestSearchMemoryReachesWorkingPhases(t *testing.T) {
 		},
 		{
 			name:  "plan",
-			event: toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`),
+			event: toolEndEvent(planToolName, `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -q done out.md"}]}`),
 			run: func(r *nativeRunner) error {
 				_, err := r.PlanSession(context.Background(), m, "")
 				return err
@@ -3535,7 +3550,7 @@ func TestSearchMemoryAbsentWithoutBackend(t *testing.T) {
 // a planner offered search_memory can consult it before planning
 // instead of being forced straight into the plan.
 func TestSearchMemoryPlanNotForcedWhenOffered(t *testing.T) {
-	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -q done out.md"}]}`
 	m := Mission{ID: "m1", Route: "default", Goal: "build a thing"}
 
 	bare := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
@@ -3564,7 +3579,7 @@ func TestSearchMemoryPlanNotForcedWhenOffered(t *testing.T) {
 // With an index the tool is allowed and submit_plan is not forced;
 // without one the turn is exactly as before.
 func TestPlanSessionAllowsLoadSkillWithIndex(t *testing.T) {
-	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -q done out.md"}]}`
 	m := Mission{ID: "m1", AgentID: "a1", Route: "default", Goal: "enter the hackathon"}
 
 	withIndex := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
@@ -3618,7 +3633,7 @@ func TestLoadedSkillsCarryIntoPlan(t *testing.T) {
 	}
 
 	const body = "Produce a rules checklist as the first artifact, rules-checklist.md"
-	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q done out.md"}]}`
+	const planArgs = `{"units":[{"title":"t","artifacts":["out.md"],"criteria":["c1","c2"],"check_cmd":"grep -q done out.md"}]}`
 	planAgent := &scriptedAgent{batches: [][]stream.StreamEvent{{toolEndEvent(planToolName, planArgs)}}}
 	pr := newTestRunner(planAgent)
 	var askedFor string
@@ -3654,5 +3669,25 @@ func TestParseLoadedSkillsIgnoresPlainNotes(t *testing.T) {
 	}
 	if got := parseLoadedSkills("Skills loaded in discover: a, b ,\n\nx"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
 		t.Fatalf("parseLoadedSkills = %v, want [a b]", got)
+	}
+}
+
+// TestParsePlanReadsLegacyVerifyCmd guards the read-side alias for
+// plans written before issue #718 renamed verify_cmd to check_cmd: the
+// old key still loads, lands in CheckCmd, and is never kept around.
+func TestParsePlanReadsLegacyVerifyCmd(t *testing.T) {
+	plan, err := parsePlan(`{"units":[{"title":"u","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q ok out.md"}]}`)
+	if err != nil {
+		t.Fatalf("parsePlan: %v", err)
+	}
+	if got := plan.Units[0].CheckCmd; got != "grep -q ok out.md" {
+		t.Fatalf("CheckCmd = %q, want the legacy verify_cmd value", got)
+	}
+	if plan.Units[0].LegacyVerifyCmd != "" {
+		t.Fatal("LegacyVerifyCmd kept after normalize; it must be cleared so it is never written back")
+	}
+	out, _ := json.Marshal(plan.Units[0])
+	if strings.Contains(string(out), "verify_cmd") {
+		t.Fatalf("marshalled unit still carries verify_cmd: %s", out)
 	}
 }

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -92,9 +92,9 @@ func PlanTool() *tools.Tool {
 								"items": {"type": "string"},
 								"description": "Workspace-relative file path(s) this unit must produce. Required: at least one. Files only — the harness rejects directories."
 							},
-							"verify_cmd": {
+							"check_cmd": {
 								"type": "string",
-								"description": "A real POSIX shell command, run as /bin/sh -c \"<verify_cmd>\" in the mission's workspace, that checks the CONTENT of the artifacts."
+								"description": "A real POSIX shell command, run as /bin/sh -c \"<check_cmd>\" in the mission's workspace, that must fail before the unit's work exists and pass after; follow the check_cmd rules above."
 							},
 							"criteria": {
 								"type": "array",
@@ -107,7 +107,7 @@ func PlanTool() *tools.Tool {
 								"description": "Workspace-relative files or directory prefixes this unit may touch. Optional: defaults to the directories of its artifacts."
 							}
 						},
-						"required": ["title", "artifacts", "verify_cmd", "criteria"]
+						"required": ["title", "artifacts", "check_cmd", "criteria"]
 					}
 				},
 				"infeasible": {
@@ -213,6 +213,10 @@ type WorkerVerdict struct {
 	// carrier. json tag needed because Go's case-insensitive field match
 	// doesn't cross the underscore.
 	FinalOutput string `json:"final_output"`
+	// noWork marks a delegated run that made no tool call at all (issue
+	// #718): whatever it reported, it did not touch the unit. RunWorker
+	// relaunches such a run fresh once before the verdict counts.
+	noWork bool
 	// Forced marks a verdict the runner fabricated because NEITHER a
 	// tool call NOR a text-form sentinel (extractTextSentinel) could be
 	// found after the recovery re-run — set true ONLY on that path
@@ -329,7 +333,7 @@ var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:"([^"]*)
 // Trust note: a text-form sentinel is trust-equivalent to the tool-call
 // form — both are the model's own self-report of its own turn, neither
 // is verified here. The harness's own evidence (CheckArtifacts,
-// verify_cmd, RunVerify) is what actually gates a unit's Passes flag;
+// check_cmd, RunVerify) is what actually gates a unit's Passes flag;
 // this function only saves a turn from being misread as "said nothing"
 // when it in fact reported an outcome in the wrong shape.
 func extractTextSentinel(text, toolName string) (json.RawMessage, bool) {

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -156,6 +156,7 @@ const (
 	InputPhaseComplete      Input = "phase_complete"
 	InputWorkerRetry        Input = "worker_retry"
 	InputWorkerBlocked      Input = "worker_blocked"
+	InputPlanDefect         Input = "plan_defect"
 	InputWorkerFailed       Input = "worker_failed"
 	InputReviewApprove      Input = "review_approve"
 	InputReviewRework       Input = "review_rework"
@@ -437,10 +438,17 @@ func stepInput(s StepState, in StepInput, cfg Config) Transition {
 	case InputWorkerRetry:
 		return stepWorkerRetry(s, in, cfg)
 	case InputWorkerBlocked:
-		return Transition{
-			Next:   withStatus(s, StatusWaitingForInput),
-			Events: []EventDraft{{Kind: "mission.blocked", Payload: map[string]any{"question": in.Message}}},
+		return stepWorkerBlocked(s, in)
+	case InputPlanDefect:
+		// A worker's diagnosis of the plan (issue #718) spends the one
+		// automatic replan, carrying the note; once that is spent, or
+		// for a mission that never plans, it parks like any other block.
+		if !s.ReplanUsed && !s.neverVisitsPlan() {
+			t := replanTransition(s, in)
+			t.Events[0].Payload["cause"] = "worker_blocked"
+			return t
 		}
+		return stepWorkerBlocked(s, in)
 	case InputAskUser:
 		// The store already appended mission.input_requested (SetPendingInput)
 		// before this input reaches Step: no separate event here, same as
@@ -706,7 +714,7 @@ func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 // backoff brake — the worker is still making an attempt, not silently
 // failing. It still tracks the stall brake same as stepReviewRework:
 // two consecutive rounds with an IDENTICAL gap fingerprint (e.g. the
-// same harness verify_cmd failing the same way every time) mean no
+// same harness check_cmd failing the same way every time) mean no
 // real progress is happening, most likely because the check itself
 // can never pass — grinding to max_iterations wastes the rest of the
 // budget on a foregone conclusion.
@@ -1136,5 +1144,15 @@ func stepResultFailed(s StepState, in StepInput) Transition {
 	return Transition{
 		Next:   withPause(s, PauseInfra),
 		Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra), "detail": in.Reason}}},
+	}
+}
+
+// stepWorkerBlocked parks the mission for the operator with the
+// worker's question; the same landing for a plan defect once the
+// automatic replan is spent.
+func stepWorkerBlocked(s StepState, in StepInput) Transition {
+	return Transition{
+		Next:   withStatus(s, StatusWaitingForInput),
+		Events: []EventDraft{{Kind: "mission.blocked", Payload: map[string]any{"question": in.Message}}},
 	}
 }

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -139,6 +139,27 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseBuild, Status: StatusWaitingForInput},
 		},
 		{
+			name:  "plan_defect spends the automatic replan instead of parking (issue #718)",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 2, ConsecutiveFailures: 1},
+			input: StepInput{Input: InputPlanDefect, Reason: "unit cannot pass in isolation", Message: "unit cannot pass in isolation"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
+		},
+		{
+			name:  "plan_defect after the replan is spent parks like a block",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ReplanUsed: true},
+			input: StepInput{Input: InputPlanDefect, Reason: "gate cannot pass", Message: "gate cannot pass"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWaitingForInput, MaxIterations: 8, ReplanUsed: true},
+		},
+		{
+			name:  "plan_defect on a light mission parks (it never plans)",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Flow: FlowLight},
+			input: StepInput{Input: InputPlanDefect, Reason: "gate cannot pass", Message: "gate cannot pass"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWaitingForInput, MaxIterations: 8, Flow: FlowLight},
+		},
+		{
 			name:  "worker_failed below backoff threshold just retries",
 			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 1},
 			input: StepInput{Input: InputWorkerFailed},
@@ -599,24 +620,24 @@ func TestStepAppliesVerification(t *testing.T) {
 		wantEvents []string
 	}{
 		{
-			name:  "worker_retry records the failing excerpt without flipping anything",
-			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "a"}}},
-			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: long}}},
-			wantUnits: []PlanUnit{{Title: "a", VerifyCheck: "verify_cmd", VerifyExcerpt: long[:verifyExcerptCap] + "…"}},
+			name:      "worker_retry records the failing excerpt without flipping anything",
+			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "a"}}},
+			input:     StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Verified: []UnitVerification{{Unit: 0, Check: "check_cmd", Excerpt: long}}},
+			wantUnits: []PlanUnit{{Title: "a", VerifyCheck: "check_cmd", VerifyExcerpt: long[:verifyExcerptCap] + "…"}},
 			wantPhase: PhaseBuild, wantEvents: []string{"mission.retry"},
 		},
 		{
-			name:  "phase_complete marks a passing unit harness-passed and stays in build while a unit is pending (D-096)",
-			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
-			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
-			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
+			name:      "phase_complete marks a passing unit harness-passed and stays in build while a unit is pending (D-096)",
+			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
+			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "check_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
 			wantPhase: PhaseBuild, wantEvents: []string{"mission.generate_continued"},
 		},
 		{
-			name:  "phase_complete enters prove once every unit is harness-passed, Passes waits for approval",
-			state: StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
-			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 1, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
-			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
+			name:      "phase_complete enters prove once every unit is harness-passed, Passes waits for approval",
+			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
+			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 1, Passed: true, Check: "check_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", HarnessPassed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "ok"}},
 			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
 		},
 		{
@@ -641,19 +662,19 @@ func TestStepAppliesVerification(t *testing.T) {
 				{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b"},
 			}},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "regression:unit_0", Verified: []UnitVerification{
-				{Unit: 0, Check: "artifacts", Excerpt: "a.md: not found"}, {Unit: 1, Passed: true, Check: "verify_cmd"},
+				{Unit: 0, Check: "artifacts", Excerpt: "a.md: not found"}, {Unit: 1, Passed: true, Check: "check_cmd"},
 			}},
 			wantUnits: []PlanUnit{
 				{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "a.md: not found"},
-				{Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd"},
+				{Title: "b", HarnessPassed: true, VerifyCheck: "check_cmd"},
 			},
 			wantPhase: PhaseBuild, wantEvents: []string{"mission.unit_regressed", "mission.retry"},
 		},
 		{
 			name:      "a regressed unit passing again clears the regression marker",
 			state:     StepState{Phase: PhaseBuild, Status: StatusWorking, Units: []PlanUnit{{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "gone"}}},
-			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
-			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
+			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "check_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "check_cmd", VerifyExcerpt: "ok"}},
 			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
 		},
 		{
@@ -690,14 +711,14 @@ func TestStepAppliesVerification(t *testing.T) {
 func TestStepRegressionEventPayload(t *testing.T) {
 	got := Step(
 		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "write a.md", Passes: true, HarnessPassed: true}}},
-		StepInput{Input: InputWorkerRetry, Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: strings.Repeat("y", 600)}}},
+		StepInput{Input: InputWorkerRetry, Verified: []UnitVerification{{Unit: 0, Check: "check_cmd", Excerpt: strings.Repeat("y", 600)}}},
 		DefaultConfig,
 	)
 	if len(got.Events) == 0 || got.Events[0].Kind != "mission.unit_regressed" {
 		t.Fatalf("events = %+v, want mission.unit_regressed first", got.Events)
 	}
 	p := got.Events[0].Payload
-	if p["unit"] != 0 || p["title"] != "write a.md" || p["check"] != "verify_cmd" || len(p["excerpt"].(string)) > 510 {
+	if p["unit"] != 0 || p["title"] != "write a.md" || p["check"] != "check_cmd" || len(p["excerpt"].(string)) > 510 {
 		t.Fatalf("payload = %+v, want unit 0, the title, the check and a bounded excerpt", p)
 	}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -183,6 +183,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		}
 	}
 	_ = json.Unmarshal(plan, &m.Plan)
+	m.Plan.normalize()
 	_ = json.Unmarshal(progress, &m.Progress)
 	if m.Progress == nil {
 		m.Progress = []ProgressNote{}
@@ -269,6 +270,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		}
 	}
 	_ = json.Unmarshal(plan, &m.Plan)
+	m.Plan.normalize()
 	_ = json.Unmarshal(progress, &m.Progress)
 	if m.Progress == nil {
 		m.Progress = []ProgressNote{}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -893,7 +893,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 	}
 
 	plan := Plan{
-		Units:       []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, VerifyCmd: "test -s a.md"}, {Title: "write b.md"}},
+		Units:       []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, CheckCmd: "test -s a.md"}, {Title: "write b.md"}},
 		Assumptions: []PlanAssumption{{Assumption: "format", Default: "markdown"}},
 	}
 	if err := s.SetPlan(ctx, id, plan); err != nil {
@@ -903,7 +903,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 	// Turn 1: unit 0 passes on harness evidence.
 	passed := Step(
 		StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Units: plan.Units},
-		StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
+		StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "check_cmd", Excerpt: "ok"}}},
 		DefaultConfig,
 	)
 	if err := s.ApplyTransition(ctx, id, passed); err != nil {
@@ -913,7 +913,7 @@ func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if u := m.Plan.Units[0]; !u.Passes || !u.HarnessPassed || u.VerifyCheck != "verify_cmd" || u.VerifyExcerpt != "ok" {
+	if u := m.Plan.Units[0]; !u.Passes || !u.HarnessPassed || u.VerifyCheck != "check_cmd" || u.VerifyExcerpt != "ok" {
 		t.Fatalf("unit 0 after pass = %+v, want passed on harness evidence with the excerpt", u)
 	}
 	if len(m.Plan.Assumptions) != 1 || m.Plan.Units[1].Title != "write b.md" {

--- a/internal/brain/missions/verifier.go
+++ b/internal/brain/missions/verifier.go
@@ -16,7 +16,7 @@ import (
 )
 
 // verifier runs the harness's own deterministic checks (declared
-// artifacts, citations, verify_cmd) for a mission's plan units.
+// artifacts, citations, check_cmd) for a mission's plan units.
 type verifier struct {
 	store       driverStore
 	sandboxExec sandboxExec
@@ -27,12 +27,12 @@ type verifier struct {
 // UnitVerification per unit checked:
 //   - a unit not yet harness-passed gets CheckArtifacts, then (citations
 //     true, general missions only, D-059) CheckCitations against seenURLs,
-//     then verify_cmd. A unit after the current one whose artifacts are
+//     then check_cmd. A unit after the current one whose artifacts are
 //     missing is skipped: not started yet, nothing to record.
-//   - an already harness-passed unit gets CheckArtifacts plus verify_cmd
+//   - an already harness-passed unit gets CheckArtifacts plus check_cmd
 //     as the regression subset.
 //
-// A hung verify_cmd counts as failed (RunVerifyWithBackend's TimedOut);
+// A hung check_cmd counts as failed (RunVerifyWithBackend's TimedOut);
 // any other exec error aborts the pass as an infrastructure failure.
 func (v *verifier) verifyAll(ctx context.Context, m Mission, seenURLs []string, citations bool) ([]UnitVerification, error) {
 	workRoot := m.WorkRoot()
@@ -53,14 +53,14 @@ func (v *verifier) verifyAll(ctx context.Context, m Mission, seenURLs []string, 
 		}
 		payload := map[string]any{"unit": i, "regression": u.verified()}
 		if res.Check == "" {
-			if u.VerifyCmd == "" {
+			if u.CheckCmd == "" {
 				res.Passed, res.Check = true, "artifacts"
 			} else {
-				r, err := v.runVerify(ctx, m.ID, m.Environment, workRoot, u.VerifyCmd)
+				r, err := v.runVerify(ctx, m.ID, m.Environment, workRoot, u.CheckCmd)
 				if err != nil {
 					return nil, fmt.Errorf("driver: verify unit %d: %w", i, err)
 				}
-				res.Passed, res.Check, res.Excerpt = r.Passed, "verify_cmd", r.Excerpt
+				res.Passed, res.Check, res.Excerpt = r.Passed, "check_cmd", r.Excerpt
 				if r.TimedOut {
 					res.Check = "timeout"
 				}
@@ -102,7 +102,7 @@ func failedUnits(verified []UnitVerification) []UnitVerification {
 	return out
 }
 
-// runVerify executes verify_cmd via the mission's sandbox container,
+// runVerify executes check_cmd via the mission's sandbox container,
 // the verify-side counterpart of nativeRunner routing shell/write_file
 // through the same backend. environment (D-05x) only matters on the
 // mission's first exec, since a container's image is fixed once

--- a/internal/brain/missions/verifier_test.go
+++ b/internal/brain/missions/verifier_test.go
@@ -16,9 +16,9 @@ func newFakeVerifier() *verifier {
 	return &verifier{store: newFakeStore(), sandboxExec: fakeSandboxExec, log: slog.Default()}
 }
 
-// TestVerifyAllNoVerifyCmdPasses covers the simplest case: a unit with
-// no declared artifacts and no verify_cmd passes outright.
-func TestVerifyAllNoVerifyCmdPasses(t *testing.T) {
+// TestVerifyAllNoCheckCmdPasses covers the simplest case: a unit with
+// no declared artifacts and no check_cmd passes outright.
+func TestVerifyAllNoCheckCmdPasses(t *testing.T) {
 	v := newFakeVerifier()
 	m := Mission{ID: "m1", Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}}}
 
@@ -58,10 +58,10 @@ func TestVerifyAllMissingArtifactFailsCurrentSkipsLater(t *testing.T) {
 	}
 }
 
-// TestVerifyAllVerifyCmdGatesPass confirms verify_cmd's exit code, not
+// TestVerifyAllCheckCmdGatesPass confirms check_cmd's exit code, not
 // any model claim, is what passes a unit, and that a later unit whose
 // artifacts already exist is verified in the same pass.
-func TestVerifyAllVerifyCmdGatesPass(t *testing.T) {
+func TestVerifyAllCheckCmdGatesPass(t *testing.T) {
 	v := newFakeVerifier()
 	workRoot := t.TempDir()
 	for _, f := range []string{"out.txt", "later.txt"} {
@@ -72,8 +72,8 @@ func TestVerifyAllVerifyCmdGatesPass(t *testing.T) {
 	m := Mission{
 		ID: "m1", Workspace: workRoot,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "writes and checks", Artifacts: []string{"out.txt"}, VerifyCmd: "echo boom; exit 1"},
-			{Title: "later", Artifacts: []string{"later.txt"}, VerifyCmd: "exit 0"},
+			{Title: "writes and checks", Artifacts: []string{"out.txt"}, CheckCmd: "echo boom; exit 1"},
+			{Title: "later", Artifacts: []string{"later.txt"}, CheckCmd: "exit 0"},
 		}},
 	}
 
@@ -84,16 +84,16 @@ func TestVerifyAllVerifyCmdGatesPass(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("verifyAll = %+v, want both units checked", got)
 	}
-	if got[0].Passed || got[0].Check != "verify_cmd" || !strings.Contains(got[0].Excerpt, "boom") {
-		t.Fatalf("unit 0 = %+v, want a verify_cmd failure carrying the output", got[0])
+	if got[0].Passed || got[0].Check != "check_cmd" || !strings.Contains(got[0].Excerpt, "boom") {
+		t.Fatalf("unit 0 = %+v, want a check_cmd failure carrying the output", got[0])
 	}
 	if !got[1].Passed {
-		t.Fatalf("unit 1 = %+v, want passed (its artifact exists and verify_cmd exits 0)", got[1])
+		t.Fatalf("unit 1 = %+v, want passed (its artifact exists and check_cmd exits 0)", got[1])
 	}
 }
 
 // TestVerifyAllRegressionSubsetRerunsPassedUnits confirms an already
-// harness-passed unit is re-checked (artifacts and verify_cmd) and
+// harness-passed unit is re-checked (artifacts and check_cmd) and
 // reported failed when its artifact vanished, without a citations
 // check that would false-fail it for want of this turn's seenURLs.
 func TestVerifyAllRegressionSubsetRerunsPassedUnits(t *testing.T) {
@@ -106,7 +106,7 @@ func TestVerifyAllRegressionSubsetRerunsPassedUnits(t *testing.T) {
 		ID: "m1", Kind: "general", Workspace: workRoot,
 		Plan: Plan{Units: []PlanUnit{
 			{Title: "gone", Artifacts: []string{"a.md"}, HarnessPassed: true, Passes: true},
-			{Title: "intact", Artifacts: []string{"b.md"}, VerifyCmd: "exit 0", HarnessPassed: true, Passes: true},
+			{Title: "intact", Artifacts: []string{"b.md"}, CheckCmd: "exit 0", HarnessPassed: true, Passes: true},
 		}},
 	}
 
@@ -154,7 +154,7 @@ func TestVerifyAllCitationsOnlyForUnverifiedUnits(t *testing.T) {
 	}
 }
 
-// TestRunVerifyTimedHungCommandCountsAsFailed confirms a verify_cmd that
+// TestRunVerifyTimedHungCommandCountsAsFailed confirms a check_cmd that
 // outlives its timeout is reported as a failed result naming the
 // timeout, never as an infrastructure error (the driver would otherwise
 // route it to worker_failed and retry the same hang).

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -18,7 +18,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
-// verifyBackend runs verify_cmd via a sandbox container instead of
+// verifyBackend runs check_cmd via a sandbox container instead of
 // brain's own process, streaming combined output to out and returning
 // the exit code — RunVerifyWithBackend's counterpart to
 // missionTools' shell Runner hook. err is non-nil only for an
@@ -26,7 +26,7 @@ import (
 // evidence-bearing outcome reported via the exit code).
 type verifyBackend func(ctx context.Context, workdir, command string, timeout time.Duration, out io.Writer) (exitCode int, err error)
 
-// verifyTimeout bounds one plan unit's verify_cmd.
+// verifyTimeout bounds one plan unit's check_cmd.
 const verifyTimeout = 10 * time.Minute
 
 // verifyExcerptCap is the trailing slice of output kept alongside the
@@ -42,7 +42,7 @@ type VerifyResult struct {
 	OutputSHA256 string
 	Excerpt      string
 	Passed       bool
-	// TimedOut marks a verify_cmd that hit verifyTimeout: a failure
+	// TimedOut marks a check_cmd that hit verifyTimeout: a failure
 	// with the timeout named in Excerpt, never an infrastructure error.
 	TimedOut bool
 }
@@ -53,14 +53,14 @@ type VerifyResult struct {
 type UnitVerification struct {
 	Unit    int
 	Passed  bool
-	Check   string // artifacts, citations, verify_cmd, timeout
+	Check   string // artifacts, citations, check_cmd, timeout
 	Excerpt string
 }
 
-// RunVerifyWithBackend executes a plan unit's verify_cmd via backend
+// RunVerifyWithBackend executes a plan unit's check_cmd via backend
 // (the mission's sandbox container) in the work root. Output is
 // streamed into a sha256 hash and a bounded tail buffer rather than
-// collected in full — a verify_cmd with runaway output must not
+// collected in full: a check_cmd with runaway output must not
 // balloon memory. Evidence recorded: exit code, sha256 digest of the
 // full output, and a trailing excerpt — "done is auditable from
 // events alone."
@@ -79,14 +79,14 @@ func runVerifyTimed(ctx context.Context, backend verifyBackend, workRoot, verify
 	exitCode, err := backend(cctx, workRoot, verifyCmd, timeout, io.MultiWriter(hash, tail))
 	if err != nil {
 		// Our own deadline firing (not the caller's cancel), or sandboxd's
-		// server-side timeout for the same duration, is a hung verify_cmd:
+		// server-side timeout for the same duration, is a hung check_cmd:
 		// real evidence the unit did not pass, not infra.
 		sandboxTimeout := strings.Contains(err.Error(), "timed out")
 		if ctx.Err() == nil && (cctx.Err() != nil || sandboxTimeout) {
 			return VerifyResult{
 				ExitCode:     exitCode,
 				OutputSHA256: hex.EncodeToString(hash.Sum(nil)),
-				Excerpt:      tail.String() + fmt.Sprintf("\nverify_cmd timed out after %s", timeout),
+				Excerpt:      tail.String() + fmt.Sprintf("\ncheck_cmd timed out after %s", timeout),
 				TimedOut:     true,
 			}, nil
 		}
@@ -101,7 +101,7 @@ func runVerifyTimed(ctx context.Context, backend verifyBackend, workRoot, verify
 }
 
 // tailBuffer keeps only the last max bytes written to it — a bounded
-// alternative to buffering a verify_cmd's entire (potentially huge)
+// alternative to buffering a check_cmd's entire (potentially huge)
 // output just to keep its trailing excerpt.
 type tailBuffer struct {
 	buf []byte
@@ -121,8 +121,8 @@ func (t *tailBuffer) String() string { return string(t.buf) }
 // CheckArtifacts verifies each declared workspace-relative artifact
 // path exists under workRoot and is non-empty, returning a
 // human-readable problem per failing path. This deterministic check
-// runs BEFORE verify_cmd and is the harness's own evidence — a plan
-// whose verify_cmd is a tautology still cannot pass a unit whose
+// runs BEFORE check_cmd and is the harness's own evidence; a plan
+// whose check_cmd is a tautology still cannot pass a unit whose
 // artifact was never written. A path that escapes workRoot (absolute,
 // or climbing out via ..) is reported as a problem, never resolved.
 func CheckArtifacts(workRoot string, artifacts []string) []string {

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -127,7 +127,7 @@ func TestRunVerifyWithBackendInfraErrorPropagates(t *testing.T) {
 
 // TestTailBufferBoundsMemoryKeepsEnd confirms the streamed excerpt is
 // bounded to the cap and keeps the TAIL of the output, not the head —
-// a verify_cmd with runaway output must not balloon memory, and the
+// a check_cmd with runaway output must not balloon memory, and the
 // kept slice must still show what actually failed at the end.
 func TestTailBufferBoundsMemoryKeepsEnd(t *testing.T) {
 	tail := &tailBuffer{max: 5}

--- a/internal/gateway/provider/openairesponses.go
+++ b/internal/gateway/provider/openairesponses.go
@@ -71,10 +71,11 @@ type orsInputItem struct {
 	CallID    string `json:"call_id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments,omitempty"`
-	// function_call_output field: a pointer so an empty tool result
-	// still serializes as "output": "", which the API requires on
-	// every function_call_output item (issue #702).
-	Output *string `json:"output,omitempty"`
+	// function_call_output field. Never empty on such an item: the API
+	// rejects "output": "" as missing_required_parameter exactly like
+	// an absent key (issues #702, #718), so appendMessage substitutes
+	// emptyToolOutput.
+	Output string `json:"output,omitempty"`
 }
 
 type orsTool struct {
@@ -211,6 +212,10 @@ func messageItem(m Message) orsInputItem {
 	return item
 }
 
+// emptyToolOutput stands in for a tool result with no content: the
+// Responses API rejects "output": "" as a missing parameter (issue #718).
+const emptyToolOutput = "(no output)"
+
 // appendMessage translates one req.Messages entry into its input
 // item(s), mirroring openaicompat.buildRequest's per-message switch:
 // a plain message becomes a message item, an assistant's tool calls
@@ -225,8 +230,11 @@ func appendMessage(items []orsInputItem, m Message) []orsInputItem {
 			// native is_error flag on this shape either.
 			output = "ERROR: " + output
 		}
+		if output == "" {
+			output = emptyToolOutput
+		}
 		return append(items, orsInputItem{
-			Type: "function_call_output", CallID: m.ToolResult.ID, Output: &output,
+			Type: "function_call_output", CallID: m.ToolResult.ID, Output: output,
 		})
 	case len(m.ToolCalls) > 0:
 		if m.Content != "" {

--- a/internal/gateway/provider/openairesponses_test.go
+++ b/internal/gateway/provider/openairesponses_test.go
@@ -276,24 +276,32 @@ func TestOpenAIResponsesContinuationMatchingDriver(t *testing.T) {
 	if len(got.Input) != 1 {
 		t.Fatalf("input items = %d, want 1 (only the tool result): %+v", len(got.Input), got.Input)
 	}
-	if got.Input[0].Type != "function_call_output" || got.Input[0].CallID != "call_1" || got.Input[0].Output == nil || *got.Input[0].Output != "sunny" {
+	if got.Input[0].Type != "function_call_output" || got.Input[0].CallID != "call_1" || got.Input[0].Output != "sunny" {
 		t.Fatalf("input[0] = %+v", got.Input[0])
 	}
 }
 
-// TestOpenAIResponsesEmptyToolResultKeepsOutputField pins issue #702: a
-// tool that returned nothing must still serialize "output": "" on its
-// function_call_output item, or the API rejects the whole request with
-// missing_required_parameter.
-func TestOpenAIResponsesEmptyToolResultKeepsOutputField(t *testing.T) {
+// TestOpenAIResponsesEmptyToolResultGetsPlaceholder pins issues #702 and
+// #718: a tool that returned nothing serializes a non-empty output on its
+// function_call_output item. The API rejects a missing key and an empty
+// string alike with missing_required_parameter (confirmed live against
+// gpt-5.4: "output": "" -> 400, "(no output)" -> 200).
+func TestOpenAIResponsesEmptyToolResultGetsPlaceholder(t *testing.T) {
 	t.Parallel()
 	items := appendMessage(nil, Message{Role: "tool", ToolResult: &ToolResult{ID: "call_1", Content: ""}})
 	raw, err := json.Marshal(items)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if !strings.Contains(string(raw), `"output":""`) {
-		t.Fatalf("empty tool result dropped the output field: %s", raw)
+	if !strings.Contains(string(raw), `"output":"`+emptyToolOutput+`"`) {
+		t.Fatalf("empty tool result must carry the placeholder output: %s", raw)
+	}
+	if strings.Contains(string(raw), `"output":""`) {
+		t.Fatalf("empty output string reached the wire: %s", raw)
+	}
+	errItems := appendMessage(nil, Message{Role: "tool", ToolResult: &ToolResult{ID: "call_2", Content: "", IsError: true}})
+	if errItems[0].Output != "ERROR: " {
+		t.Fatalf("errored empty result = %q, want the ERROR prefix alone (already non-empty)", errItems[0].Output)
 	}
 }
 

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -159,6 +159,11 @@ var harnessDrivers = map[string]map[string]bool{
 // executorUsable against the row's probed OpenAIResponses flag.
 var harnessNeedsResponses = map[string]bool{"codex-cli": true}
 
+// harnessChatOnly names harnesses whose openai wire is
+// chat/completions with no Responses fallback (pi's openai-completions
+// api); opencode and codex speak Responses themselves.
+var harnessChatOnly = map[string]bool{"pi": true}
+
 // RouteRow mirrors one routes table row. Strategy picks the chain
 // order at resolve time: "ordered" keeps the written priority; "auto",
 // "price", and "latency" score entries from recent ledger stats and
@@ -764,6 +769,15 @@ func (s *Snapshot) ResolveRoute(route, harness string) ([]ResolvedRouteEntry, bo
 				re.BaseURL = row.AnthropicBaseURL
 			}
 			re.Usable, re.SkipReason = executorUsable(row, harness)
+			// A harness whose openai wire is chat/completions only cannot
+			// run a model the catalog marks Responses-only (issue #718: pi
+			// on gpt-5.3-codex got a 404 every turn).
+			if re.Usable && harnessChatOnly[harness] && s.responsesOnly(row, re.Model) {
+				re.Usable, re.SkipReason = false, "responses_only: "+harness+" speaks chat/completions and this model serves only /v1/responses"
+			}
+			if re.Usable && re.Model == "" {
+				re.Usable, re.SkipReason = false, emptyModelSkip
+			}
 			if row.Kind != "cli" {
 				re.Wire = harnessWire(row.Driver, overrideApplied)
 			}
@@ -797,6 +811,9 @@ func (s *Snapshot) resolveSelfPaired(harness string) []ResolvedRouteEntry {
 		}
 		re.Prices = s.Prices(row.Name, re.Model)
 		re.Usable, re.SkipReason = executorUsable(row, harness)
+		if re.Usable && re.Model == "" {
+			re.Usable, re.SkipReason = false, emptyModelSkip
+		}
 		out = append(out, re)
 	}
 	return out
@@ -851,6 +868,14 @@ func executorUsable(row ProviderRow, harness string) (bool, string) {
 	}
 	return true, ""
 }
+
+// emptyModelSkip is the skip reason for an entry that resolved to no
+// model at all: the chain pinned none and the provider row carries no
+// default_model. Every adapter's BuildInvocation rejects an empty model
+// (issue #718: a cursor-cli row with no default_model reported usable,
+// then failed every build turn with "executor/cursor: empty model"), so
+// the entry is unusable here rather than three retries later.
+const emptyModelSkip = "provider row has no default_model and the route pins none"
 
 // sortedKeys returns m's keys, sorted — used only to keep an operator-
 // facing skip-reason string deterministic.

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -1693,3 +1693,65 @@ func TestPricesOperatorOverride(t *testing.T) {
 		t.Fatalf("Prices(anthropic, haiku) = %+v, want nil (no override, no catalog entry)", p)
 	}
 }
+
+// TestResolveRouteMarksChatOnlyHarnessUnusableOnResponsesModel (issue
+// #718): pi speaks chat/completions on its openai wire, so a catalog
+// model in Responses-only mode is unusable for it (it 404ed every
+// turn), while codex-cli and opencode, which speak Responses, keep the
+// same row.
+func TestResolveRouteMarksChatOnlyHarnessUnusableOnResponsesModel(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "openai", Kind: "api", Driver: "openaicompat", BaseURL: "https://api.openai.com/v1",
+			DefaultModel: "gpt-5.3-codex", CredentialRef: "OPENAI_KEY", Enabled: true},
+	}
+	routeRows := []RouteRow{{Name: "builder", Chain: []ChainEntry{{ProviderID: "p1", Model: "gpt-5.3-codex"}}, Enabled: true}}
+	cat := &fakeCatalog{pool: []catalog.Model{catModel("gpt-5.3-codex", "responses", nil)}}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" }, cat)
+
+	pi, ok := snap.ResolveRoute("builder", "pi")
+	if !ok || len(pi) != 1 {
+		t.Fatalf("ResolveRoute pi = %v, %v", pi, ok)
+	}
+	if pi[0].Usable || !strings.HasPrefix(pi[0].SkipReason, "responses_only") {
+		t.Fatalf("pi entry = usable %v, skip %q; want unusable with a responses_only reason", pi[0].Usable, pi[0].SkipReason)
+	}
+	for _, h := range []string{"codex-cli", "opencode"} {
+		entries, _ := snap.ResolveRoute("builder", h)
+		if len(entries) != 1 || !entries[0].Usable {
+			t.Fatalf("%s entry = %+v, want usable", h, entries)
+		}
+	}
+}
+
+// TestResolveRouteMarksEmptyModelUnusable (issue #718): a cursor-cli
+// provider row with no default_model reported usable and then failed
+// every build turn with "executor/cursor: empty model". An entry that
+// resolves to no model is unusable at resolution, on the self-paired
+// path and on the chain path alike.
+func TestResolveRouteMarksEmptyModelUnusable(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "cielara", Kind: "cli", Driver: "cursor-cli", CredentialRef: "K", Enabled: true},
+		{ID: "p2", Name: "anthropic", Kind: "api", Driver: "anthropic", BaseURL: "https://api.anthropic.com",
+			CredentialRef: "K", Enabled: true},
+	}
+	routeRows := []RouteRow{{Name: "builder", Chain: []ChainEntry{{ProviderID: "p2"}}, Enabled: true}}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" }, &fakeCatalog{})
+
+	cursor, ok := snap.ResolveRoute("builder", "cursor-cli")
+	if !ok || len(cursor) != 1 {
+		t.Fatalf("ResolveRoute cursor-cli = %v, %v", cursor, ok)
+	}
+	if cursor[0].Usable || cursor[0].SkipReason != emptyModelSkip {
+		t.Fatalf("self-paired entry = usable %v, skip %q; want unusable with %q", cursor[0].Usable, cursor[0].SkipReason, emptyModelSkip)
+	}
+
+	claude, _ := snap.ResolveRoute("builder", "claude-cli")
+	if len(claude) != 1 {
+		t.Fatalf("ResolveRoute claude-cli = %v", claude)
+	}
+	if claude[0].Usable || claude[0].SkipReason != emptyModelSkip {
+		t.Fatalf("chain entry = usable %v, skip %q; want unusable with %q", claude[0].Usable, claude[0].SkipReason, emptyModelSkip)
+	}
+}

--- a/internal/sandboxd/api.go
+++ b/internal/sandboxd/api.go
@@ -26,7 +26,7 @@ const (
 	// execMinTimeout / execMaxTimeout clamp a client-supplied
 	// timeout_seconds server-side — never trust the caller's number
 	// unbounded, even though brain is the only caller today. 15m covers
-	// verify_cmd's own ceiling (10m) with room to spare.
+	// check_cmd's own ceiling (10m) with room to spare.
 	execMinTimeout = 1 * time.Second
 	execMaxTimeout = 15 * time.Minute
 

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -1,6 +1,6 @@
 // Package sandboxd drives per-mission Docker containers that execute
 // model-authored shell commands (mission worker/reviewer shell calls,
-// verify_cmd) OUTSIDE brain's own process — so a command never inherits
+// check_cmd) OUTSIDE brain's own process, so a command never inherits
 // brain's environment (DATABASE_URL, TIMOTHY_MASTER_KEY, API tokens)
 // or reaches brain's filesystem/binaries. Harness-authored git
 // operations stay in brain; only model/plan-authored commands route

--- a/scripts/canary-research.sh
+++ b/scripts/canary-research.sh
@@ -98,7 +98,7 @@ turns = [e for e in events if e["kind"] == "mission.turn"]
 total_ms = sum((e.get("payload") or {}).get("duration_ms", 0) for e in turns)
 
 # mission.unit_verified fires once per check (artifacts/citations/
-# verify_cmd/review) per unit, in order — retries on a failed check
+# check_cmd/review) per unit, in order; retries on a failed check
 # (e.g. an uncited URL) are allowed mid-run, but the LAST verified
 # event recorded for each unit must be passed:true, or "done" was
 # claimed without the harness ever proving it for that unit.

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -5,5 +5,18 @@ run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
 ```sql
-(none)
+-- issue #718: plan units renamed verify_cmd -> check_cmd. The brain
+-- reads both keys (PlanUnit.LegacyVerifyCmd) until this has run; after
+-- it, the alias field can be dropped.
+UPDATE missions
+SET plan = jsonb_set(
+  plan,
+  '{units}',
+  (SELECT jsonb_agg(
+     CASE WHEN u ? 'verify_cmd' AND NOT u ? 'check_cmd'
+          THEN (u - 'verify_cmd') || jsonb_build_object('check_cmd', u->'verify_cmd')
+          ELSE u - 'verify_cmd' END)
+   FROM jsonb_array_elements(plan->'units') AS u))
+WHERE plan ? 'units' AND jsonb_typeof(plan->'units') = 'array'
+  AND EXISTS (SELECT 1 FROM jsonb_array_elements(plan->'units') AS u WHERE u ? 'verify_cmd');
 ```

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -23,7 +23,7 @@ description: Decomposes complex research questions into independent sub-question
 - Stop researching a sub-question once it has an adequately supported answer. If a query goes nowhere, note the dead end briefly and try a materially different research angle rather than repeating the same query.
 - The final unit is synthesis only: read every `findings-*.md` file and do not perform new web research. Write `report.md` with an overview plus a section per sub-question, using claims supported by the findings files. If synthesis discovers a material evidence gap, return it to the appropriate research unit rather than silently filling it.
 - Close `report.md` with one consolidated `## Sources` list merged from the findings files. Every substantive factual claim in the report must be traceable to a cited source in those findings files; analytical conclusions should be clearly identified as inference when appropriate.
-- Verify each research unit's artifact with a verify_cmd that confirms the findings file exists, contains a `## Sources` heading, and contains at least one retrieved source URL. Verify the synthesis unit's verify_cmd confirms `report.md` exists and contains a `## Sources` heading.
+- Verify each research unit's artifact with a check_cmd that confirms the findings file exists, contains a `## Sources` heading, and contains at least one retrieved source URL. Verify the synthesis unit's check_cmd confirms `report.md` exists and contains a `## Sources` heading.
 - Conflicting credible sources must be reported explicitly as a conflict in both the relevant findings file and, when load-bearing, the final report. Do not silently pick a side.
 
 ## Anti-rationalization

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -701,7 +701,7 @@ export interface KbDocument {
 // verify_check/verify_excerpt.
 export interface PlanUnit {
   title: string
-  verify_cmd: string
+  check_cmd: string
   artifacts?: string[]
   // criteria (D-095) are the unit's acceptance criteria, 2 to 6 short
   // lines the reviewer judges against; scope lists the paths the unit

--- a/web/src/components/missions/MissionCard.test.tsx
+++ b/web/src/components/missions/MissionCard.test.tsx
@@ -224,7 +224,7 @@ describe('MissionCard removed fields', () => {
       ...baseMission,
       phase: 'build',
       iteration: 3,
-      plan: { units: [{ title: 'a', verify_cmd: '', passes: true }, { title: 'b', verify_cmd: '', passes: false }] },
+      plan: { units: [{ title: 'a', check_cmd: '', passes: true }, { title: 'b', check_cmd: '', passes: false }] },
     })
     expect(screen.queryByText(/Retries/)).not.toBeInTheDocument()
     expect(screen.queryByText(/\d+\/\d+ units/)).not.toBeInTheDocument()

--- a/web/src/components/missions/PlanApprovalGate.test.tsx
+++ b/web/src/components/missions/PlanApprovalGate.test.tsx
@@ -5,7 +5,7 @@ import { PlanApprovalGate } from './PlanApprovalGate'
 
 afterEach(cleanup)
 
-const units: PlanUnit[] = [{ title: 'Add validation', verify_cmd: 'go test ./...', passes: false }]
+const units: PlanUnit[] = [{ title: 'Add validation', check_cmd: 'go test ./...', passes: false }]
 
 describe('PlanApprovalGate', () => {
   it('renders the plan units and assumptions', () => {

--- a/web/src/components/missions/PlanSection.test.tsx
+++ b/web/src/components/missions/PlanSection.test.tsx
@@ -5,7 +5,7 @@ import { PlanSection } from './PlanSection'
 
 afterEach(cleanup)
 
-const units: PlanUnit[] = [{ title: 'Add validation', verify_cmd: 'go test ./...', passes: true }]
+const units: PlanUnit[] = [{ title: 'Add validation', check_cmd: 'go test ./...', passes: true }]
 
 describe('PlanSection', () => {
   it('renders no plan message when there are no units', () => {
@@ -17,10 +17,10 @@ describe('PlanSection', () => {
     render(
       <PlanSection
         units={[
-          { title: 'done', verify_cmd: '', passes: true, harness_passed: true },
-          { title: 'awaiting review', verify_cmd: '', passes: false, harness_passed: true },
-          { title: 'broke', verify_cmd: '', passes: false, regressed: true, verify_check: 'artifacts', verify_excerpt: 'a.md: not found' },
-          { title: 'todo', verify_cmd: '', passes: false },
+          { title: 'done', check_cmd: '', passes: true, harness_passed: true },
+          { title: 'awaiting review', check_cmd: '', passes: false, harness_passed: true },
+          { title: 'broke', check_cmd: '', passes: false, regressed: true, verify_check: 'artifacts', verify_excerpt: 'a.md: not found' },
+          { title: 'todo', check_cmd: '', passes: false },
         ]}
       />,
     )
@@ -41,8 +41,8 @@ describe('PlanSection', () => {
     render(
       <PlanSection
         units={[
-          { title: 'with criteria', verify_cmd: '', passes: false, criteria: ['report.md names RFC 6585', 'under 200 words'] },
-          { title: 'legacy', verify_cmd: '', passes: false },
+          { title: 'with criteria', check_cmd: '', passes: false, criteria: ['report.md names RFC 6585', 'under 200 words'] },
+          { title: 'legacy', check_cmd: '', passes: false },
         ]}
       />,
     )

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -84,7 +84,7 @@ const baseMission: Mission = {
   branch: 'mission/fix-login',
   base_commit: 'abc123def456',
   workspace: 'ws-1',
-  plan: { units: [{ title: 'Add validation', verify_cmd: 'go test', passes: true }] },
+  plan: { units: [{ title: 'Add validation', check_cmd: 'go test', passes: true }] },
   progress: [{ at: '2026-01-01T00:00:00Z', note: 'found the root cause' }],
   iteration: 2,
   max_iterations: 8,
@@ -1477,7 +1477,7 @@ describe('MissionDetail plan approval gate', () => {
       status: 'paused',
       pause_reason: 'approval',
       plan: {
-        units: [{ title: 'Add validation', verify_cmd: 'go test', passes: true }],
+        units: [{ title: 'Add validation', check_cmd: 'go test', passes: true }],
         assumptions: [{ assumption: 'staging only', default: 'high' }],
       },
     })


### PR DESCRIPTION
## Summary

All five delegated code harnesses (codex-cli, claude-cli, cursor-cli, opencode, pi) failed the same eight-file coding slice. This PR closes the gaps found in the eval, tracked in #718 (G1 to G7, G10 to G12). G8 and G9 stay open there.

### Plan gate
- Reject `gofmt -l ... | grep -q '^$'` (exits 1 on empty input), units with no artifact of their own, and source units gated by grep alone.
- Probe each `check_cmd` once in the sandbox at plan acceptance: a gate that already exits 0, or names a missing command (exit 127 or the shell's own `not found` line), is sent back to the planner with the fix.
- `verify_cmd` renamed `check_cmd`; legacy alias keeps stored plans readable, column rename in `scripts/pending-alters.md`.

### Delegated runner
- Provider rejections (billing, 404 wrong endpoint, quota, HTTP shape status codes) and sandbox launch failures pause as infra with an `until`; they never cost a retry.
- A run that made no tool call relaunches once with a fresh session before its verdict counts.
- A BLOCKED note that names the plan spends the one automatic replan; harness evidence survives the replan by artifact match, reviewer approval only on exact match.
- Worker retries keep the worktree; only a review rework rolls back.

### Gateway
- Responses adapter sends `(no output)` for an empty `function_call_output` (the API rejects `""` as a missing parameter, confirmed live).
- Router marks an entry that resolves to no model unusable instead of failing every build turn.

### Prompt trims
- Plan schema description no longer repeats the system prompt rules.
- Review prompt no longer renders the worker's last note twice.

## Verification
- Local five-arm eval on this branch: 5/5 missions `done` at iteration 0, 4/4 units harness-passed each, delegated review approved.
- `make build vet test lint`: green, 0 lint issues.
- `make canary-coding`: PASS three times on the rebuilt brain.

Refs #718

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791820006&installation_model_id=431401&pr_number=719&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F719&signature=3092ca5c9e3c1bef546f6b2d399e8c7a64bf423c518ef67116411e6dbb931604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->