### PR TITLE
feat(missions): cut delegated token spend with coarser units and CLI caps

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1487,6 +1487,12 @@ func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gw
 	}); ok {
 		withSteering.SetProgressReader(store)
 	}
+	// issue #720: settings-backed CLI turn cap and thinking budget.
+	if withKnobs, ok := runner.(interface {
+		SetExecutorKnobs(func(context.Context) int, func(context.Context) int)
+	}); ok {
+		withKnobs.SetExecutorKnobs(flags.ExecutorReviewMaxTurns, flags.ExecutorThinkingTokens)
+	}
 	return runner
 }
 

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -466,6 +466,10 @@ type createMissionRequest struct {
 	// or "native" (stored as "") keeps the native reviewer, anything
 	// else must name a registered harness. No settings default.
 	ReviewHarness string `json:"review_harness"`
+	// ExecutorSessionPolicy (issue #720) selects whether a delegated
+	// worker run resumes the prior CLI session: "" or "resume" keeps
+	// resume, "fresh" starts every unit cold.
+	ExecutorSessionPolicy string `json:"executor_session_policy"`
 	// Environment selects the per-language sandbox image (D-05x) a
 	// coding mission's container runs: "" auto-detects from the repo at
 	// provisioning (falling back to base), a registered key forces that
@@ -805,6 +809,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveTools: autoApproveTools, AutoApprovePlan: autoApprovePlan, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
 		ReviewHarness:            req.ReviewHarness,
+		ExecutorSessionPolicy:    req.ExecutorSessionPolicy,
 		HasPlan:                  req.HasPlan,
 		ParentMissionID:          parentMissionID,
 		Sources:                  sources,

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -207,6 +207,11 @@ type delegatedRunner struct {
 	// runBudgetFn, when set, is read once per launch and wins over
 	// runBudget: the settings-backed cap (issue #498).
 	runBudgetFn func(context.Context) time.Duration
+	// reviewMaxTurnsFn/thinkingTokensFn are the settings-backed CLI
+	// knobs read once per launch (issue #720); nil means neither is
+	// set on the spec, today's behaviour.
+	reviewMaxTurnsFn func(context.Context) int
+	thinkingTokensFn func(context.Context) int
 
 	mu       sync.Mutex
 	cooldown map[cooldownKey]time.Time
@@ -234,6 +239,30 @@ func NewDelegatedRunner(native Runner, resolveRoute routeResolver, resolveCred c
 // cmd/brain/main.go can pass the same *Store both runners share.
 func (r *delegatedRunner) SetProgressReader(pr ProgressReader) {
 	r.progressReader = pr
+}
+
+// SetExecutorKnobs wires the settings-backed CLI turn cap and thinking
+// budget (issue #720); either may be nil, leaving that knob unset.
+func (r *delegatedRunner) SetExecutorKnobs(reviewMaxTurns, thinkingTokens func(context.Context) int) {
+	r.reviewMaxTurnsFn, r.thinkingTokensFn = reviewMaxTurns, thinkingTokens
+}
+
+// effectiveReviewMaxTurns is the review run's CLI turn cap; 0 leaves
+// the CLI's own loop uncapped.
+func (r *delegatedRunner) effectiveReviewMaxTurns(ctx context.Context) int {
+	if r.reviewMaxTurnsFn == nil {
+		return 0
+	}
+	return r.reviewMaxTurnsFn(ctx)
+}
+
+// effectiveThinkingTokens is the per-turn thinking budget for a launch
+// happening now; 0 leaves the CLI's own default.
+func (r *delegatedRunner) effectiveThinkingTokens(ctx context.Context) int {
+	if r.thinkingTokensFn == nil {
+		return 0
+	}
+	return r.thinkingTokensFn(ctx)
 }
 
 // effectiveRunBudget is the wall-clock cap for a launch happening now.
@@ -303,7 +332,7 @@ const (
 // review_verdict tool, its structured result is the verdict channel,
 // and the read-only tool surface the adapter enforces is spelled out so
 // the model does not waste turns trying to edit.
-const delegatedReviewSystemAppend = " You are running as a delegated read-only CLI reviewer, not through a review_verdict tool. You may read files in the working directory to spot-check; you cannot modify files or run commands, so never try. End your turn by producing the required structured output: decision approve or rework, findings (each with title, file, detail, severity and quoted evidence) and the resolved ids of prior findings the work closed."
+const delegatedReviewSystemAppend = " You are running as a delegated read-only CLI reviewer, not through a review_verdict tool. The diff in the prompt is authoritative: judge the work from it, and read a file in the working directory only when the diff alone cannot settle a criterion. You cannot modify files or run commands, so never try. End your turn by producing the required structured output: decision approve or rework, findings (each with title, file, detail, severity and quoted evidence) and the resolved ids of prior findings the work closed."
 
 // runDelegatedReview resolves the review harness, route and entry, runs
 // the review packet through the CLI read-only, and parses its result as
@@ -351,6 +380,10 @@ func (r *delegatedRunner) runDelegatedReview(ctx context.Context, m Mission, pac
 		// ResumeSessionID stays empty: every review round is a cold
 		// session (D-092). ReadOnly is the enforced safety knob.
 		ReadOnly: true,
+		// issue #720: the reviewer judges a diff the prompt already
+		// carries, so its own agent loop is capped.
+		MaxTurns:       r.effectiveReviewMaxTurns(ctx),
+		ThinkingTokens: r.effectiveThinkingTokens(ctx),
 	}
 	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, renderReviewContent(packet), nil, resumeDecision{reason: resumeReasonNoPriorRun}); err != nil {
 		if errors.Is(err, executor.ErrReadOnlyUnsupported) {
@@ -849,6 +882,9 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 			ResultSchema: workerResultSchema(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 			ResumeSessionID: decision.sessionID,
 			StateDir:        executorStateDir(m.Workspace, m.Harness),
+			// MaxTurns stays 0: a worker turn does the work, so only its
+			// thinking is budgeted (issue #720).
+			ThinkingTokens: r.effectiveThinkingTokens(ctx),
 		}
 		if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, refFiles, decision); err != nil {
 			return WorkerVerdict{}, "", err
@@ -982,6 +1018,9 @@ const (
 	resumeReasonSessionReset       = "session_reset"
 	resumeReasonAdapterUnsupported = "adapter_unsupported"
 	resumeReasonContainerRecreated = "container_recreated"
+	// resumeReasonPolicyFresh is the mission's own executor session
+	// policy asking for a cold session every unit (issue #720).
+	resumeReasonPolicyFresh = "policy_fresh"
 )
 
 // resumeDecision is what planSessionResume works out before a fresh
@@ -999,11 +1038,15 @@ type resumeDecision struct {
 // run (handled=false there means the prior run, if any, already reached
 // a terminal event or never existed), so a non-nil, Finished state
 // here means the prior run genuinely ended (executor.died, most often)
-// and this is a retry. Gates, in order: a prior run must exist for this
+// and this is a retry. Gates, in order: the mission's session policy
+// must not be fresh (issue #720); a prior run must exist for this
 // harness; it must have recorded a session id; the adapter must
 // support resume; and the SAME sandbox container (never recreated
 // since that run's launch) must still be alive.
 func (r *delegatedRunner) planSessionResume(ctx context.Context, m Mission, workRoot string, adapter executor.Adapter) resumeDecision {
+	if m.ExecutorSessionPolicy == SessionPolicyFresh {
+		return resumeDecision{reason: resumeReasonPolicyFresh}
+	}
 	if r.lastRun == nil {
 		return resumeDecision{reason: resumeReasonNoPriorRun}
 	}

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -2941,3 +2941,134 @@ func TestRecordLedgerPrefersReportedModel(t *testing.T) {
 		})
 	}
 }
+
+// TestDelegatedRunWorker_SessionPolicyFreshStartsFresh covers issue
+// #720: a mission whose executor session policy is fresh never resumes,
+// even when every other resume gate would have passed.
+func TestDelegatedRunWorker_SessionPolicyFreshStartsFresh(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.containerAlive = true
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	lastRun := diedRunLastRun("claude-cli", "prior-run-id", "/does/not/matter", "sess-prior-123")
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, lastRun, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+	m.ExecutorSessionPolicy = SessionPolicyFresh
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if strings.Contains(sandbox.lastLaunchCmd(), "--resume") {
+		t.Fatalf("fresh policy must not resume: %s", sandbox.lastLaunchCmd())
+	}
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != false {
+		t.Fatalf("executor.spawned resumed = %v, want false", payload["resumed"])
+	}
+	if payload["resume_reason"] != resumeReasonPolicyFresh {
+		t.Fatalf("executor.spawned resume_reason = %v, want %q", payload["resume_reason"], resumeReasonPolicyFresh)
+	}
+}
+
+// TestDelegatedRunWorker_SessionPolicyResumeUnchanged pins that the
+// default policy leaves the resume path exactly as it was (issue #720).
+func TestDelegatedRunWorker_SessionPolicyResumeUnchanged(t *testing.T) {
+	for _, policy := range []string{"", SessionPolicyResume} {
+		t.Run("policy="+policy, func(t *testing.T) {
+			sandbox := newFakeSandbox()
+			sandbox.containerAlive = true
+			sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+			sandbox.seedExitCode = 0
+			events := &fakeEventSink{}
+			entry := harnessEntry("subscription")
+			route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+			lastRun := diedRunLastRun("claude-cli", "prior-run-id", "/does/not/matter", "sess-prior-123")
+
+			r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, lastRun, &fakeLedger{})
+			m := testMission("m1", t.TempDir())
+			m.ExecutorSessionPolicy = policy
+
+			if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+				t.Fatalf("RunWorker: %v", err)
+			}
+			payload := spawnedPayload(t, events)
+			if payload["resumed"] != true {
+				t.Fatalf("executor.spawned resumed = %v, want true", payload["resumed"])
+			}
+		})
+	}
+}
+
+// TestDelegatedExecutorKnobs covers issue #720: a review spec carries
+// the settings-backed turn cap and thinking budget, a worker spec
+// carries the thinking budget only.
+func TestDelegatedExecutorKnobs(t *testing.T) {
+	r := &delegatedRunner{}
+	ctx := testCtx(t)
+	if got := r.effectiveReviewMaxTurns(ctx); got != 0 {
+		t.Fatalf("unset reviewMaxTurns = %d, want 0", got)
+	}
+	if got := r.effectiveThinkingTokens(ctx); got != 0 {
+		t.Fatalf("unset thinkingTokens = %d, want 0", got)
+	}
+	r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 4000 })
+	if got := r.effectiveReviewMaxTurns(ctx); got != 6 {
+		t.Fatalf("reviewMaxTurns = %d, want 6", got)
+	}
+	if got := r.effectiveThinkingTokens(ctx); got != 4000 {
+		t.Fatalf("thinkingTokens = %d, want 4000", got)
+	}
+}
+
+// TestDelegatedKnobsReachTheLaunch covers issue #720 end to end: a
+// claude-cli review run's launch carries --max-turns and
+// MAX_THINKING_TOKENS, a worker run carries the thinking budget only.
+func TestDelegatedKnobsReachTheLaunch(t *testing.T) {
+	newRunner := func(events *fakeEventSink, sandbox *fakeSandbox) *delegatedRunner {
+		entry := harnessEntry("subscription")
+		route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+		r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+		r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 4000 })
+		return r
+	}
+
+	t.Run("review carries both", func(t *testing.T) {
+		sandbox := newFakeSandbox()
+		sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+		sandbox.seedExitCode = 0
+		r := newRunner(&fakeEventSink{}, sandbox)
+		m := testMission("m1", t.TempDir())
+		m.ReviewHarness = "claude-cli"
+		if _, err := r.RunReview(testCtx(t), m, ReviewPacket{Goal: "review"}); err != nil {
+			t.Fatalf("RunReview: %v", err)
+		}
+		cmd := sandbox.lastLaunchCmd()
+		if !strings.Contains(cmd, "--max-turns") || !strings.Contains(cmd, "6") {
+			t.Fatalf("review launch missing --max-turns 6: %s", cmd)
+		}
+		if sandbox.lastEnv["MAX_THINKING_TOKENS"] != "4000" {
+			t.Fatalf("review launch env MAX_THINKING_TOKENS = %q, want 4000", sandbox.lastEnv["MAX_THINKING_TOKENS"])
+		}
+	})
+
+	t.Run("worker carries the thinking budget only", func(t *testing.T) {
+		sandbox := newFakeSandbox()
+		sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+		sandbox.seedExitCode = 0
+		r := newRunner(&fakeEventSink{}, sandbox)
+		if _, _, err := r.RunWorker(testCtx(t), testMission("m1", t.TempDir()), WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		cmd := sandbox.lastLaunchCmd()
+		if strings.Contains(cmd, "--max-turns") {
+			t.Fatalf("worker launch must not carry a turn cap: %s", cmd)
+		}
+		if sandbox.lastEnv["MAX_THINKING_TOKENS"] != "4000" {
+			t.Fatalf("worker launch env MAX_THINKING_TOKENS = %q, want 4000", sandbox.lastEnv["MAX_THINKING_TOKENS"])
+		}
+	})
+}

--- a/internal/brain/missions/executor/claude.go
+++ b/internal/brain/missions/executor/claude.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -112,11 +113,17 @@ func (claudeAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	if spec.ResumeSessionID != "" {
 		argv = append(argv, "--resume", spec.ResumeSessionID)
 	}
+	if spec.MaxTurns > 0 {
+		argv = append(argv, "--max-turns", strconv.Itoa(spec.MaxTurns))
+	}
 
 	// nodeMaxOldSpaceMB (D-056) bounds the CLI's node heap: unbounded,
 	// node sizes its heap from cgroup limits, and a long run's transcript
 	// heap balloons toward the sandbox's 2 GiB cap.
 	env := map[string]string{"NO_COLOR": "1", "NODE_OPTIONS": "--max-old-space-size=768"}
+	if spec.ThinkingTokens > 0 {
+		env["MAX_THINKING_TOKENS"] = strconv.Itoa(spec.ThinkingTokens)
+	}
 	if spec.AuthMode == AuthAPIKey {
 		env["ANTHROPIC_API_KEY"] = spec.APIKey
 	}

--- a/internal/brain/missions/executor/claude_test.go
+++ b/internal/brain/missions/executor/claude_test.go
@@ -397,6 +397,35 @@ func TestClaudeAdapter_BuildInvocation(t *testing.T) {
 			},
 		},
 		{
+			name: "max turns and thinking tokens set the flag and env (issue #720)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,
+				MaxTurns: 6, ThinkingTokens: 4000,
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--max-turns", "6") {
+					t.Errorf("argv %v missing --max-turns 6", inv.Argv)
+				}
+				if inv.Env["MAX_THINKING_TOKENS"] != "4000" {
+					t.Errorf("MAX_THINKING_TOKENS = %q, want 4000", inv.Env["MAX_THINKING_TOKENS"])
+				}
+			},
+		},
+		{
+			name: "zero max turns and thinking tokens leave the invocation unchanged (issue #720)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if containsFlag(inv.Argv, "--max-turns") {
+					t.Errorf("argv %v must not carry --max-turns when MaxTurns is 0", inv.Argv)
+				}
+				if _, ok := inv.Env["MAX_THINKING_TOKENS"]; ok {
+					t.Error("MAX_THINKING_TOKENS must not be set when ThinkingTokens is 0")
+				}
+			},
+		},
+		{
 			name: "resume session id appends --resume flag (D-103, issue #499)",
 			spec: InvocationSpec{
 				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -88,6 +88,15 @@ type InvocationSpec struct {
 	// with no such knob returns ErrReadOnlyUnsupported from
 	// BuildInvocation instead of pretending.
 	ReadOnly bool
+	// MaxTurns, when > 0, caps the CLI's own agent loop at that many
+	// turns (issue #720). Set for review runs, which judge a diff the
+	// prompt already carries; an adapter whose CLI has no such flag
+	// ignores it.
+	MaxTurns int
+	// ThinkingTokens, when > 0, caps the model's per-turn thinking
+	// budget (issue #720). An adapter whose CLI exposes no such knob
+	// ignores it.
+	ThinkingTokens int
 }
 
 // ErrReadOnlyUnsupported is returned by BuildInvocation when

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -111,6 +111,12 @@ type Mission struct {
 	// keeps the native gateway reviewer. Native is the floor: every
 	// delegated failure falls back to it.
 	ReviewHarness string `json:"review_harness,omitempty"`
+	// ExecutorSessionPolicy decides whether a delegated worker run
+	// resumes the prior CLI session (issue #720). "" and
+	// SessionPolicyResume keep today's behaviour; SessionPolicyFresh
+	// starts every unit cold, so the packet's progress notes and recent
+	// commits are the only carried context. Coding-only, like Harness.
+	ExecutorSessionPolicy string `json:"executor_session_policy,omitempty"`
 	// Flow is the phase set this mission runs (D-090, issue #459),
 	// chosen once at create time, snapshotted here, never model-
 	// mutable. FlowLight (D-069, general kind only) skips discover/plan/

--- a/internal/brain/missions/plangate.go
+++ b/internal/brain/missions/plangate.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -73,7 +74,48 @@ func checkPlanGates(plan Plan, m Mission) error {
 	if m.Kind != KindCoding {
 		return nil
 	}
+	if err := checkUnitGranularity(plan, m); err != nil {
+		return err
+	}
 	return checkCodeFloor(plan, m.Environment)
+}
+
+// smallPlanArtifactCap is the plan size below which a single-directory
+// coding plan is one unit: each extra unit costs a CLI session
+// bootstrap and a reviewed evidence set (issue #720).
+const smallPlanArtifactCap = 8
+
+// checkUnitGranularity rejects a coding plan that splits a small
+// single-directory change into several units. Every extra unit pays
+// for another session bootstrap and another evidence set, and the files
+// share a package, so the work is one unit. Applies in transcribe mode
+// too (D-102): an operator's file list is not a unit split.
+func checkUnitGranularity(plan Plan, m Mission) error {
+	if len(plan.Units) < 2 {
+		return nil
+	}
+	dir := ""
+	count := 0
+	titles := make([]string, 0, len(plan.Units))
+	for _, u := range plan.Units {
+		for _, a := range u.Artifacts {
+			count++
+			d := path.Dir(cleanArtifact(a))
+			if dir == "" {
+				dir = d
+			} else if d != dir {
+				return nil
+			}
+		}
+		titles = append(titles, strconv.Quote(u.Title))
+	}
+	if count == 0 || count > smallPlanArtifactCap {
+		return nil
+	}
+	if dir == "." {
+		dir = "the workspace root"
+	}
+	return fmt.Errorf("mission runner: units %s all produce files in %s and the plan has only %d artifacts, so they are one unit of work; merge them into a single unit with the combined artifacts, criteria and one check_cmd covering all of them", strings.Join(titles, ", "), dir, count)
 }
 
 // checkOwnArtifacts rejects a unit whose every artifact is already

--- a/internal/brain/missions/plangate_test.go
+++ b/internal/brain/missions/plangate_test.go
@@ -214,3 +214,55 @@ func TestCheckOwnArtifacts(t *testing.T) {
 		t.Fatalf("checkOwnArtifacts rejected a unit that adds encoder.go: %v", err)
 	}
 }
+
+// TestCheckUnitGranularity pins the coarse-unit gate (issue #720): a
+// designed coding plan that splits a small single-directory change is
+// rejected, in transcribe mode too; multi-package and larger plans are not.
+func TestCheckUnitGranularity(t *testing.T) {
+	fourUnitsOneDir := []PlanUnit{
+		{Title: "base62", Artifacts: []string{"internal/core/base62.go", "internal/core/base62_test.go"}},
+		{Title: "store", Artifacts: []string{"internal/core/store.go", "internal/core/store_test.go"}},
+		{Title: "shorten", Artifacts: []string{"internal/core/shorten.go", "internal/core/shorten_test.go"}},
+		{Title: "resolve", Artifacts: []string{"internal/core/resolve.go", "internal/core/resolve_test.go"}},
+	}
+	cases := []struct {
+		name    string
+		kind    string
+		hasPlan bool
+		units   []PlanUnit
+		wantErr string
+	}{
+		{"eval slice shape rejected", KindCoding, false, fourUnitsOneDir, "they are one unit of work"},
+		{"two packages accepted", KindCoding, false, []PlanUnit{
+			{Title: "core", Artifacts: []string{"internal/core/a.go"}},
+			{Title: "api", Artifacts: []string{"internal/api/b.go"}},
+		}, ""},
+		{"transcribe mode merged too", KindCoding, true, fourUnitsOneDir, "they are one unit of work"},
+		{"general kind not applied", KindGeneral, false, fourUnitsOneDir, ""},
+		{"nine artifacts in one dir accepted", KindCoding, false, []PlanUnit{
+			{Title: "a", Artifacts: []string{"pkg/a1.go", "pkg/a2.go", "pkg/a3.go", "pkg/a4.go", "pkg/a5.go"}},
+			{Title: "b", Artifacts: []string{"pkg/b1.go", "pkg/b2.go", "pkg/b3.go", "pkg/b4.go"}},
+		}, ""},
+		{"single unit accepted", KindCoding, false, []PlanUnit{
+			{Title: "only", Artifacts: []string{"internal/core/a.go", "internal/core/b.go"}},
+		}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkUnitGranularity(Plan{Units: tc.units}, Mission{Kind: tc.kind, HasPlan: tc.hasPlan})
+			if tc.kind != KindCoding {
+				// checkPlanGates is where the kind gate lives.
+				err = checkPlanGates(Plan{Units: tc.units}, Mission{Kind: tc.kind})
+			}
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkUnitGranularity: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("checkUnitGranularity = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -7,6 +7,15 @@ const (
 	KindGeneral = "general"
 )
 
+// SessionPolicyResume and SessionPolicyFresh are Mission.
+// ExecutorSessionPolicy's values (issue #720): resume (the default,
+// "" means the same) carries the prior CLI session into the next unit;
+// fresh starts every run cold.
+const (
+	SessionPolicyResume = "resume"
+	SessionPolicyFresh  = "fresh"
+)
+
 // Flow names the phase set a mission runs, chosen once at create time
 // and snapshotted onto the row (D-090, issue #459): never model-
 // mutable, no tool or sentinel arg can change it.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1413,6 +1413,31 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 	return WorkerVerdict{Outcome: "retry", Forced: true, Analysis: reason}
 }
 
+// specifiedGoalDiscoverSteps caps discover for a goal that is already
+// fully specified (issue #720).
+const specifiedGoalDiscoverSteps = 4
+
+// goalNamesFiles matches a path-like token: a directory separator and a
+// file extension, e.g. internal/core/base62.go. A clone URL's .git is
+// not a file the goal names; discoverMaxSteps skips it.
+var goalNamesFiles = regexp.MustCompile(`[\w.-]+/[\w./-]*\w+\.[A-Za-z0-9]+`)
+
+// discoverMaxSteps bounds the discover turn. A mission whose goal
+// carries the operator's own plan (D-102) and names the files it
+// touches has nothing left to explore, so it gets a short orientation;
+// every other goal keeps the agent's default ceiling (0).
+func discoverMaxSteps(m Mission) int {
+	if !m.HasPlan {
+		return 0
+	}
+	for _, tok := range goalNamesFiles.FindAllString(m.Goal, -1) {
+		if !strings.HasSuffix(tok, ".git") {
+			return specifiedGoalDiscoverSteps
+		}
+	}
+	return 0
+}
+
 // DiscoverSession runs the mission's discover turn: explore the goal
 // before planning commits to a shape. Unlike RunWorker's sentinel
 // ladder, a missing discover_notes call never fails the phase: the
@@ -1466,6 +1491,10 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, s
 		// turns (issue #458): a note posted while discover is in flight
 		// reaches this turn instead of only the next phase's prompt.
 		Steering: r.steeringFor(m.ID, m.Progress),
+		// issue #720: a goal that already carries the operator's plan and
+		// names its files leaves discover nothing to design, so it gets a
+		// short orientation instead of open-ended exploration.
+		MaxSteps: discoverMaxSteps(m),
 	}
 
 	res, err := r.runTurn(ctx, req, discoverNotesToolName, PhaseDiscover)
@@ -1839,7 +1868,7 @@ func reportInProgress(p ReviewPacket) bool {
 // (D-077), and assumptions. Kept as one shared string so
 // build/prove's unit parsing (parsePlan) never has to distinguish
 // which mode produced a plan.
-const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). check_cmd is executed literally as `/bin/sh -c \"<check_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command). It is a gate, not a proof: it must FAIL against the workspace as it stands now and PASS once the unit's work exists, and the harness runs it once at plan acceptance to confirm the first half, rejecting a gate that already passes. For a unit whose artifacts are source files it must build, test or run them with the environment's toolchain (`go test ./pkg/...`, `python3 -m pytest tests/`, `npm test`); a grep against source only proves text is present, so greps may accompany the toolchain call but never stand alone. A toolchain call alone passes while the unit's files are still missing (`go test ./pkg/ -run TestX` exits 0 when no test file exists, `gofmt -l` prints nothing for absent files, pytest collects nothing), so anchor each code unit's check_cmd on a symbol the unit adds, e.g. `grep -q 'func TestBase62' internal/core/base62_test.go && go test ./internal/core/ -run TestBase62`. For document artifacts check CONTENT (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in check_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`; to assert a command prints nothing (gofmt -l, a linter) pipe it into `awk 'END{exit NR>0}'`, NEVER `grep -q '^$'`, which exits 1 on empty input. Do not add a separate final \"format and verify\" unit: put the toolchain call in every code unit's own check_cmd. The harness commits each unit's files itself after the worker turn, so criteria and check_cmd must judge file CONTENT only, never git status, staging, untracked, or uncommitted state. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
+const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). check_cmd is executed literally as `/bin/sh -c \"<check_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command). It is a gate, not a proof: it must FAIL against the workspace as it stands now and PASS once the unit's work exists, and the harness runs it once at plan acceptance to confirm the first half, rejecting a gate that already passes. For a unit whose artifacts are source files it must build, test or run them with the environment's toolchain (`go test ./pkg/...`, `python3 -m pytest tests/`, `npm test`); a grep against source only proves text is present, so greps may accompany the toolchain call but never stand alone. A toolchain call alone passes while the unit's files are still missing (`go test ./pkg/ -run TestX` exits 0 when no test file exists, `gofmt -l` prints nothing for absent files, pytest collects nothing), so anchor each code unit's check_cmd on a symbol the unit adds, e.g. `grep -q 'func TestBase62' internal/core/base62_test.go && go test ./internal/core/ -run TestBase62`. For document artifacts check CONTENT (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in check_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`; to assert a command prints nothing (gofmt -l, a linter) pipe it into `awk 'END{exit NR>0}'`, NEVER `grep -q '^$'`, which exits 1 on empty input. Do not add a separate final \"format and verify\" unit: put the toolchain call in every code unit's own check_cmd. For a small coding change (at most 8 source files, all in one directory or package), submit ONE unit covering all of them rather than one unit per file, since each extra unit costs a separate session and review round. The harness commits each unit's files itself after the worker turn, so criteria and check_cmd must judge file CONTENT only, never git status, staging, untracked, or uncommitted state. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
 
 // planSystemPrompt builds PlanSession's system prompt: the design-mode
 // opening (break the goal into units from scratch) or, when hasPlan is
@@ -1851,7 +1880,7 @@ const planUnitShapeRules = " Every unit must list at least one artifact, the wor
 // to a transcribed plan as to a designed one.
 func planSystemPrompt(hasPlan bool) string {
 	if hasPlan {
-		return "You are transcribing a mission plan. The goal below already contains the operator's own plan: convert it into an ordered list of verifiable units faithfully, preserving its steps and order. Do not redesign the plan, do not add scope or steps the operator didn't ask for, and do not merge or split steps the operator kept separate, except where the shape rules below force a natural split (e.g. one step whose own deliverable would truncate a single worker turn)." + planUnitShapeRules
+		return "You are transcribing a mission plan. The goal below already contains the operator's own plan: convert it into an ordered list of verifiable units faithfully, preserving its steps and order. Do not redesign the plan, do not add scope or steps the operator didn't ask for, and do not merge or split steps the operator kept separate, except where the shape rules below force a split (one step whose own deliverable would truncate a single worker turn) or a merge (a small change inside one directory)." + planUnitShapeRules
 	}
 	return "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it: one unit is correct for a simple goal; never pad the plan. A worker turn is one continuous model generation: if a single unit's own deliverable would demand a very long uninterrupted output (many chapters, dozens of sections, a large multi-file dataset, or similar), a long stream is more likely to truncate mid-generation, so split that unit along its own natural boundaries (one unit per chapter/section/file) instead of one unit for the whole deliverable; this applies regardless of the goal's subject matter." + planUnitShapeRules
 }

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3691,3 +3691,29 @@ func TestParsePlanReadsLegacyVerifyCmd(t *testing.T) {
 		t.Fatalf("marshalled unit still carries verify_cmd: %s", out)
 	}
 }
+
+// TestDiscoverMaxSteps pins the discover shortcut (issue #720): a goal
+// that carries the operator's plan AND names its files gets a short
+// orientation; every other goal keeps the agent's default ceiling.
+func TestDiscoverMaxSteps(t *testing.T) {
+	cases := []struct {
+		name    string
+		hasPlan bool
+		goal    string
+		want    int
+	}{
+		{"plan naming files", true, "1. add internal/core/base62.go\n2. add internal/core/base62_test.go", specifiedGoalDiscoverSteps},
+		{"plan without file names", true, "1. design the scheme\n2. write it up", 0},
+		{"files without a plan", false, "make internal/core/base62.go shorter", 0},
+		{"neither", false, "research the shortener market", 0},
+		{"bare word with a dot is not a path", true, "1. update the README.md\n2. ship it", 0},
+		{"clone url alone is not a file list", true, "1. clone https://github.com/x/y.git\n2. read it", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := discoverMaxSteps(Mission{HasPlan: tc.hasPlan, Goal: tc.goal}); got != tc.want {
+				t.Fatalf("discoverMaxSteps = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -52,7 +52,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	discover_notes, replan_used, schedule_id, session_id, harness, review_harness, environment,
 	parent_mission_id, sources, destinations, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, permission_timeout_seconds, pending_input, asks_used, flow,
-	review_findings, rework_rounds, has_plan`
+	review_findings, rework_rounds, has_plan, executor_session_policy`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
@@ -138,7 +138,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan,
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -226,7 +226,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan); err != nil {
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy); err != nil {
 		return Mission{}, err
 	}
 	m.Flow = parseFlow(flow)
@@ -324,9 +324,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, flow)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan, review_harness)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30, $31) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan, m.ReviewHarness,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan, review_harness, executor_session_policy)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30, $31, $32) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan, m.ReviewHarness, m.ExecutorSessionPolicy,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -91,6 +91,8 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 			return fmt.Errorf("%w: harness is only valid for kind=coding missions", ErrInvalidMission)
 		case m.Environment != "":
 			return fmt.Errorf("%w: environment is only valid for kind=coding missions", ErrInvalidMission)
+		case m.ExecutorSessionPolicy != "":
+			return fmt.Errorf("%w: executor_session_policy is only valid for kind=coding missions", ErrInvalidMission)
 		case repoURL != "":
 			return fmt.Errorf("%w: repo_url is only valid for kind=coding missions", ErrInvalidMission)
 		}
@@ -104,6 +106,11 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 		if _, ok := executor.Lookup(m.ReviewHarness); !ok {
 			return fmt.Errorf("%w: unknown review_harness %q", ErrInvalidMission, m.ReviewHarness)
 		}
+	}
+	switch m.ExecutorSessionPolicy {
+	case "", SessionPolicyResume, SessionPolicyFresh:
+	default:
+		return fmt.Errorf("%w: unknown executor_session_policy %q", ErrInvalidMission, m.ExecutorSessionPolicy)
 	}
 	if !ValidEnvironment(m.Environment) {
 		return fmt.Errorf("%w: unknown environment %q", ErrInvalidMission, m.Environment)

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -66,6 +66,18 @@ func TestValidateCreate(t *testing.T) {
 			m.Kind, m.ReviewHarness = "coding", "pi"
 			return m
 		}, ValidateDeps{}, false},
+		{"unknown executor_session_policy", func(m Mission) Mission {
+			m.Kind, m.ExecutorSessionPolicy = "coding", "sometimes"
+			return m
+		}, ValidateDeps{}, true},
+		{"fresh executor_session_policy", func(m Mission) Mission {
+			m.Kind, m.ExecutorSessionPolicy = "coding", SessionPolicyFresh
+			return m
+		}, ValidateDeps{}, false},
+		{"executor_session_policy on general", func(m Mission) Mission {
+			m.ExecutorSessionPolicy = SessionPolicyFresh
+			return m
+		}, ValidateDeps{}, true},
 		{"environment on general", func(m Mission) Mission {
 			m.Environment = "go"
 			return m

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -141,7 +141,20 @@ const (
 	// agents.Agent.Knowledge already stores names, so a deleted or
 	// renamed collection simply stops boosting.
 	ValueWritingSamplesCollection = "writing_samples_collection"
+	// ValueExecutorReviewMaxTurns caps a delegated review run's own CLI
+	// agent loop (missions/delegated.go, issue #720); "" defers to
+	// DefaultExecutorReviewMaxTurns, "0" removes the cap. The reviewer
+	// judges a diff the prompt already carries, so it needs few turns.
+	ValueExecutorReviewMaxTurns = "executor_review_max_turns"
+	// ValueExecutorThinkingTokens caps the per-turn thinking budget a
+	// delegated worker or review run gets (issue #720); "" or "0" (the
+	// default) leaves the CLI's own default in place.
+	ValueExecutorThinkingTokens = "executor_thinking_tokens"
 )
+
+// DefaultExecutorReviewMaxTurns is the delegated review run's turn cap
+// when ValueExecutorReviewMaxTurns is unset.
+const DefaultExecutorReviewMaxTurns = 6
 
 // writingStyleCap bounds the free-text writing-style setting; it rides
 // every prompt, so an unbounded value would be an unbounded per-turn
@@ -172,6 +185,7 @@ var knownValueKeys = map[string]bool{
 	ValueExecutorRunBudgetMinutes: true, ValueReviewTokenCeiling: true,
 	ValueMCPToolIndexThreshold: true,
 	ValueWritingStyle:          true, ValueWritingSamplesCollection: true,
+	ValueExecutorReviewMaxTurns: true, ValueExecutorThinkingTokens: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -297,6 +311,29 @@ func (s *Store) ExecutorRunBudget(ctx context.Context) time.Duration {
 		}
 	}
 	return DefaultExecutorRunBudget
+}
+
+// ExecutorReviewMaxTurns parses the delegated review turn cap, falling
+// back to DefaultExecutorReviewMaxTurns when unset or unparsable; 0
+// removes the cap.
+func (s *Store) ExecutorReviewMaxTurns(ctx context.Context) int {
+	if v := s.Value(ctx, ValueExecutorReviewMaxTurns); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return DefaultExecutorReviewMaxTurns
+}
+
+// ExecutorThinkingTokens parses the per-turn thinking budget a
+// delegated run gets; 0 (the default) leaves the CLI's own default.
+func (s *Store) ExecutorThinkingTokens(ctx context.Context) int {
+	if v := s.Value(ctx, ValueExecutorThinkingTokens); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // ReviewTokenCeiling parses the per-mission review input token cap:
@@ -469,7 +506,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}
 	}
-	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling || key == ValueMCPToolIndexThreshold) && value != "" {
+	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling || key == ValueMCPToolIndexThreshold || key == ValueExecutorReviewMaxTurns || key == ValueExecutorThinkingTokens) && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}

--- a/internal/brain/settings/settings_test.go
+++ b/internal/brain/settings/settings_test.go
@@ -84,3 +84,15 @@ func TestWritingSettingsDefaultEmpty(t *testing.T) {
 		t.Fatalf("WritingSamplesCollection = %q, want empty", got)
 	}
 }
+
+// TestExecutorKnobDefaults pins the issue #720 accessors: an absent row
+// means the built-in review turn cap and no thinking budget at all.
+func TestExecutorKnobDefaults(t *testing.T) {
+	s := degradedStore(t)
+	if got := s.ExecutorReviewMaxTurns(context.Background()); got != DefaultExecutorReviewMaxTurns {
+		t.Fatalf("ExecutorReviewMaxTurns = %d, want %d", got, DefaultExecutorReviewMaxTurns)
+	}
+	if got := s.ExecutorThinkingTokens(context.Background()); got != 0 {
+		t.Fatalf("ExecutorThinkingTokens = %d, want 0", got)
+	}
+}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -705,6 +705,11 @@ CREATE TABLE IF NOT EXISTS missions (
     -- "" keeps the native gateway reviewer, which every delegated
     -- failure also falls back to.
     review_harness        text NOT NULL DEFAULT '',
+    -- ExecutorSessionPolicy (issue #720) decides whether a delegated
+    -- worker run resumes the prior CLI session: '' and 'resume' keep
+    -- resume, 'fresh' starts every unit cold so only the packet's
+    -- progress notes and recent commits carry over.
+    executor_session_policy text NOT NULL DEFAULT '',
     -- Mission worker turns run through loop.Agent same as chat, but
     -- tool-call bookkeeping (session_events, tools audit) hard-requires
     -- a real session_id uuid FK -- a mission has no chat session of its

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -20,3 +20,9 @@ SET plan = jsonb_set(
 WHERE plan ? 'units' AND jsonb_typeof(plan->'units') = 'array'
   AND EXISTS (SELECT 1 FROM jsonb_array_elements(plan->'units') AS u WHERE u ? 'verify_cmd');
 ```
+
+```sql
+-- issue #720: per-mission executor session policy ('' / 'resume' keep
+-- today's resume behaviour, 'fresh' starts every unit cold).
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS executor_session_policy text NOT NULL DEFAULT '';
+```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -867,6 +867,10 @@ export interface Mission {
   // phase's review round runs as a read-only delegated CLI; "" or
   // absent keeps the native reviewer (also the fallback on any failure).
   review_harness?: string
+  // executor_session_policy (issue #720) decides whether a delegated
+  // worker run resumes the prior CLI session: "" or "resume" keeps
+  // resume, "fresh" starts every unit cold.
+  executor_session_policy?: string
   // top_model/top_model_provider are decorated onto the list/get
   // response from the cost ledger's top-served-model-per-mission
   // lookup (internal/brain/api/missions.go's decorateTopModels): the


### PR DESCRIPTION
## Summary

Closes #720. Four levers on delegated mission cost, measured on the same eight-file slice as #718/#719.

| Arm | Before (4 units) | After (1 unit) | Cut |
|---|---|---|---|
| claude-cli | $3.19, 8:08 | $1.77, 6:02 | 45% |
| codex-cli | $2.00, 3:16 | $0.84, 3:21 | 58% |

### Slice 1: coarser units
`checkUnitGranularity` rejects a coding plan that splits at most 8 files in one directory into several units, naming the units to merge. Applies in transcribe mode too (D-102): an operator's file list is not a unit split. One sentence added to the planner rules. This gate is the whole saving above.

### Slice 2: executor session policy
`executor_session_policy` on the mission (`resume` default, `fresh` starts every unit cold): API field, validation (coding only), store column, init migration plus ALTER in `scripts/pending-alters.md`, web `Mission` type. `planSessionResume` returns `policy_fresh` before every other gate. Not measurable on this slice any more (one unit, one launch); needs a multi-package goal.

### Slice 3: reviewer cap and thinking budget
`InvocationSpec.MaxTurns` / `ThinkingTokens`; the Claude adapter emits `--max-turns` and `MAX_THINKING_TOKENS`, other adapters ignore them. Settings `executor_review_max_turns` (default 6) and `executor_thinking_tokens` (default 0). Review runs get both, worker runs the thinking budget only. Reviewer system prompt: the diff is authoritative. A capped review with no structured output falls to the native reviewer through the existing `unparseable_verdict` path, never a silent approve. Observed 5 review turns on the eval; cap did not bind.

### Slice 4: discover shortcut
`discoverMaxSteps` caps discover at 4 steps when the goal carries an operator plan and names files (a clone URL's `.git` does not count). 13 model calls / 40 s before, 8 / 20 s after (the sentinel ladder's nudge adds its own rung).

## Verification
- `make build vet test lint`: green, 0 issues; web build/lint/test green.
- Local eval: claude-cli and codex-cli arms `done` at iteration 0 with a one-unit plan accepted on the first plan turn.
- Homelab needs the ALTER from `scripts/pending-alters.md` before this release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791823813&installation_model_id=431401&pr_number=721&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F721&signature=090b7841b641a26070b8efbb07ebc664ec3112c58b01710892414cd19112cee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->