### PR TITLE
feat(missions): bound harness retries and judge every criterion

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1176,6 +1176,13 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetReviewWindow(missions.GatewayReviewWindow(gwc.ResolveRoute, gwc.ModelWindows))
 	driver.SetRouteResolver(gwc.ResolveRoute)
 	driver.SetReviewTokenCeiling(flags.ReviewTokenCeiling)
+	// issue #718: every retry ceiling is an operator setting, read per
+	// turn so a change lands on the next turn without a restart.
+	driver.SetCeilings(func(ctx context.Context) (int, int, int) {
+		return flags.MissionBackoffFailures(ctx), flags.MissionStallRounds(ctx), flags.MissionHarnessRetryCap(ctx)
+	})
+	driver.SetAutoResumeMax(flags.MissionAutoResumeBackoffMax, flags.MissionAutoResumeInfraMax)
+	store.SetDefaultMaxIterations(flags.MissionDefaultMaxIterations)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 	driver.SetNameMission(chat.TitleOverGateway(gwc, log))
@@ -1489,9 +1496,9 @@ func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gw
 	}
 	// issue #720: settings-backed CLI turn cap and thinking budget.
 	if withKnobs, ok := runner.(interface {
-		SetExecutorKnobs(func(context.Context) int, func(context.Context) int)
+		SetExecutorKnobs(func(context.Context) int, func(context.Context) int, func(context.Context) int)
 	}); ok {
-		withKnobs.SetExecutorKnobs(flags.ExecutorReviewMaxTurns, flags.ExecutorThinkingTokens)
+		withKnobs.SetExecutorKnobs(flags.ExecutorReviewMaxTurns, flags.ExecutorWorkerMaxTurns, flags.ExecutorThinkingTokens)
 	}
 	return runner
 }

--- a/internal/brain/missions/CLAUDE.md
+++ b/internal/brain/missions/CLAUDE.md
@@ -143,7 +143,21 @@ CLAUDE.md so other work does not pay for it every session.
   (pi) unusable on a Responses-only catalog model, and any harness
   entry that resolves to no model (`emptyModelSkip`: chain pins none,
   provider row has no `default_model`) unusable instead of letting
-  `BuildInvocation` fail three retries later.
+  `BuildInvocation` fail three retries later. A retry the harness
+  caused (`StepInput.HarnessCaused`: an unreadable sentinel, a runner
+  error, an executor death, an idle timeout) spends no iteration and
+  skips the `MaxIterations` ceiling, marked `harness_caused` on
+  `mission.retry`; the stall and backoff brakes still count it, so a
+  harness that keeps failing still pauses, including on a planless flow
+  where the stall pause is the only stop left. `missions.harness_retries`
+  is their lifetime count, capped by
+  `settings.mission_harness_retry_cap` (pause cause
+  `harness_retries_exhausted`) and reset by nothing. On a
+  harness-caused FAILURE the cap is checked before the backoff brake:
+  resume clears the pause but not `ConsecutiveFailures`, so a
+  backoff-first order would re-pause as backoff on every resumed harness
+  failure and the cap would be dead code. On a harness-caused RETRY the
+  stall brake still comes first.
 - A tool result with no content (`git status --short` on a clean tree)
   used to 400 every OpenAI Responses turn: the API rejects
   `"output": ""` as missing, the continuation retry resends the full
@@ -187,4 +201,29 @@ CLAUDE.md so other work does not pay for it every session.
   a 60 s sandbox probe against the pre-work tree, a gate that already
   exits 0 or names a command the environment lacks. Verifying that the
   criteria are met is the reviewer's job, not the gate's.
+- Per-criterion review rubric (issue #718): `review_verdict` carries
+  `criteria` (unit index, criterion index, met/not_met/cannot_tell,
+  evidence), optional so existing fixtures still parse and an unknown
+  status reads as cannot_tell. `Driver.runReview` decides in Go, not in
+  the prompt: a not_met criterion opens a blocking finding titled with
+  the criterion and forces rework even on an approve decision (Warn
+  logged), a cannot_tell opens a minor finding, a title already open
+  opens nothing, and unanswered criteria are only logged. Skipped: a
+  criterion on a unit outside the round (`mergeFindings` stamps every
+  finding with the reviewed unit) and a not_met quoting no evidence,
+  read as cannot_tell since the D-095 gate would demote it anyway. The
+  full-round packet numbers each unit's criteria and heads each unit
+  with its plan index; a findings-only round asks no rubric.
+- Every retry, iteration and auto-resume ceiling is an operator
+  setting, read per turn rather than compiled in (issue #718):
+  `mission_default_max_iterations` (Store.Create/scheduler via
+  `SetDefaultMaxIterations`), `mission_backoff_failures`,
+  `mission_stall_rounds` and `mission_harness_retry_cap` (the
+  statemachine `Config`, built per Advance by `Driver.config` from
+  `SetCeilings`), `mission_auto_resume_backoff_max` and
+  `mission_auto_resume_infra_max` (the sweep ladders' exhausted caps via
+  `SetAutoResumeMax`). `DefaultConfig` and the `sweep.go` constants stay
+  as the fallbacks. Delegated CLI runs are capped too:
+  `executor_worker_max_turns` (40) alongside
+  `executor_review_max_turns` (6), both on `SetExecutorKnobs`.
 - `make canary` is the regression gate for any harness change.

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -211,6 +211,7 @@ type delegatedRunner struct {
 	// knobs read once per launch (issue #720); nil means neither is
 	// set on the spec, today's behaviour.
 	reviewMaxTurnsFn func(context.Context) int
+	workerMaxTurnsFn func(context.Context) int
 	thinkingTokensFn func(context.Context) int
 
 	mu       sync.Mutex
@@ -241,10 +242,20 @@ func (r *delegatedRunner) SetProgressReader(pr ProgressReader) {
 	r.progressReader = pr
 }
 
-// SetExecutorKnobs wires the settings-backed CLI turn cap and thinking
-// budget (issue #720); either may be nil, leaving that knob unset.
-func (r *delegatedRunner) SetExecutorKnobs(reviewMaxTurns, thinkingTokens func(context.Context) int) {
-	r.reviewMaxTurnsFn, r.thinkingTokensFn = reviewMaxTurns, thinkingTokens
+// SetExecutorKnobs wires the settings-backed CLI turn caps and thinking
+// budget (issue #720, worker cap issue #718); any may be nil, leaving
+// that knob unset.
+func (r *delegatedRunner) SetExecutorKnobs(reviewMaxTurns, workerMaxTurns, thinkingTokens func(context.Context) int) {
+	r.reviewMaxTurnsFn, r.workerMaxTurnsFn, r.thinkingTokensFn = reviewMaxTurns, workerMaxTurns, thinkingTokens
+}
+
+// effectiveWorkerMaxTurns is the worker run's CLI turn cap; 0 leaves
+// the CLI's own loop uncapped.
+func (r *delegatedRunner) effectiveWorkerMaxTurns(ctx context.Context) int {
+	if r.workerMaxTurnsFn == nil {
+		return 0
+	}
+	return r.workerMaxTurnsFn(ctx)
 }
 
 // effectiveReviewMaxTurns is the review run's CLI turn cap; 0 leaves
@@ -332,7 +343,7 @@ const (
 // review_verdict tool, its structured result is the verdict channel,
 // and the read-only tool surface the adapter enforces is spelled out so
 // the model does not waste turns trying to edit.
-const delegatedReviewSystemAppend = " You are running as a delegated read-only CLI reviewer, not through a review_verdict tool. The diff in the prompt is authoritative: judge the work from it, and read a file in the working directory only when the diff alone cannot settle a criterion. You cannot modify files or run commands, so never try. End your turn by producing the required structured output: decision approve or rework, findings (each with title, file, detail, severity and quoted evidence) and the resolved ids of prior findings the work closed."
+const delegatedReviewSystemAppend = " You are running as a delegated read-only CLI reviewer, not through a review_verdict tool. The diff in the prompt is authoritative: judge the work from it, and read a file in the working directory only when the diff alone cannot settle a criterion. You cannot modify files or run commands, so never try. End your turn by producing the required structured output: decision approve or rework, findings (each with title, file, detail, severity and quoted evidence), the resolved ids of prior findings the work closed, and criteria answering every numbered criterion listed under every unit exactly once as met, not_met or cannot_tell, each citing the file and the line you read it from as evidence."
 
 // runDelegatedReview resolves the review harness, route and entry, runs
 // the review packet through the CLI read-only, and parses its result as
@@ -882,8 +893,16 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 			ResultSchema: workerResultSchema(adapter), RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 			ResumeSessionID: decision.sessionID,
 			StateDir:        executorStateDir(m.Workspace, m.Harness),
-			// MaxTurns stays 0: a worker turn does the work, so only its
-			// thinking is budgeted (issue #720).
+			// MaxTurns bounds the CLI's own agent loop (issue #718): a
+			// worker does real multi-step work, so its cap is far above
+			// the reviewer's, but no run may loop without one. A run that
+			// ends on the cap comes back as an error result with no
+			// structured output, so finish parses no status and returns a
+			// forced retry: harness-caused, spending no iteration, and
+			// the next turn resumes the same session and continues where
+			// it stopped. The harness retry cap is what bounds that, so a
+			// worker gets max_turns-sized chunks and then parks.
+			MaxTurns:       r.effectiveWorkerMaxTurns(ctx),
 			ThinkingTokens: r.effectiveThinkingTokens(ctx),
 		}
 		if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, refFiles, decision); err != nil {

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -3003,36 +3003,42 @@ func TestDelegatedRunWorker_SessionPolicyResumeUnchanged(t *testing.T) {
 	}
 }
 
-// TestDelegatedExecutorKnobs covers issue #720: a review spec carries
-// the settings-backed turn cap and thinking budget, a worker spec
-// carries the thinking budget only.
+// TestDelegatedExecutorKnobs covers issue #720 plus the worker turn cap
+// (issue #718): each knob is 0 until wired, then reads its getter.
 func TestDelegatedExecutorKnobs(t *testing.T) {
 	r := &delegatedRunner{}
 	ctx := testCtx(t)
 	if got := r.effectiveReviewMaxTurns(ctx); got != 0 {
 		t.Fatalf("unset reviewMaxTurns = %d, want 0", got)
 	}
+	if got := r.effectiveWorkerMaxTurns(ctx); got != 0 {
+		t.Fatalf("unset workerMaxTurns = %d, want 0", got)
+	}
 	if got := r.effectiveThinkingTokens(ctx); got != 0 {
 		t.Fatalf("unset thinkingTokens = %d, want 0", got)
 	}
-	r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 4000 })
+	r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 40 }, func(context.Context) int { return 4000 })
 	if got := r.effectiveReviewMaxTurns(ctx); got != 6 {
 		t.Fatalf("reviewMaxTurns = %d, want 6", got)
+	}
+	if got := r.effectiveWorkerMaxTurns(ctx); got != 40 {
+		t.Fatalf("workerMaxTurns = %d, want 40", got)
 	}
 	if got := r.effectiveThinkingTokens(ctx); got != 4000 {
 		t.Fatalf("thinkingTokens = %d, want 4000", got)
 	}
 }
 
-// TestDelegatedKnobsReachTheLaunch covers issue #720 end to end: a
-// claude-cli review run's launch carries --max-turns and
-// MAX_THINKING_TOKENS, a worker run carries the thinking budget only.
+// TestDelegatedKnobsReachTheLaunch covers issue #720 end to end plus
+// the worker turn cap (issue #718): a claude-cli review run's launch
+// carries its own --max-turns and MAX_THINKING_TOKENS, and a worker run
+// carries the worker cap and the same thinking budget.
 func TestDelegatedKnobsReachTheLaunch(t *testing.T) {
 	newRunner := func(events *fakeEventSink, sandbox *fakeSandbox) *delegatedRunner {
 		entry := harnessEntry("subscription")
 		route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
 		r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
-		r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 4000 })
+		r.SetExecutorKnobs(func(context.Context) int { return 6 }, func(context.Context) int { return 40 }, func(context.Context) int { return 4000 })
 		return r
 	}
 
@@ -3055,7 +3061,7 @@ func TestDelegatedKnobsReachTheLaunch(t *testing.T) {
 		}
 	})
 
-	t.Run("worker carries the thinking budget only", func(t *testing.T) {
+	t.Run("worker carries its own cap and the thinking budget", func(t *testing.T) {
 		sandbox := newFakeSandbox()
 		sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
 		sandbox.seedExitCode = 0
@@ -3064,8 +3070,8 @@ func TestDelegatedKnobsReachTheLaunch(t *testing.T) {
 			t.Fatalf("RunWorker: %v", err)
 		}
 		cmd := sandbox.lastLaunchCmd()
-		if strings.Contains(cmd, "--max-turns") {
-			t.Fatalf("worker launch must not carry a turn cap: %s", cmd)
+		if !strings.Contains(cmd, "--max-turns") || !strings.Contains(cmd, "40") {
+			t.Fatalf("worker launch missing --max-turns 40: %s", cmd)
 		}
 		if sandbox.lastEnv["MAX_THINKING_TOKENS"] != "4000" {
 			t.Fatalf("worker launch env MAX_THINKING_TOKENS = %q, want 4000", sandbox.lastEnv["MAX_THINKING_TOKENS"])

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -191,6 +191,16 @@ type Driver struct {
 	// (D-097, see SetReviewTokenCeiling); nil or 0 disables the check.
 	reviewTokenCeiling func(ctx context.Context) int64
 
+	// ceilings reads the settings-backed statemachine brakes (issue
+	// #718, see SetCeilings); nil leaves cfg's own values in place.
+	ceilings func(ctx context.Context) (backoffFailures, stallRounds, harnessRetryCap int)
+
+	// autoResumeBackoffMax/autoResumeInfraMax read the sweep's
+	// settings-backed auto-resume caps (issue #718, see
+	// SetAutoResumeMax); nil falls back to the constants in sweep.go.
+	autoResumeBackoffMax func(ctx context.Context) int
+	autoResumeInfraMax   func(ctx context.Context) int
+
 	// location resolves the operator's configured timezone for the
 	// worker packet's exec-environment note and progress-note timestamps
 	// (see SetLocation), nil-safe: unset renders both in UTC.
@@ -517,6 +527,38 @@ func (d *Driver) SetRouteResolver(fn routeResolver) {
 // (D-097).
 func (d *Driver) SetReviewTokenCeiling(fn func(ctx context.Context) int64) {
 	d.reviewTokenCeiling = fn
+}
+
+// SetCeilings wires the settings-backed retry brakes: every Step call
+// reads them, so an operator's change takes effect on the next turn
+// without a restart. A getter returning 0 for a brake keeps cfg's.
+func (d *Driver) SetCeilings(fn func(ctx context.Context) (backoffFailures, stallRounds, harnessRetryCap int)) {
+	d.ceilings = fn
+}
+
+// SetAutoResumeMax wires the settings-backed auto-resume pause caps
+// the sweep reads (issue #718).
+func (d *Driver) SetAutoResumeMax(backoff, infra func(ctx context.Context) int) {
+	d.autoResumeBackoffMax, d.autoResumeInfraMax = backoff, infra
+}
+
+// config is d.cfg with the settings-backed brakes folded in.
+func (d *Driver) config(ctx context.Context) Config {
+	cfg := d.cfg
+	if d.ceilings == nil {
+		return cfg
+	}
+	backoff, stall, harnessCap := d.ceilings(ctx)
+	if backoff > 0 {
+		cfg.BackoffFailures = backoff
+	}
+	if stall > 0 {
+		cfg.StallRounds = stall
+	}
+	if harnessCap > 0 {
+		cfg.HarnessRetryCap = harnessCap
+	}
+	return cfg
 }
 
 // GatewayReviewWindow builds a Driver.reviewWindow over the gateway
@@ -959,7 +1001,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			// phase-run error takes below.
 			d.log.Error("driver: provisioning failed", "mission_id", id, "agent", d.agentName(ctx, m.AgentID), "error", provErr)
 			in := StepInput{Input: InputReviewInfraFailure, Reason: "provisioning failed: " + provErr.Error()}
-			t := Step(d.toStepState(ctx, m), in, d.cfg)
+			t := Step(d.toStepState(ctx, m), in, d.config(ctx))
 			if err := d.store.ApplyTransition(ctx, id, t); err != nil {
 				return false, fmt.Errorf("driver advance: apply transition after provisioning failure: %w", err)
 			}
@@ -1030,8 +1072,11 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			// review_infra_failure is prove's error input; other phases
 			// report the equivalent-shaped worker_failed so the same
 			// backoff/pause machinery applies uniformly regardless of
-			// which phase actually failed.
-			in = StepInput{Input: InputWorkerFailed, Reason: err.Error()}
+			// which phase actually failed. A turn that errored out (the
+			// executor died, the turn failed, an idle timeout fired) is
+			// the harness's fault, never the worker's, so it spends no
+			// iteration (issue #718); the backoff brake still counts it.
+			in = StepInput{Input: InputWorkerFailed, Reason: err.Error(), HarnessCaused: true}
 		}
 	}
 	// Turn telemetry: one event per phase run, so a mission's cost in
@@ -1077,7 +1122,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		return false, fmt.Errorf("driver advance: reload after phase: %w", err)
 	}
 	state := d.toStepState(ctx, m)
-	t := Step(state, in, d.cfg)
+	t := Step(state, in, d.config(ctx))
 	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
 		if errors.Is(err, ErrTerminal) {
 			// The mission reached a terminal state (e.g. cancel) while this
@@ -1175,7 +1220,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 		return ErrTerminal
 	}
 	before := m.Status
-	t := Step(d.toStepState(ctx, m), StepInput{Input: input}, d.cfg)
+	t := Step(d.toStepState(ctx, m), StepInput{Input: input}, d.config(ctx))
 	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
 		return fmt.Errorf("driver: signal: apply transition: %w", err)
 	}
@@ -1257,7 +1302,7 @@ func (d *Driver) ChangeRouting(ctx context.Context, id, reviewRoute, reviewRoute
 	if m.Status != StatusPaused {
 		return ErrNotPaused
 	}
-	t := Step(d.toStepState(ctx, m), StepInput{Input: InputRouteChange, ReviewRoute: reviewRoute, ReviewRouteModel: reviewRouteModel}, d.cfg)
+	t := Step(d.toStepState(ctx, m), StepInput{Input: InputRouteChange, ReviewRoute: reviewRoute, ReviewRouteModel: reviewRouteModel}, d.config(ctx))
 	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
 		return fmt.Errorf("driver: change routing: apply transition: %w", err)
 	}
@@ -1283,7 +1328,7 @@ func (d *Driver) DecidePlan(ctx context.Context, id string, input Input, feedbac
 		return ErrNotAwaitingApproval
 	}
 	before := m.Status
-	t := Step(d.toStepState(ctx, m), StepInput{Input: input, Reason: feedback}, d.cfg)
+	t := Step(d.toStepState(ctx, m), StepInput{Input: input, Reason: feedback}, d.config(ctx))
 	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
 		return fmt.Errorf("driver: decide plan: apply transition: %w", err)
 	}
@@ -1342,7 +1387,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 	return StepState{
 		Phase: m.Phase, Status: m.Status, PauseReason: m.PauseReason,
 		Iteration: m.Iteration, MaxIterations: m.MaxIterations,
-		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint,
+		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint, HarnessRetries: m.HarnessRetries,
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
 		Units: m.Plan.Units, ReplanUsed: m.ReplanUsed,
@@ -1751,6 +1796,9 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 			// sentinel-less turns instead of grinding to max_iterations on
 			// a model that never learns to end its turn correctly.
 			in.GapFingerprint = "no_sentinel"
+			// The worker did not choose this retry (issue #718), so it
+			// costs no iteration; the stall brake above still stops it.
+			in.HarnessCaused = true
 		}
 		return in, nil
 	}
@@ -1926,10 +1974,10 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 // the diff restricted to the units' scope and, per unit, the changed
 // files inside its own scope (D-098). The returned files are every path
 // the change touches, for the evidence gate.
-func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, units []PlanUnit) (ReviewPacket, []string, error) {
+func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, idx []int, units []PlanUnit) (ReviewPacket, []string, error) {
 	var changedFiles []string
 	packet := ReviewPacket{
-		Plan: m.Plan, Units: units, Evidence: m.LastEvidence,
+		Plan: m.Plan, Units: units, UnitIndex: idx, Evidence: m.LastEvidence,
 		Listing: ListWorkspace(m.WorkRoot()), Progress: m.Progress,
 		OpenFindings: OpenFindings(m.ReviewFindings),
 	}
@@ -2030,7 +2078,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	if open := OpenFindings(m.ReviewFindings); len(open) > 0 && m.Plan.LastReviewCommit != "" && m.WorktreePath() != "" {
 		packet, changedFiles, err = d.findingsReviewPacket(ctx, m, open)
 	} else {
-		packet, changedFiles, err = d.fullReviewPacket(ctx, m, units)
+		packet, changedFiles, err = d.fullReviewPacket(ctx, m, idx, units)
 	}
 	if err != nil {
 		return StepInput{}, err
@@ -2054,6 +2102,25 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	if err != nil {
 		return StepInput{}, err
 	}
+	// Per-criterion rubric (issue #718): the reviewer answers every
+	// criterion met / not_met / cannot_tell, and the decision about what
+	// that means is made here in Go, not left to the reviewer's own
+	// approve/rework call. A not_met criterion is a blocking finding and
+	// overrides an approval; a cannot_tell is a minor finding so the gap
+	// is visible without blocking. Omitted criteria are logged, never
+	// penalised.
+	rubric, notMet := criteriaFindings(m.Plan, idx, verdict.Criteria, OpenFindings(m.ReviewFindings))
+	verdict.Findings = append(verdict.Findings, rubric...)
+	if notMet && verdict.Approved {
+		d.log.Warn("driver: reviewer approved with a criterion not met, overriding to rework",
+			"mission_id", m.ID, "criteria", len(verdict.Criteria))
+		verdict.Approved = false
+	}
+	// A findings-only round carries no criteria at all (the packet drops
+	// them), so there is nothing to have left unanswered.
+	if missing := missingCriteria(m.Plan, idx, verdict.Criteria); missing > 0 && !packet.FindingsOnly {
+		d.log.Warn("driver: reviewer left criteria unanswered", "mission_id", m.ID, "missing", missing)
+	}
 	// D-095 evidence gate: a blocking finding must name a changed or
 	// declared file and quote evidence, or it is demoted to minor here,
 	// deterministically. A rework whose findings all end up minor, with
@@ -2069,7 +2136,10 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 			}
 		}
 		verdict.Findings = gated
-		if !blockingRemain(gated, packet.OpenFindings, verdict.Resolved) {
+		// A not_met criterion blocks regardless of what the evidence
+		// gate did to its synthesized finding (issue #718): the rubric
+		// answer, not the quoted line, is the harness's own reading.
+		if !notMet && !blockingRemain(gated, packet.OpenFindings, verdict.Resolved) {
 			verdict.Approved = true
 		}
 	}
@@ -2094,7 +2164,8 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		decision = "approved"
 	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_verdict", map[string]any{
-		"decision": decision, "findings": verdict.Findings, "resolved": verdict.Resolved, "findings_only": packet.FindingsOnly,
+		"decision": decision, "findings": verdict.Findings, "resolved": verdict.Resolved,
+		"findings_only": packet.FindingsOnly, "criteria": verdict.Criteria,
 	}); err != nil {
 		d.log.Warn("driver: record review verdict failed", "mission_id", m.ID, "error", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -122,6 +122,7 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	m.Iteration, m.MaxIterations = t.Next.Iteration, t.Next.MaxIterations
 	m.ConsecutiveFailures, m.LastGapFingerprint, m.StallCount = t.Next.ConsecutiveFailures, t.Next.LastGapFingerprint, t.Next.StallCount
 	m.ReplanUsed = t.Next.ReplanUsed
+	m.HarnessRetries = t.Next.HarnessRetries
 	m.ReviewFindings, m.ReworkRounds = t.Next.ReviewFindings, t.Next.ReworkRounds
 	if t.Next.ReviewRoute != "" {
 		m.ReviewRoute, m.ReviewRouteModel = t.Next.ReviewRoute, t.Next.ReviewRouteModel
@@ -1307,7 +1308,31 @@ func TestDriverNoProveStillChecksArtifacts(t *testing.T) {
 	}
 }
 
+// TestDriverBackoffPauseAfterThreeFailures pins the backoff brake. A
+// runner error is harness-caused (issue #718), so the harness-retry cap
+// is lowered out of the way here: with both at 3 the cap parks first,
+// which TestDriverHarnessCapBeatsBackoff covers instead.
 func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{workerErr: fmt.Errorf("gateway unavailable")}
+	d := testDriver(store, runner)
+	d.SetCeilings(func(context.Context) (int, int, int) { return 3, 2, 9 })
+
+	driveN(t, d, "m1", 3)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused || m.PauseReason != PauseBackoff {
+		t.Fatalf("mission after 3 consecutive runner failures = %+v, want paused/backoff", m)
+	}
+}
+
+// TestDriverHarnessCapBeatsBackoff pins issue #718's precedence: with
+// both ceilings at 3, three runner errors park on the harness cap, not
+// on backoff. Resume clears the pause but not ConsecutiveFailures, so a
+// backoff-first order would re-pause as backoff on every resumed
+// harness failure and the cap would never be reached.
+func TestDriverHarnessCapBeatsBackoff(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("gateway unavailable")}
@@ -1316,8 +1341,29 @@ func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
 	driveN(t, d, "m1", 3)
 
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Status != StatusPaused || m.PauseReason != PauseBackoff {
-		t.Fatalf("mission after 3 consecutive runner failures = %+v, want paused/backoff", m)
+	if m.PauseReason != PauseNoProgress {
+		t.Fatalf("pause reason = %q, want no_progress from the harness cap", m.PauseReason)
+	}
+	if m.HarnessRetries != 3 {
+		t.Fatalf("mission.HarnessRetries = %d, want 3", m.HarnessRetries)
+	}
+	var found bool
+	for _, ev := range store.events["m1"] {
+		if ev.Kind != "mission.paused" {
+			continue
+		}
+		var payload struct {
+			Cause string `json:"cause"`
+		}
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal pause payload: %v", err)
+		}
+		if payload.Cause == "harness_retries_exhausted" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.paused event with cause harness_retries_exhausted")
 	}
 }
 
@@ -4210,5 +4256,313 @@ func TestDriverReviewRouteSkip(t *testing.T) {
 	m.ReviewRoute = ""
 	if route, _, ok := d.reviewRouteSkip(context.Background(), m, noRoute); ok || route != "" {
 		t.Fatalf("unknown route resolve error: got %q, %v; want ok=false", route, ok)
+	}
+}
+
+// TestDriverForcedRetryIsHarnessCaused pins issue #718: a turn with no
+// readable sentinel is the harness's own retry, so it spends no
+// iteration and says so on the mission.retry event.
+func TestDriverForcedRetryIsHarnessCaused(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
+		MaxIterations: 8, Iteration: 2, Flow: FlowLight,
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
+		{Outcome: "retry", Forced: true, Analysis: "no sentinel"},
+	}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Iteration != 2 {
+		t.Fatalf("mission.Iteration = %d, want it unchanged at 2: a forced retry spends none", m.Iteration)
+	}
+}
+
+// TestDriverRunnerErrorIsHarnessCaused pins issue #718: a RunWorker
+// error (executor died, turn failed, idle timeout) counts toward the
+// backoff brake but spends no iteration.
+func TestDriverRunnerErrorIsHarnessCaused(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
+		MaxIterations: 8, Iteration: 2, Flow: FlowLight,
+	})
+	runner := &scriptedRunner{workerErr: fmt.Errorf("executor died mid-run")}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Iteration != 2 {
+		t.Fatalf("mission.Iteration = %d, want it unchanged at 2: a runner error spends none", m.Iteration)
+	}
+	if m.ConsecutiveFailures != 1 {
+		t.Fatalf("mission.ConsecutiveFailures = %d, want 1: the backoff brake still counts it", m.ConsecutiveFailures)
+	}
+}
+
+// criteriaReviewMission is the shared fixture for issue #718's rubric
+// tests: one harness-passed unit with two criteria, awaiting approval.
+func criteriaReviewMission(t *testing.T) Mission {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "summary.md"), []byte("RFC 6585 explains 429.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return Mission{
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8, Workspace: root,
+		Plan: Plan{Units: []PlanUnit{{
+			Title: "Write summary", Artifacts: []string{"summary.md"},
+			Criteria: []string{"names RFC 6585", "under 200 words"}, HarnessPassed: true,
+		}}},
+	}
+}
+
+// reviewVerdictCriteria returns the criteria recorded on the mission's
+// latest mission.review_verdict event.
+func reviewVerdictCriteria(t *testing.T, store *fakeStore) (string, []CriterionVerdict) {
+	t.Helper()
+	// The driver's own verdict event is the first one of the round; the
+	// state machine appends a second on a rework, carrying no rubric.
+	for i := range store.events["m1"] {
+		if store.events["m1"][i].Kind != "mission.review_verdict" {
+			continue
+		}
+		var payload struct {
+			Decision string             `json:"decision"`
+			Criteria []CriterionVerdict `json:"criteria"`
+		}
+		if err := json.Unmarshal(store.events["m1"][i].Payload, &payload); err != nil {
+			t.Fatalf("unmarshal review verdict payload: %v", err)
+		}
+		return payload.Decision, payload.Criteria
+	}
+	t.Fatal("no mission.review_verdict event recorded")
+	return "", nil
+}
+
+// TestDriverReviewNotMetCriterionOverridesApproval pins issue #718: a
+// reviewer that says approve while answering a criterion not_met is
+// overridden to rework, with the criterion opened as a blocking
+// finding and the rubric on the verdict event.
+func TestDriverReviewNotMetCriterionOverridesApproval(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", criteriaReviewMission(t))
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true, Criteria: []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet, Evidence: "summary.md:3 RFC 6585"},
+		{Unit: 0, Criterion: 1, Status: CriterionNotMet, Evidence: "summary.md is 640 words"},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseBuild {
+		t.Fatalf("mission phase = %q, want build: a not_met criterion is a rework", m.Phase)
+	}
+	if m.Plan.Units[0].Passes {
+		t.Fatal("unit Passes flipped despite a not_met criterion")
+	}
+	open := OpenFindings(m.ReviewFindings)
+	if len(open) != 1 || open[0].Title != "under 200 words" || !open[0].Blocking() {
+		t.Fatalf("open findings = %+v, want one blocking finding titled with the criterion", open)
+	}
+	decision, criteria := reviewVerdictCriteria(t, store)
+	if decision != "rework" || len(criteria) != 2 {
+		t.Fatalf("verdict event decision=%q criteria=%+v, want rework and both criteria", decision, criteria)
+	}
+}
+
+// TestDriverReviewCannotTellCriterionApprovesWithMinorFinding pins the
+// other half of issue #718's rubric: cannot_tell is visible as a minor
+// finding but never blocks, so approval still flips Passes.
+func TestDriverReviewCannotTellCriterionApprovesWithMinorFinding(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", criteriaReviewMission(t))
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true, Criteria: []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet, Evidence: "summary.md:3 RFC 6585"},
+		{Unit: 0, Criterion: 1, Status: CriterionCannotTell, Evidence: "no word count available"},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if !m.Plan.Units[0].Passes {
+		t.Fatal("unit Passes did not flip: cannot_tell must not block approval")
+	}
+	decision, _ := reviewVerdictCriteria(t, store)
+	if decision != "approved" {
+		t.Fatalf("verdict event decision = %q, want approved", decision)
+	}
+}
+
+// TestDriverReviewAllMetApproves pins the unchanged happy path: every
+// criterion met approves exactly as before the rubric existed.
+func TestDriverReviewAllMetApproves(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", criteriaReviewMission(t))
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true, Criteria: []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet, Evidence: "summary.md:3 RFC 6585"},
+		{Unit: 0, Criterion: 1, Status: CriterionMet, Evidence: "summary.md is 140 words"},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if !m.Plan.Units[0].Passes {
+		t.Fatal("unit Passes did not flip on an all-met rubric")
+	}
+	if len(OpenFindings(m.ReviewFindings)) != 0 {
+		t.Fatalf("open findings = %+v, want none", OpenFindings(m.ReviewFindings))
+	}
+}
+
+// TestDriverReviewNotMetCriterionDoesNotDuplicateFinding pins the
+// dedup: a second round repeating the same not_met criterion reuses the
+// open finding rather than opening a second one.
+func TestDriverReviewNotMetCriterionDoesNotDuplicateFinding(t *testing.T) {
+	store := newFakeStore()
+	m := criteriaReviewMission(t)
+	m.ReviewFindings = []Finding{{
+		ID: "F1", Unit: 0, Title: "under 200 words", File: "summary.md",
+		Detail: "criterion not met", Severity: SeverityBlocking, Status: FindingOpen,
+	}}
+	store.put("m1", m)
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true, Criteria: []CriterionVerdict{
+		{Unit: 0, Criterion: 1, Status: CriterionNotMet, Evidence: "summary.md is 640 words"},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	got, _ := store.Get(context.Background(), "m1")
+	if open := OpenFindings(got.ReviewFindings); len(open) != 1 || open[0].ID != "F1" {
+		t.Fatalf("open findings = %+v, want only the pre-existing F1", open)
+	}
+}
+
+// TestDriverReviewNotMetWithoutEvidenceApproves pins issue #718: an
+// evidence-less not_met reads as cannot_tell, so it neither forces a
+// rework round with no blocking finding behind it nor blocks approval.
+func TestDriverReviewNotMetWithoutEvidenceApproves(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", criteriaReviewMission(t))
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true, Criteria: []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet, Evidence: "summary.md:3 RFC 6585"},
+		{Unit: 0, Criterion: 1, Status: CriterionNotMet},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if !m.Plan.Units[0].Passes {
+		t.Fatal("unit Passes did not flip: an evidence-less not_met must not block")
+	}
+	for _, f := range OpenFindings(m.ReviewFindings) {
+		if f.Blocking() {
+			t.Fatalf("open blocking finding %+v, want only minor ones", f)
+		}
+	}
+}
+
+// TestDriverForcedRetriesHitTheHarnessCap covers issue #718: forced
+// no-sentinel retries are harness-caused, so they count into the
+// lifetime cap and the third pauses as no_progress with the cause,
+// even though the stall brake would have replanned instead.
+func TestDriverForcedRetriesHitTheHarnessCap(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
+		MaxIterations: 8, Flow: FlowLight,
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Forced: true, Analysis: "no sentinel"}},
+	}
+	d := testDriver(store, runner)
+	// Stall brake out of the way (it would pause on the 2nd identical
+	// no_sentinel fingerprint): this asserts the CAP is what stops a
+	// run of forced retries, and that they never spend an iteration.
+	d.SetCeilings(func(context.Context) (int, int, int) { return 3, 9, 3 })
+
+	for i := 0; i < 12; i++ {
+		more, err := d.Advance(context.Background(), "m1")
+		if err != nil {
+			t.Fatalf("Advance[%d]: %v", i, err)
+		}
+		if !more {
+			break
+		}
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.HarnessRetries != 3 {
+		t.Fatalf("mission.HarnessRetries = %d, want 3", m.HarnessRetries)
+	}
+	if m.Status != StatusPaused || m.PauseReason != PauseNoProgress {
+		t.Fatalf("mission status/pause = %q/%q, want paused/no_progress", m.Status, m.PauseReason)
+	}
+	if m.Iteration != 0 {
+		t.Fatalf("mission.Iteration = %d, want 0: forced retries spend none", m.Iteration)
+	}
+	var found bool
+	for _, ev := range store.events["m1"] {
+		if ev.Kind != "mission.paused" {
+			continue
+		}
+		var payload struct {
+			Cause          string `json:"cause"`
+			HarnessRetries int    `json:"harness_retries"`
+		}
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal pause payload: %v", err)
+		}
+		if payload.Cause == "harness_retries_exhausted" && payload.HarnessRetries == 3 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.paused event with cause harness_retries_exhausted and count 3")
+	}
+}
+
+// TestDriverCeilingsComeFromSettings covers issue #718: the brakes are
+// operator settings read per turn, so a backoff cap of 2 pauses on the
+// second failure instead of DefaultConfig's third.
+func TestDriverCeilingsComeFromSettings(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseBuild, Status: StatusWorking,
+		MaxIterations: 8, Flow: FlowLight,
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
+		{Outcome: "retry", Analysis: "still working"},
+		{Outcome: "retry", Analysis: "still working"},
+	}}
+	d := testDriver(store, runner)
+	d.SetCeilings(func(context.Context) (int, int, int) { return 2, 2, 9 })
+
+	// A worker's own retry never touches the backoff counter, so drive
+	// the brake with runner errors instead.
+	runner.workerErr = fmt.Errorf("gateway unreachable")
+	for i := range 2 {
+		if _, err := d.Advance(context.Background(), "m1"); err != nil {
+			t.Fatalf("Advance[%d]: %v", i, err)
+		}
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.PauseReason != PauseBackoff {
+		t.Fatalf("pause reason = %q, want backoff on the 2nd failure with a cap of 2", m.PauseReason)
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -60,6 +60,10 @@ type Mission struct {
 	ConsecutiveFailures int    `json:"consecutive_failures"`
 	LastGapFingerprint  string `json:"last_gap_fingerprint,omitempty"`
 	StallCount          int    `json:"stall_count"`
+	// HarnessRetries counts the retries the harness attributed to itself
+	// over this mission's life (issue #718): they spend no iteration, so
+	// they have their own cap and nothing resets them.
+	HarnessRetries int `json:"harness_retries"`
 	// ReplanUsed reports whether this mission already spent its one
 	// automatic replan-on-stall attempt (statemachine.go's
 	// stepWorkerRetry).

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -120,9 +120,12 @@ type ReviewPacket struct {
 	// Goal is set only for legacy plans whose units carry no criteria
 	// (rows written before D-095); the criteria replace it otherwise.
 	Goal string
-	// Units are the plan units this round judges.
-	Units []PlanUnit
-	Plan  Plan
+	// Units are the plan units this round judges; UnitIndex holds each
+	// one's plan index, the number the criteria rubric answers under
+	// (issue #718). nil renders the headings without indices.
+	Units     []PlanUnit
+	UnitIndex []int
+	Plan      Plan
 	// DiffStat is `git diff --stat` for the whole change; Diff is the
 	// diff restricted to the reviewed units' scope paths.
 	DiffStat string
@@ -412,6 +415,20 @@ var reviewVerdictSchema = json.RawMessage(`{
 					"type": "array",
 					"items": {"type": "string"},
 					"description": "Ids of prior-round findings (F1, F2, ...) this round's work closed."
+				},
+				"criteria": {
+					"type": "array",
+					"description": "Per-criterion rubric: every acceptance criterion of every unit under review must appear here exactly once, answered met, not_met or cannot_tell with cited evidence. A criterion answered not_met sends the unit back to the worker.",
+					"items": {
+						"type": "object",
+						"properties": {
+							"unit": {"type": "integer", "description": "The unit's plan index, as shown in its heading."},
+							"criterion": {"type": "integer", "description": "Zero-based index of the criterion in that unit's listed criteria."},
+							"status": {"type": "string", "enum": ["met", "not_met", "cannot_tell"], "description": "met only when the evidence shows the criterion satisfied."},
+							"evidence": {"type": "string", "description": "A file and a line quoted verbatim from the diff, an artifact or the harness output that supports the status."}
+						},
+						"required": ["unit", "criterion", "status"]
+					}
 				}
 			},
 			"required": ["decision"]
@@ -471,6 +488,25 @@ func OpenFindings(findings []Finding) []Finding {
 	return out
 }
 
+// Criterion verdict statuses (issue #718).
+const (
+	CriterionMet        = "met"
+	CriterionNotMet     = "not_met"
+	CriterionCannotTell = "cannot_tell"
+)
+
+// CriterionVerdict is the reviewer's answer for one unit criterion
+// (issue #718): the deterministic check_cmd says the code runs, this
+// says the criteria are met.
+type CriterionVerdict struct {
+	// Unit is the criterion's plan index; Criterion its zero-based
+	// index in that unit's criteria list.
+	Unit      int    `json:"unit"`
+	Criterion int    `json:"criterion"`
+	Status    string `json:"status"`
+	Evidence  string `json:"evidence,omitempty"`
+}
+
 // ReviewVerdict is the parsed review_verdict call.
 type ReviewVerdict struct {
 	Approved bool
@@ -478,6 +514,9 @@ type ReviewVerdict struct {
 	// Resolved names prior-round finding ids the reviewer considers
 	// closed.
 	Resolved []string
+	// Criteria is the per-criterion rubric (issue #718); empty on a
+	// reviewer that answered none, which is logged, never penalised.
+	Criteria []CriterionVerdict
 	// Provider/Model (issue #507) are who served the review turn; set by
 	// RunReview after parsing.
 	Provider string
@@ -485,12 +524,15 @@ type ReviewVerdict struct {
 }
 
 // parseReviewVerdict decodes a review_verdict tool call's arguments.
-// An unknown severity is read as blocking, same as an absent one.
+// An unknown severity is read as blocking, same as an absent one; an
+// unknown criterion status is read as cannot_tell (issue #718), the
+// answer that neither blocks nor claims the criterion is met.
 func parseReviewVerdict(args json.RawMessage) (ReviewVerdict, error) {
 	var raw struct {
-		Decision string    `json:"decision"`
-		Findings []Finding `json:"findings"`
-		Resolved []string  `json:"resolved"`
+		Decision string             `json:"decision"`
+		Findings []Finding          `json:"findings"`
+		Resolved []string           `json:"resolved"`
+		Criteria []CriterionVerdict `json:"criteria"`
 	}
 	if err := json.Unmarshal(args, &raw); err != nil {
 		return ReviewVerdict{}, err
@@ -500,7 +542,14 @@ func parseReviewVerdict(args json.RawMessage) (ReviewVerdict, error) {
 			raw.Findings[i].Severity = SeverityBlocking
 		}
 	}
-	return ReviewVerdict{Approved: raw.Decision == "approve", Findings: raw.Findings, Resolved: raw.Resolved}, nil
+	for i := range raw.Criteria {
+		switch raw.Criteria[i].Status {
+		case CriterionMet, CriterionNotMet, CriterionCannotTell:
+		default:
+			raw.Criteria[i].Status = CriterionCannotTell
+		}
+	}
+	return ReviewVerdict{Approved: raw.Decision == "approve", Findings: raw.Findings, Resolved: raw.Resolved, Criteria: raw.Criteria}, nil
 }
 
 // baselineDiffExcludes are pathspecs excluded from the reviewer's
@@ -625,6 +674,93 @@ func truncateDiff(diff string, limit int) string {
 	}
 	fmt.Fprintf(&b, "\n[diff truncated: %d files omitted]", len(files)-kept)
 	return b.String()
+}
+
+// criterionText returns the criterion's own line from the plan, or ""
+// when the reviewer named a unit or index the plan does not have.
+func criterionText(plan Plan, c CriterionVerdict) string {
+	if c.Unit < 0 || c.Unit >= len(plan.Units) {
+		return ""
+	}
+	crit := plan.Units[c.Unit].Criteria
+	if c.Criterion < 0 || c.Criterion >= len(crit) {
+		return ""
+	}
+	return crit[c.Criterion]
+}
+
+// criteriaFindings turns a rubric into findings (issue #718): one
+// blocking finding per not_met criterion, one minor per cannot_tell,
+// plus whether any criterion was not_met. Skipped: a criterion on a
+// unit outside units (mergeFindings would stamp it onto the wrong
+// one), and a title already open or already synthesized. A not_met
+// quoting no evidence is read as cannot_tell, since the D-095
+// evidence gate would demote its finding to minor anyway.
+func criteriaFindings(plan Plan, units []int, criteria []CriterionVerdict, open []Finding) (out []Finding, notMet bool) {
+	isOpen := func(title string) bool {
+		for _, f := range open {
+			if f.Open() && f.Title == title {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range criteria {
+		if c.Status == CriterionMet || !slices.Contains(units, c.Unit) {
+			continue
+		}
+		title := criterionText(plan, c)
+		if title == "" {
+			continue
+		}
+		status := c.Status
+		if status == CriterionNotMet && strings.TrimSpace(c.Evidence) == "" {
+			status = CriterionCannotTell
+		}
+		if status == CriterionNotMet {
+			notMet = true
+		}
+		if isOpen(title) || slices.ContainsFunc(out, func(f Finding) bool { return f.Title == title }) {
+			continue
+		}
+		f := Finding{
+			Unit:     c.Unit,
+			Title:    title,
+			Detail:   "criterion not met",
+			Evidence: c.Evidence,
+			Severity: SeverityBlocking,
+		}
+		if status == CriterionCannotTell {
+			f.Detail, f.Severity = "reviewer could not tell", SeverityMinor
+		}
+		if len(plan.Units[c.Unit].Artifacts) > 0 {
+			f.File = plan.Units[c.Unit].Artifacts[0]
+		}
+		out = append(out, f)
+	}
+	return out, notMet
+}
+
+// missingCriteria counts the criteria of the units under review the
+// rubric left unanswered (issue #718). Logged only, never a failure:
+// the round's other evidence still stands.
+func missingCriteria(plan Plan, units []int, criteria []CriterionVerdict) int {
+	answered := make(map[[2]int]bool, len(criteria))
+	for _, c := range criteria {
+		answered[[2]int{c.Unit, c.Criterion}] = true
+	}
+	missing := 0
+	for _, u := range units {
+		if u < 0 || u >= len(plan.Units) {
+			continue
+		}
+		for i := range plan.Units[u].Criteria {
+			if !answered[[2]int{u, i}] {
+				missing++
+			}
+		}
+	}
+	return missing
 }
 
 // findingDemotion is one blocking finding the evidence gate demoted,

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -540,3 +540,112 @@ func TestFitReviewPacketShrinkOrder(t *testing.T) {
 		}
 	})
 }
+
+// TestParseReviewVerdictCriteria pins issue #718's rubric decode: the
+// three statuses survive round-trip and anything else reads as
+// cannot_tell, the answer that neither blocks nor claims a criterion met.
+func TestParseReviewVerdictCriteria(t *testing.T) {
+	args := []byte(`{"decision":"approve","criteria":[
+		{"unit":0,"criterion":0,"status":"met","evidence":"base62.go:12 const alphabet"},
+		{"unit":0,"criterion":1,"status":"not_met","evidence":"no test file exists"},
+		{"unit":1,"criterion":0,"status":"cannot_tell"},
+		{"unit":1,"criterion":1,"status":"probably"}
+	]}`)
+	v, err := parseReviewVerdict(args)
+	if err != nil {
+		t.Fatalf("parseReviewVerdict: %v", err)
+	}
+	want := []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet, Evidence: "base62.go:12 const alphabet"},
+		{Unit: 0, Criterion: 1, Status: CriterionNotMet, Evidence: "no test file exists"},
+		{Unit: 1, Criterion: 0, Status: CriterionCannotTell},
+		{Unit: 1, Criterion: 1, Status: CriterionCannotTell},
+	}
+	if !reflect.DeepEqual(v.Criteria, want) {
+		t.Fatalf("criteria = %+v, want %+v", v.Criteria, want)
+	}
+}
+
+// TestCriteriaFindingsSynthesis pins issue #718's Go-side rubric rules:
+// not_met opens a blocking finding titled with the criterion,
+// cannot_tell a minor one, met opens nothing, an already-open title
+// opens no second finding, and a criterion the plan lacks is skipped.
+func TestCriteriaFindingsSynthesis(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{{
+		Title:     "Base62",
+		Artifacts: []string{"base62.go"},
+		Criteria:  []string{"round-trips every id", "rejects empty input", "has a table test"},
+	}}}
+	open := []Finding{{ID: "F1", Unit: 0, Title: "rejects empty input", Status: FindingOpen, Severity: SeverityBlocking}}
+	got, notMet := criteriaFindings(plan, []int{0}, []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionMet},
+		{Unit: 0, Criterion: 1, Status: CriterionNotMet, Evidence: "empty_test.go is missing"},
+		{Unit: 0, Criterion: 2, Status: CriterionCannotTell, Evidence: "no test files in the diff"},
+		{Unit: 4, Criterion: 0, Status: CriterionNotMet, Evidence: "out of range"},
+	}, open)
+	if !notMet {
+		t.Fatal("notMet = false, want true: criterion 1 is not_met")
+	}
+	if len(got) != 1 {
+		t.Fatalf("findings = %+v, want exactly the cannot_tell one", got)
+	}
+	want := Finding{
+		Unit: 0, Title: "has a table test", File: "base62.go",
+		Detail: "reviewer could not tell", Evidence: "no test files in the diff", Severity: SeverityMinor,
+	}
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("finding = %+v, want %+v", got[0], want)
+	}
+}
+
+// TestMissingCriteria counts the reviewed units' unanswered criteria,
+// the number the driver only logs (issue #718).
+func TestMissingCriteria(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{
+		{Criteria: []string{"a", "b"}},
+		{Criteria: []string{"c"}},
+	}}
+	answered := []CriterionVerdict{{Unit: 0, Criterion: 0, Status: CriterionMet}}
+	if got := missingCriteria(plan, []int{0, 1}, answered); got != 2 {
+		t.Fatalf("missingCriteria = %d, want 2", got)
+	}
+	if got := missingCriteria(plan, []int{0}, answered); got != 1 {
+		t.Fatalf("missingCriteria over unit 0 only = %d, want 1", got)
+	}
+}
+
+// TestCriteriaFindingsSkipsUnitsNotUnderReview pins issue #718: the
+// round stamps every finding with the reviewed unit (mergeFindings), so
+// a criterion answered for a unit outside this round opens nothing
+// rather than a blocking finding on the wrong unit.
+func TestCriteriaFindingsSkipsUnitsNotUnderReview(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{
+		{Title: "already done", Criteria: []string{"ships the binary"}, Passes: true},
+		{Title: "under review", Criteria: []string{"has a table test"}},
+	}}
+	got, notMet := criteriaFindings(plan, []int{1}, []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionNotMet, Evidence: "no binary in the diff"},
+	}, nil)
+	if len(got) != 0 || notMet {
+		t.Fatalf("findings = %+v, notMet = %v, want nothing for a unit outside the round", got, notMet)
+	}
+}
+
+// TestCriteriaFindingsNotMetWithoutEvidenceIsCannotTell pins issue
+// #718: a not_met quoting no evidence would be demoted to minor by the
+// D-095 evidence gate, so it reads as cannot_tell and never forces a
+// rework round with no blocking finding behind it.
+func TestCriteriaFindingsNotMetWithoutEvidenceIsCannotTell(t *testing.T) {
+	plan := Plan{Units: []PlanUnit{{
+		Title: "Base62", Artifacts: []string{"base62.go"}, Criteria: []string{"round-trips every id"},
+	}}}
+	got, notMet := criteriaFindings(plan, []int{0}, []CriterionVerdict{
+		{Unit: 0, Criterion: 0, Status: CriterionNotMet},
+	}, nil)
+	if notMet {
+		t.Fatal("notMet = true, want false: an evidence-less not_met cannot force a rework")
+	}
+	if len(got) != 1 || got[0].Severity != SeverityMinor || got[0].Detail != "reviewer could not tell" {
+		t.Fatalf("findings = %+v, want one minor cannot_tell finding", got)
+	}
+}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1590,7 +1590,7 @@ func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, repor
 // reuses the body with its own closing instruction, so the native
 // prompt stays byte-identical.
 const (
-	reviewSystemPrompt   = "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. The changed-files stat spans every unit of the plan: judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone, never against another unit's files. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings."
+	reviewSystemPrompt   = "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. The changed-files stat spans every unit of the plan: judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone, never against another unit's files. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. Answer every numbered criterion listed under every unit exactly once in criteria, as met, not_met or cannot_tell, each citing the file and the line you read it from as evidence."
 	reviewSystemToolCall = " End your turn with exactly one review_verdict tool call."
 )
 
@@ -1714,15 +1714,29 @@ func renderReviewContent(p ReviewPacket) string {
 				b.WriteString("The change set below spans all of these units. Judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone; a file another unit changed is never a gap for this one.\n")
 			}
 		}
+		hasIndex := len(p.UnitIndex) == len(p.Units)
 		for i, u := range p.Units {
-			fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
+			if hasIndex {
+				fmt.Fprintf(&b, "\n### Unit %d: %s [%s]\n", p.UnitIndex[i], NeutralizeSlot(u.Title), unitStatus(u))
+			} else {
+				fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
+			}
 			if u.Regressed && !u.verified() {
 				b.WriteString("Regressed: this unit passed before and fails now.\n")
 			}
+			// A findings-only round asks no rubric (the packet drops the
+			// criteria), so it never gets the numbering instruction.
 			if len(u.Criteria) > 0 {
-				b.WriteString("Acceptance criteria:\n")
-				for _, c := range u.Criteria {
-					fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(c))
+				if p.FindingsOnly {
+					b.WriteString("Acceptance criteria:\n")
+					for _, c := range u.Criteria {
+						fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(c))
+					}
+				} else {
+					b.WriteString("Acceptance criteria (answer each by its number in criteria):\n")
+					for n, c := range u.Criteria {
+						fmt.Fprintf(&b, "%d. %s\n", n, NeutralizeSlot(c))
+					}
 				}
 			}
 			if unitFiles {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -528,8 +528,8 @@ func TestRenderReviewContentMultiUnitFiles(t *testing.T) {
 	})
 	for _, want := range []string{
 		"The change set below spans all of these units. Judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone",
-		"### add changelog [harness-verified]\nAcceptance criteria:\n- no other root files modified\nFiles this unit changed (changed files inside its scope): CHANGELOG.md\n",
-		"### add contributing [harness-verified]\nAcceptance criteria:\n- no other root files modified\nFiles this unit changed (changed files inside its scope): CONTRIBUTING.md\n",
+		"### add changelog [harness-verified]\nAcceptance criteria (answer each by its number in criteria):\n0. no other root files modified\nFiles this unit changed (changed files inside its scope): CHANGELOG.md\n",
+		"### add contributing [harness-verified]\nAcceptance criteria (answer each by its number in criteria):\n0. no other root files modified\nFiles this unit changed (changed files inside its scope): CONTRIBUTING.md\n",
 		"### legacy unit [harness-verified]\nFiles this unit changed (no scope declared, so every changed file): CHANGELOG.md, CONTRIBUTING.md\n",
 		"### untouched unit [harness-verified]\nFiles this unit changed: none\n",
 		"Changed files (whole change, spanning every unit above; each unit's own files are listed in its block):\n" + stat,
@@ -3356,8 +3356,8 @@ func TestRenderReviewContentCriteriaReplaceGoal(t *testing.T) {
 	for _, want := range []string{
 		"Units under review (judge each against its acceptance criteria):",
 		"### Write summary [harness-verified]",
-		"- summary.md names RFC 6585",
-		"- under 200 words",
+		"0. summary.md names RFC 6585",
+		"1. under 200 words",
 		"Harness check_cmd check: passed",
 		"Verify output:\ngrep ok\n",
 		"Changed files (whole change):\n summary.md | 3 +++",
@@ -3715,5 +3715,23 @@ func TestDiscoverMaxSteps(t *testing.T) {
 				t.Fatalf("discoverMaxSteps = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRenderReviewContentFindingsOnlyHasNoRubric pins issue #718: a
+// findings-only round asks no per-criterion rubric, so its units render
+// without the numbering instruction.
+func TestRenderReviewContentFindingsOnlyHasNoRubric(t *testing.T) {
+	p := ReviewPacket{
+		FindingsOnly: true,
+		Units:        []PlanUnit{{Title: "Write summary", Criteria: []string{"names RFC 6585"}, HarnessPassed: true}},
+		OpenFindings: []Finding{{ID: "F1", Title: "wrong status text", File: "summary.md", Status: FindingOpen, Severity: SeverityBlocking, Evidence: "429"}},
+	}
+	got := renderReviewContent(p)
+	if strings.Contains(got, "answer each by its number") {
+		t.Fatalf("findings-only content asks for the rubric:\n%s", got)
+	}
+	if !strings.Contains(got, "Acceptance criteria:\n- names RFC 6585") {
+		t.Fatalf("findings-only content lost the plain criteria list:\n%s", got)
 	}
 }

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -520,7 +520,7 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	_, err = tx.Exec(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, auto_approve_tools, auto_approve_plan, plan, schedule_id, harness, environment, sources, destinations, phase, flow, review_harness)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
-		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
+		t.Goal, name, t.Kind, t.AgentID, s.missions.maxIterationsFor(ctx, t.MaxIterations), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
 		promptOverlay, t.AutoApproveTools, true, plan, sc.ID, t.Harness, t.Environment, sourcesJSON, destinationsJSON, phase, flow, t.ReviewHarness)
 	return err
 }

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -214,6 +214,10 @@ type StepState struct {
 	ConsecutiveFailures int
 	LastGapFingerprint  string
 	StallCount          int
+	// HarnessRetries counts the retries the harness attributed to
+	// itself over the mission's whole life (issue #718). It spends no
+	// iteration, so this is its own ceiling; nothing resets it.
+	HarnessRetries int
 	// Spent is this mission's spend in Budget's currency, INCLUDING any
 	// other-currency spend the driver could convert via a stored fx
 	// rate (toStepState) — 0 if there is no spend at all yet, honest
@@ -297,6 +301,11 @@ type StepInput struct {
 	Input          Input
 	GapFingerprint string // set on InputWorkerRetry (verify/regression/no_sentinel stalls)
 	Message        string // set on InputWorkerBlocked / pause explanations
+	// HarnessCaused marks a retry the harness attributed to itself
+	// (issue #718): an unreadable sentinel, a runner error, an executor
+	// death, an idle timeout. It spends no iteration; the stall and
+	// backoff brakes still apply.
+	HarnessCaused bool
 	// Reason is WHY this input happened (a worker's retry analysis, an
 	// error string, flattened review findings) — carried into the
 	// transition's event payloads so a mission's failure cause is
@@ -368,10 +377,14 @@ type Config struct {
 	// fingerprint worker retries, or consecutive worker turns that left
 	// an open blocking finding's file untouched (D-092).
 	StallRounds int
+	// HarnessRetryCap bounds the retries the harness attributed to
+	// itself (issue #718): they spend no iteration, so without this a
+	// failing harness would retry forever.
+	HarnessRetryCap int
 }
 
 // DefaultConfig matches the reference design's thresholds.
-var DefaultConfig = Config{BackoffFailures: 3, StallRounds: 2}
+var DefaultConfig = Config{BackoffFailures: 3, StallRounds: 2, HarnessRetryCap: 3}
 
 // Step is the pure state machine transition function: no I/O, fully
 // deterministic given (state, input). Cross-cutting order, checked
@@ -682,6 +695,24 @@ func stepRouteChange(s StepState, in StepInput) Transition {
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.route_changed", Payload: payload}}}
 }
 
+// harnessRetryExhausted counts one harness-caused retry against the
+// mission's lifetime cap (issue #718) and returns the pause transition
+// when it is reached. Harness retries spend no iteration, so this is
+// the only ceiling they have; PauseNoProgress is never auto-resumed,
+// so a broken harness stops here instead of looping.
+func harnessRetryExhausted(s StepState, in StepInput, cfg Config) (Transition, bool) {
+	if cfg.HarnessRetryCap <= 0 || s.HarnessRetries < cfg.HarnessRetryCap {
+		return Transition{}, false
+	}
+	return Transition{
+		Next: withPause(s, PauseNoProgress),
+		Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{
+			"reason": string(PauseNoProgress), "cause": "harness_retries_exhausted",
+			"harness_retries": s.HarnessRetries, "detail": in.Reason,
+		}}},
+	}, true
+}
+
 // stepWorkerFailed counts consecutive failures toward the backoff
 // brake; progress resets the counter elsewhere in this file
 // (stepPhaseComplete, stepWorkerRetry, stepReviewApprove all zero it).
@@ -690,13 +721,28 @@ func stepRouteChange(s StepState, in StepInput) Transition {
 // a hard stop, and a backoff pause must only ever happen below the
 // ceiling. Checking backoff first would let a mission repeatedly
 // resumed after backoff pauses exceed its iteration ceiling forever.
+//
+// A harness-caused failure (issue #718) spends no iteration and skips
+// the ceiling: the worker made no mistake. The backoff brake still
+// counts it, so a harness failing over and over still pauses.
 func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 	s.ConsecutiveFailures++
-	s.Iteration++
-	if s.Iteration >= s.MaxIterations {
-		return Transition{
-			Next:   withPhaseFailed(s),
-			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
+	// The harness-retry cap is checked BEFORE the backoff brake: resume
+	// clears the pause but not ConsecutiveFailures, so a backoff pause
+	// checked first would re-pause as backoff on every resumed harness
+	// failure and the cap would never be reached.
+	if in.HarnessCaused {
+		s.HarnessRetries++
+		if t, done := harnessRetryExhausted(s, in, cfg); done {
+			return t
+		}
+	} else {
+		s.Iteration++
+		if s.Iteration >= s.MaxIterations {
+			return Transition{
+				Next:   withPhaseFailed(s),
+				Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
+			}
 		}
 	}
 	if s.ConsecutiveFailures >= cfg.BackoffFailures {
@@ -705,7 +751,17 @@ func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff), "detail": in.Reason}}},
 		}
 	}
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_failed", "reason": in.Reason}}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: retryPayload("worker_failed", in)}}}
+}
+
+// retryPayload builds a mission.retry payload, marking the retries the
+// harness attributed to itself (issue #718).
+func retryPayload(cause string, in StepInput) map[string]any {
+	payload := map[string]any{"cause": cause, "reason": in.Reason}
+	if in.HarnessCaused {
+		payload["harness_caused"] = true
+	}
+	return payload
 }
 
 // stepWorkerRetry is a worker's own self-reported RETRY (failure
@@ -720,6 +776,11 @@ func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 // budget on a foregone conclusion.
 func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 	s.ConsecutiveFailures = 0
+	// Counted before any brake: a harness retry that ends in a stall
+	// pause still happened, and the count is what the next resume reads.
+	if in.HarnessCaused {
+		s.HarnessRetries++
+	}
 	if in.GapFingerprint != "" {
 		if in.GapFingerprint == s.LastGapFingerprint {
 			s.StallCount++
@@ -732,8 +793,12 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 		// brake entirely and falls straight through to the plain
 		// retry/max_iterations path below, same as stepWorkerFailed's
 		// backoff ceiling.
-		if s.StallCount >= cfg.StallRounds && !s.neverVisitsPlan() {
-			if !s.ReplanUsed {
+		// A harness-caused retry spends no iteration below, so for a
+		// planless mission the stall brake is the ONLY stop left
+		// (issue #718): it pauses instead of falling through and
+		// looping forever on a model that never ends its turn.
+		if s.StallCount >= cfg.StallRounds && (!s.neverVisitsPlan() || in.HarnessCaused) {
+			if !s.ReplanUsed && !s.neverVisitsPlan() {
 				return replanTransition(s, in)
 			}
 			return Transition{
@@ -742,14 +807,23 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 			}
 		}
 	}
-	s.Iteration++
-	if s.Iteration >= s.MaxIterations {
-		return Transition{
-			Next:   withPhaseFailed(s),
-			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
+	// A harness-caused retry (issue #718: no readable sentinel) spends
+	// no iteration; the stall brake above and the lifetime harness-retry
+	// cap here are what stop a harness that keeps failing.
+	if in.HarnessCaused {
+		if t, done := harnessRetryExhausted(s, in, cfg); done {
+			return t
+		}
+	} else {
+		s.Iteration++
+		if s.Iteration >= s.MaxIterations {
+			return Transition{
+				Next:   withPhaseFailed(s),
+				Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
+			}
 		}
 	}
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_retry", "reason": in.Reason}}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: retryPayload("worker_retry", in)}}}
 }
 
 // replanTransition sends a first-time stall back to planning instead of

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -191,6 +191,128 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 3, Iteration: 3, ConsecutiveFailures: 3},
 		},
 		{
+			// issue #718: an executor death or turn error is not the
+			// worker's mistake, so it spends no iteration; the backoff
+			// counter still climbs.
+			name:  "harness-caused worker_failed spends no iteration",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 1, Iteration: 2},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 2, HarnessRetries: 1},
+		},
+		{
+			name:  "harness-caused worker_failed at the ceiling keeps working instead of failing",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Iteration: 0},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   Config{BackoffFailures: 10, StallRounds: 10},
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, ConsecutiveFailures: 1, Iteration: 0, HarnessRetries: 1},
+		},
+		{
+			name:  "harness-caused worker_failed still trips the backoff brake",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff, MaxIterations: 8, ConsecutiveFailures: 3, HarnessRetries: 1},
+		},
+		{
+			name:  "harness-caused worker_retry spends no iteration",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 2},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true, GapFingerprint: "no_sentinel"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Iteration: 2, StallCount: 1, LastGapFingerprint: "no_sentinel", HarnessRetries: 1},
+		},
+		{
+			name:  "harness-caused worker_retry at the ceiling keeps working instead of failing",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Iteration: 0},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 1, Iteration: 0, HarnessRetries: 1},
+		},
+		{
+			name:  "harness-caused worker_retry still trips the stall brake",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "no_sentinel", ReplanUsed: true},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true, GapFingerprint: "no_sentinel"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "no_sentinel", ReplanUsed: true, HarnessRetries: 1},
+		},
+		{
+			// issue #718: a planless flow skips the replan brake and a
+			// harness-caused retry skips the ceiling, so the stall pause
+			// is the only stop left; without it the mission loops forever.
+			name:  "harness-caused worker_retry on a light flow pauses on the stall brake",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Flow: FlowLight, StallCount: 1, LastGapFingerprint: "no_sentinel"},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true, GapFingerprint: "no_sentinel"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, Flow: FlowLight, StallCount: 2, LastGapFingerprint: "no_sentinel", HarnessRetries: 1},
+		},
+		{
+			// The same light flow with a worker-caused retry keeps the
+			// pre-#718 behaviour: the ceiling is its stop, not a pause.
+			name:  "worker-caused retry on a light flow still falls through the stall brake",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Flow: FlowLight, StallCount: 1, LastGapFingerprint: "fp"},
+			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "fp"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, Flow: FlowLight, Iteration: 1, StallCount: 2, LastGapFingerprint: "fp"},
+		},
+		{
+			// issue #718: harness retries spend no iteration, so the
+			// lifetime cap is their only ceiling. The 2nd is still a retry.
+			name:  "2nd harness-caused retry is below the cap and keeps working",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 1},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 2},
+		},
+		{
+			name:  "3rd harness-caused retry hits the cap and pauses",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 2},
+			input: StepInput{Input: InputWorkerRetry, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, HarnessRetries: 3},
+		},
+		{
+			name:  "2nd harness-caused failure is below the cap and keeps working",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 1},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 1, HarnessRetries: 2},
+		},
+		{
+			name:  "3rd harness-caused failure hits the cap and pauses",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 2},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, ConsecutiveFailures: 1, HarnessRetries: 3},
+		},
+		{
+			// The cap wins when both brakes trip on the same failure:
+			// resume clears the pause but not ConsecutiveFailures, so a
+			// backoff-first order would never let the cap be reached.
+			name:  "harness cap beats backoff on the same failure",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, HarnessRetries: 2},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, ConsecutiveFailures: 3, HarnessRetries: 3},
+		},
+		{
+			// A resumed harness failure below the cap still backs off:
+			// the cap is a lifetime bound, not a replacement for backoff.
+			name:  "harness failure below the cap still pauses for backoff",
+			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, HarnessRetries: 0},
+			input: StepInput{Input: InputWorkerFailed, HarnessCaused: true},
+			cfg:   Config{BackoffFailures: 3, StallRounds: 2, HarnessRetryCap: 9},
+			want:  StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseBackoff, MaxIterations: 8, ConsecutiveFailures: 3, HarnessRetries: 1},
+		},
+		{
+			// The cap is a lifetime count: resuming the pause it caused
+			// must not hand the mission three more harness retries.
+			name:  "resume leaves the harness retry count alone",
+			state: StepState{Phase: PhaseBuild, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, HarnessRetries: 3},
+			input: StepInput{Input: InputResume},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseBuild, Status: StatusIdle, MaxIterations: 8, HarnessRetries: 3},
+		},
+		{
 			name:  "worker_retry costs an iteration and resets consecutive failures",
 			state: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
 			input: StepInput{Input: InputWorkerRetry},
@@ -1352,5 +1474,65 @@ func TestStepReviewInfraFailureCarriesRoute(t *testing.T) {
 	got = Step(StepState{Phase: PhaseBuild, Status: StatusWorking}, StepInput{Input: InputReviewInfraFailure, Reason: "cooling", Until: until}, DefaultConfig)
 	if u, _ := got.Events[0].Payload["until"].(string); u != "2026-09-12T10:00:00Z" {
 		t.Fatalf("payload = %+v, want until=2026-09-12T10:00:00Z (issue #704)", got.Events[0].Payload)
+	}
+}
+
+// TestRetryPayloadMarksHarnessCaused pins issue #718's event contract:
+// a retry the harness attributed to itself says so in the payload, and
+// a worker's own retry carries no such flag.
+func TestRetryPayloadMarksHarnessCaused(t *testing.T) {
+	base := StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8}
+	for _, tc := range []struct {
+		name  string
+		input StepInput
+		want  bool
+	}{
+		{"harness retry", StepInput{Input: InputWorkerRetry, HarnessCaused: true}, true},
+		{"worker retry", StepInput{Input: InputWorkerRetry}, false},
+		{"harness failure", StepInput{Input: InputWorkerFailed, HarnessCaused: true}, true},
+		{"worker failure", StepInput{Input: InputWorkerFailed}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := Step(base, tc.input, DefaultConfig)
+			if len(tr.Events) != 1 || tr.Events[0].Kind != "mission.retry" {
+				t.Fatalf("want one mission.retry event, got %+v", tr.Events)
+			}
+			flag, ok := tr.Events[0].Payload["harness_caused"].(bool)
+			if got := ok && flag; got != tc.want {
+				t.Fatalf("harness_caused = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHarnessRetryCapPausePayload pins the cap's event contract (issue
+// #718): the pause names its cause and the count that reached it.
+func TestHarnessRetryCapPausePayload(t *testing.T) {
+	base := StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8, HarnessRetries: 2}
+	for _, input := range []Input{InputWorkerRetry, InputWorkerFailed} {
+		t.Run(string(input), func(t *testing.T) {
+			tr := Step(base, StepInput{Input: input, HarnessCaused: true, Reason: "executor died"}, DefaultConfig)
+			if tr.Next.PauseReason != PauseNoProgress {
+				t.Fatalf("pause reason = %q, want no_progress", tr.Next.PauseReason)
+			}
+			if len(tr.Events) != 1 || tr.Events[0].Kind != "mission.paused" {
+				t.Fatalf("events = %+v, want one mission.paused", tr.Events)
+			}
+			p := tr.Events[0].Payload
+			if p["cause"] != "harness_retries_exhausted" || p["harness_retries"] != 3 || p["detail"] != "executor died" {
+				t.Fatalf("payload = %+v, want the cause, count 3 and the detail", p)
+			}
+		})
+	}
+}
+
+// TestHarnessRetryCapFromConfig pins that the cap is configurable
+// (issue #718): a Config with a cap of 1 pauses on the first one.
+func TestHarnessRetryCapFromConfig(t *testing.T) {
+	cfg := Config{BackoffFailures: 3, StallRounds: 2, HarnessRetryCap: 1}
+	tr := Step(StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 8},
+		StepInput{Input: InputWorkerRetry, HarnessCaused: true}, cfg)
+	if tr.Next.PauseReason != PauseNoProgress {
+		t.Fatalf("pause reason = %q, want no_progress on a cap of 1", tr.Next.PauseReason)
 	}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -30,10 +30,40 @@ type Store struct {
 	db  *pgpool.Pool
 	log *slog.Logger
 	hub *Hub
+	// defaultMaxIterations resolves the iteration ceiling a mission
+	// created without one gets (settings.mission_default_max_iterations);
+	// nil, before SetDefaultMaxIterations is called, means the built-in
+	// fallback.
+	defaultMaxIterations func(context.Context) int
 }
 
 func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 	return &Store{db: db, log: log}
+}
+
+// fallbackMaxIterations is the iteration ceiling used when neither the
+// mission nor the settings getter supplies one.
+const fallbackMaxIterations = 3
+
+// SetDefaultMaxIterations wires the settings-backed iteration ceiling
+// for missions created without one, a setter for the same reason
+// SetHub is: the store must not import settings.
+func (s *Store) SetDefaultMaxIterations(fn func(context.Context) int) {
+	s.defaultMaxIterations = fn
+}
+
+// maxIterationsFor resolves a create's ceiling: the mission's own
+// value, else the configured default, else fallbackMaxIterations.
+func (s *Store) maxIterationsFor(ctx context.Context, want int) int {
+	if want > 0 {
+		return want
+	}
+	if s.defaultMaxIterations != nil {
+		if n := s.defaultMaxIterations(ctx); n > 0 {
+			return n
+		}
+	}
+	return fallbackMaxIterations
 }
 
 // SetHub wires the push-notification hub: a nil hub (the default,
@@ -52,7 +82,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	discover_notes, replan_used, schedule_id, session_id, harness, review_harness, environment,
 	parent_mission_id, sources, destinations, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, permission_timeout_seconds, pending_input, asks_used, flow,
-	review_findings, rework_rounds, has_plan, executor_session_policy`
+	review_findings, rework_rounds, has_plan, executor_session_policy, harness_retries`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
@@ -138,7 +168,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy,
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy, &m.HarnessRetries,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -226,7 +256,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy); err != nil {
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan, &m.ExecutorSessionPolicy, &m.HarnessRetries); err != nil {
 		return Mission{}, err
 	}
 	m.Flow = parseFlow(flow)
@@ -326,7 +356,7 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	err = db.QueryRow(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan, review_harness, executor_session_policy)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30, $31, $32) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan, m.ReviewHarness, m.ExecutorSessionPolicy,
+		m.Goal, m.Name, m.Kind, m.AgentID, s.maxIterationsFor(ctx, m.MaxIterations), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan, m.ReviewHarness, m.ExecutorSessionPolicy,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -339,13 +369,6 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 // escaping).
 func escapeLike(s string) string {
 	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
-}
-
-func orDefault(v, def int) int {
-	if v == 0 {
-		return def
-	}
-	return v
 }
 
 // Get returns one mission by id.
@@ -1149,6 +1172,7 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
 			phase = $2, status = $3, pause_reason = $4, pause_message = '', iteration = $5, max_iterations = $6,
 			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, replan_used = $11, updated_at = now(),
+			harness_retries = $19,
 			pending_permission = CASE WHEN $10 THEN NULL ELSE pending_permission END,
 			review_findings = $12, rework_rounds = $13,
 			plan = (CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END)
@@ -1161,7 +1185,7 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
 		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
 		findingsJSON, t.Next.ReworkRounds, unitsJSON, t.Next.LastReviewCommit, lastReviewAt,
-		t.Next.ReviewRoute, t.Next.ReviewRouteModel,
+		t.Next.ReviewRoute, t.Next.ReviewRouteModel, t.Next.HarnessRetries,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -1951,3 +1951,76 @@ func TestSweepPermissionTimeoutsAutoDeniesAndResumes(t *testing.T) {
 		t.Fatalf("Drive calls = %v, want exactly [%s] (mission resumed)", drove, id)
 	}
 }
+
+// TestHarnessRetriesRoundTrips confirms issue #718's harness_retries
+// column is real DB state: it starts at 0, ApplyTransition writes it,
+// and both Get and List read it back.
+func TestHarnessRetriesRoundTrips(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "harness retries", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.HarnessRetries != 0 {
+		t.Fatalf("HarnessRetries on a fresh mission = %d, want 0", m.HarnessRetries)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next: StepState{Phase: PhaseBuild, Status: StatusWorking, MaxIterations: 3, HarnessRetries: 2},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+	if m, err = s.Get(ctx, id); err != nil {
+		t.Fatalf("Get after transition: %v", err)
+	}
+	if m.HarnessRetries != 2 {
+		t.Fatalf("HarnessRetries after transition = %d, want 2", m.HarnessRetries)
+	}
+}
+
+// TestCreateUsesSettingsMaxIterations confirms the iteration ceiling a
+// mission created without one gets comes from the settings-backed
+// getter (issue #718), with the built-in fallback when unwired.
+func TestCreateUsesSettingsMaxIterations(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "default iterations", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.MaxIterations != fallbackMaxIterations {
+		t.Fatalf("MaxIterations unwired = %d, want %d", m.MaxIterations, fallbackMaxIterations)
+	}
+
+	s.SetDefaultMaxIterations(func(context.Context) int { return 7 })
+	if id, err = s.Create(ctx, Mission{Goal: marker + "settings iterations", Kind: "general"}); err != nil {
+		t.Fatalf("Create with setting: %v", err)
+	}
+	if m, err = s.Get(ctx, id); err != nil {
+		t.Fatalf("Get with setting: %v", err)
+	}
+	if m.MaxIterations != 7 {
+		t.Fatalf("MaxIterations = %d, want the configured 7", m.MaxIterations)
+	}
+
+	// An explicit per-mission value always wins over the setting.
+	if id, err = s.Create(ctx, Mission{Goal: marker + "explicit iterations", Kind: "general", MaxIterations: 12}); err != nil {
+		t.Fatalf("Create explicit: %v", err)
+	}
+	if m, err = s.Get(ctx, id); err != nil {
+		t.Fatalf("Get explicit: %v", err)
+	}
+	if m.MaxIterations != 12 {
+		t.Fatalf("MaxIterations = %d, want the explicit 12", m.MaxIterations)
+	}
+}

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -180,6 +180,17 @@ type signaler interface {
 // happens — see that ladder's own comment for the split's rationale.
 var autoResumeBackoffDelays = [...]time.Duration{5 * time.Minute, 15 * time.Minute, 60 * time.Minute}
 
+// autoResumeMax resolves an auto-resume cap from its settings getter,
+// falling back to def when unwired or unset (issue #718).
+func autoResumeMax(ctx context.Context, get func(context.Context) int, def int) int {
+	if get != nil {
+		if n := get(ctx); n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
 // autoResumeExhaustedAfter is the prior-backoff-pause count at and
 // above which autoResumeBackoff stops resuming a mission and instead
 // notifies once and leaves it paused for a human.
@@ -324,8 +335,8 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 		case <-ticker.C:
 			sweepOrphanSandboxes(ctx, store, sandbox, log)
 			reDriveStaleWorking(ctx, d, store, log)
-			autoResumeBackoff(ctx, d, store, notify, log)
-			autoResumeInfra(ctx, d, store, notify, log)
+			autoResumeBackoff(ctx, d, store, notify, d.autoResumeBackoffMax, log)
+			autoResumeInfra(ctx, d, store, notify, d.autoResumeInfraMax, log)
 			sweepPermissionTimeouts(ctx, d, store, globalPermissionTimeout, resolveBroker, notify, log)
 			sweepAskTimeouts(ctx, d, store, globalAskTimeout, notify, log)
 			// D-056: skip the claim entirely this tick if the host can't
@@ -391,7 +402,8 @@ func reDriveStaleWorking(ctx context.Context, d *Driver, store *Store, log *slog
 // before the input switch), not 'backoff' — it naturally leaves
 // BackoffPaused's result set on the very next tick, no special case
 // needed here.
-func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, notify messageNotifier, log *slog.Logger) {
+func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, notify messageNotifier, maxPauses func(context.Context) int, log *slog.Logger) {
+	exhaustedAfter := autoResumeMax(ctx, maxPauses, autoResumeExhaustedAfter)
 	missions, err := store.BackoffPaused(ctx)
 	if err != nil {
 		log.Error("auto-resume backoff sweep: list failed", "error", err)
@@ -406,7 +418,7 @@ func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, noti
 		if n <= 0 {
 			continue // no recorded backoff pause yet — nothing to ladder from
 		}
-		if n >= autoResumeExhaustedAfter {
+		if n >= exhaustedAfter {
 			if notify != nil {
 				msg := fmt.Sprintf("this mission has paused for backoff %d times and will not auto-resume again — it needs a human look", n)
 				if err := notify.NotifyMessage(ctx, m.ID, "auto_resume_exhausted", msg); err != nil {
@@ -444,7 +456,8 @@ func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, noti
 // checks run before the input switch) — it naturally leaves
 // PausedByReason's result set on the very next tick if that reason
 // isn't 'infra', no special case needed here.
-func autoResumeInfra(ctx context.Context, d signaler, store pausedByReasonStore, notify messageNotifier, log *slog.Logger) {
+func autoResumeInfra(ctx context.Context, d signaler, store pausedByReasonStore, notify messageNotifier, maxPauses func(context.Context) int, log *slog.Logger) {
+	exhaustedAfter := autoResumeMax(ctx, maxPauses, autoResumeInfraExhaustedAfter)
 	missions, err := store.PausedByReason(ctx, string(PauseInfra))
 	if err != nil {
 		log.Error("auto-resume infra sweep: list failed", "error", err)
@@ -459,7 +472,7 @@ func autoResumeInfra(ctx context.Context, d signaler, store pausedByReasonStore,
 		if n <= 0 {
 			continue // no recorded infra pause yet — nothing to ladder from
 		}
-		if n >= autoResumeInfraExhaustedAfter {
+		if n >= exhaustedAfter {
 			if notify != nil {
 				msg := fmt.Sprintf("this mission has paused for infra failure %d times and will not auto-resume again — it needs a human look", n)
 				if err := notify.NotifyMessage(ctx, m.ID, "auto_resume_exhausted", msg); err != nil {

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -138,7 +138,7 @@ func TestAutoResumeBackoffLadder(t *testing.T) {
 			}
 			signaler := &fakeSignaler{}
 			notifier := &fakeMessageNotifier{}
-			autoResumeBackoff(context.Background(), signaler, store, notifier, log)
+			autoResumeBackoff(context.Background(), signaler, store, notifier, nil, log)
 
 			if resumed := len(signaler.signaled) == 1; resumed != tc.wantResume {
 				t.Fatalf("signaled = %v, want resume=%v", signaler.signaled, tc.wantResume)
@@ -160,7 +160,7 @@ func TestAutoResumeBackoffNilNotifierSafe(t *testing.T) {
 		counts: map[string]int{"m1": 4},
 	}
 	signaler := &fakeSignaler{}
-	autoResumeBackoff(context.Background(), signaler, store, nil, log)
+	autoResumeBackoff(context.Background(), signaler, store, nil, nil, log)
 	if len(signaler.signaled) != 0 {
 		t.Fatal("exhausted mission must never be resumed")
 	}
@@ -212,7 +212,7 @@ func TestAutoResumeInfraLadder(t *testing.T) {
 			}
 			signaler := &fakeSignaler{}
 			notifier := &fakeMessageNotifier{}
-			autoResumeInfra(context.Background(), signaler, store, notifier, log)
+			autoResumeInfra(context.Background(), signaler, store, notifier, nil, log)
 
 			if resumed := len(signaler.signaled) == 1; resumed != tc.wantResume {
 				t.Fatalf("signaled = %v, want resume=%v", signaler.signaled, tc.wantResume)
@@ -244,7 +244,7 @@ func TestAutoResumeInfraWaitsForResumeAfter(t *testing.T) {
 				counts: map[string]int{"m1": 1},
 			}
 			signaler := &fakeSignaler{}
-			autoResumeInfra(context.Background(), signaler, store, nil, log)
+			autoResumeInfra(context.Background(), signaler, store, nil, nil, log)
 			if resumed := len(signaler.signaled) == 1; resumed != tc.wantResume {
 				t.Fatalf("signaled = %v, want resume=%v", signaler.signaled, tc.wantResume)
 			}
@@ -266,7 +266,7 @@ func TestAutoResumeInfraNotifiesOncePerTick(t *testing.T) {
 	}
 	signaler := &fakeSignaler{}
 	notifier := &fakeMessageNotifier{}
-	autoResumeInfra(context.Background(), signaler, store, notifier, log)
+	autoResumeInfra(context.Background(), signaler, store, notifier, nil, log)
 	if len(notifier.notified) != 1 {
 		t.Fatalf("notified = %d, want 1", len(notifier.notified))
 	}
@@ -285,7 +285,7 @@ func TestAutoResumeInfraNilNotifierSafe(t *testing.T) {
 		counts: map[string]int{"m1": 3},
 	}
 	signaler := &fakeSignaler{}
-	autoResumeInfra(context.Background(), signaler, store, nil, log)
+	autoResumeInfra(context.Background(), signaler, store, nil, nil, log)
 	if len(signaler.signaled) != 0 {
 		t.Fatal("exhausted mission must never be resumed")
 	}
@@ -681,4 +681,54 @@ func TestWaitForGatewayReadyRespectsContextCancellation(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("waitForGatewayReady did not return promptly after context cancellation")
 	}
+}
+
+// TestAutoResumeCapsComeFromSettings covers issue #718: both ladders
+// read their exhausted cap from the settings getter, so lowering it to
+// 2 stops resuming a mission the built-in cap would still have retried.
+func TestAutoResumeCapsComeFromSettings(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cap2 := func(context.Context) int { return 2 }
+	old := time.Now().Add(-999 * time.Hour)
+
+	t.Run("backoff", func(t *testing.T) {
+		store := fakeBackoffStore{
+			paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: old}},
+			counts: map[string]int{"m1": 2},
+		}
+		signaler, notifier := &fakeSignaler{}, &fakeMessageNotifier{}
+		autoResumeBackoff(context.Background(), signaler, store, notifier, cap2, log)
+		if len(signaler.signaled) != 0 {
+			t.Fatal("2 prior pauses must exhaust a cap of 2, never resume")
+		}
+		if len(notifier.notified) != 1 {
+			t.Fatalf("notified = %d, want 1", len(notifier.notified))
+		}
+		// The same state under the built-in cap of 4 still resumes.
+		signaler = &fakeSignaler{}
+		autoResumeBackoff(context.Background(), signaler, store, &fakeMessageNotifier{}, nil, log)
+		if len(signaler.signaled) != 1 {
+			t.Fatalf("signaled = %d under the default cap, want 1", len(signaler.signaled))
+		}
+	})
+
+	t.Run("infra", func(t *testing.T) {
+		store := fakePausedByReasonStore{
+			paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: old}},
+			counts: map[string]int{"m1": 2},
+		}
+		signaler, notifier := &fakeSignaler{}, &fakeMessageNotifier{}
+		autoResumeInfra(context.Background(), signaler, store, notifier, cap2, log)
+		if len(signaler.signaled) != 0 {
+			t.Fatal("2 prior pauses must exhaust a cap of 2, never resume")
+		}
+		if len(notifier.notified) != 1 {
+			t.Fatalf("notified = %d, want 1", len(notifier.notified))
+		}
+		signaler = &fakeSignaler{}
+		autoResumeInfra(context.Background(), signaler, store, &fakeMessageNotifier{}, nil, log)
+		if len(signaler.signaled) != 1 {
+			t.Fatalf("signaled = %d under the default cap, want 1", len(signaler.signaled))
+		}
+	})
 }

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -150,7 +150,45 @@ const (
 	// delegated worker or review run gets (issue #720); "" or "0" (the
 	// default) leaves the CLI's own default in place.
 	ValueExecutorThinkingTokens = "executor_thinking_tokens"
+	// ValueExecutorWorkerMaxTurns caps a delegated WORKER run's own CLI
+	// agent loop (missions/delegated.go, issue #718); "" defers to
+	// DefaultExecutorWorkerMaxTurns, "0" removes the cap. A worker does
+	// real multi-step work, so its cap is far above the reviewer's.
+	ValueExecutorWorkerMaxTurns = "executor_worker_max_turns"
+	// ValueMissionDefaultMaxIterations is the iteration ceiling a
+	// mission created without one gets (issue #718); "" defers to
+	// DefaultMissionMaxIterations.
+	ValueMissionDefaultMaxIterations = "mission_default_max_iterations"
+	// ValueMissionBackoffFailures is the statemachine's backoff brake:
+	// consecutive worker_failed inputs before a backoff pause.
+	ValueMissionBackoffFailures = "mission_backoff_failures"
+	// ValueMissionStallRounds is the statemachine's no-progress brake:
+	// consecutive rounds with an identical gap fingerprint.
+	ValueMissionStallRounds = "mission_stall_rounds"
+	// ValueMissionHarnessRetryCap bounds the retries the harness
+	// attributed to itself over a mission's life (issue #718); they
+	// spend no iteration, so this is their only ceiling.
+	ValueMissionHarnessRetryCap = "mission_harness_retry_cap"
+	// ValueMissionAutoResumeBackoffMax bounds how many times the sweep
+	// auto-resumes a backoff pause before leaving it for the operator.
+	ValueMissionAutoResumeBackoffMax = "mission_auto_resume_backoff_max"
+	// ValueMissionAutoResumeInfraMax is the same bound for infra pauses.
+	ValueMissionAutoResumeInfraMax = "mission_auto_resume_infra_max"
 )
+
+// Mission ceiling defaults, used when the matching setting is unset.
+const (
+	DefaultMissionMaxIterations        = 3
+	DefaultMissionBackoffFailures      = 3
+	DefaultMissionStallRounds          = 2
+	DefaultMissionHarnessRetryCap      = 3
+	DefaultMissionAutoResumeBackoffMax = 4
+	DefaultMissionAutoResumeInfraMax   = 3
+)
+
+// DefaultExecutorWorkerMaxTurns is the delegated worker run's turn cap
+// when ValueExecutorWorkerMaxTurns is unset.
+const DefaultExecutorWorkerMaxTurns = 40
 
 // DefaultExecutorReviewMaxTurns is the delegated review run's turn cap
 // when ValueExecutorReviewMaxTurns is unset.
@@ -186,6 +224,22 @@ var knownValueKeys = map[string]bool{
 	ValueMCPToolIndexThreshold: true,
 	ValueWritingStyle:          true, ValueWritingSamplesCollection: true,
 	ValueExecutorReviewMaxTurns: true, ValueExecutorThinkingTokens: true,
+	ValueExecutorWorkerMaxTurns:      true,
+	ValueMissionDefaultMaxIterations: true, ValueMissionBackoffFailures: true,
+	ValueMissionStallRounds: true, ValueMissionHarnessRetryCap: true,
+	ValueMissionAutoResumeBackoffMax: true, ValueMissionAutoResumeInfraMax: true,
+}
+
+// nonNegativeIntKeys are the settings whose value must parse as an
+// integer >= 0 when set.
+var nonNegativeIntKeys = map[string]bool{
+	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
+	ValueReviewTokenCeiling: true, ValueMCPToolIndexThreshold: true,
+	ValueExecutorReviewMaxTurns: true, ValueExecutorThinkingTokens: true,
+	ValueExecutorWorkerMaxTurns:      true,
+	ValueMissionDefaultMaxIterations: true, ValueMissionBackoffFailures: true,
+	ValueMissionStallRounds: true, ValueMissionHarnessRetryCap: true,
+	ValueMissionAutoResumeBackoffMax: true, ValueMissionAutoResumeInfraMax: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -323,6 +377,55 @@ func (s *Store) ExecutorReviewMaxTurns(ctx context.Context) int {
 		}
 	}
 	return DefaultExecutorReviewMaxTurns
+}
+
+// ExecutorWorkerMaxTurns parses the delegated worker turn cap, falling
+// back to DefaultExecutorWorkerMaxTurns when unset or unparsable; 0
+// removes the cap.
+func (s *Store) ExecutorWorkerMaxTurns(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueExecutorWorkerMaxTurns, DefaultExecutorWorkerMaxTurns)
+}
+
+// MissionDefaultMaxIterations is the iteration ceiling a mission
+// created without one gets.
+func (s *Store) MissionDefaultMaxIterations(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionDefaultMaxIterations, DefaultMissionMaxIterations)
+}
+
+// MissionBackoffFailures is the statemachine's backoff brake.
+func (s *Store) MissionBackoffFailures(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionBackoffFailures, DefaultMissionBackoffFailures)
+}
+
+// MissionStallRounds is the statemachine's no-progress brake.
+func (s *Store) MissionStallRounds(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionStallRounds, DefaultMissionStallRounds)
+}
+
+// MissionHarnessRetryCap bounds a mission's harness-caused retries.
+func (s *Store) MissionHarnessRetryCap(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionHarnessRetryCap, DefaultMissionHarnessRetryCap)
+}
+
+// MissionAutoResumeBackoffMax bounds the sweep's backoff auto-resumes.
+func (s *Store) MissionAutoResumeBackoffMax(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionAutoResumeBackoffMax, DefaultMissionAutoResumeBackoffMax)
+}
+
+// MissionAutoResumeInfraMax bounds the sweep's infra auto-resumes.
+func (s *Store) MissionAutoResumeInfraMax(ctx context.Context) int {
+	return s.nonNegativeInt(ctx, ValueMissionAutoResumeInfraMax, DefaultMissionAutoResumeInfraMax)
+}
+
+// nonNegativeInt reads key as an integer >= 0, falling back to def when
+// unset or unparsable.
+func (s *Store) nonNegativeInt(ctx context.Context, key string, def int) int {
+	if v := s.Value(ctx, key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return def
 }
 
 // ExecutorThinkingTokens parses the per-turn thinking budget a
@@ -506,7 +609,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}
 	}
-	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling || key == ValueMCPToolIndexThreshold || key == ValueExecutorReviewMaxTurns || key == ValueExecutorThinkingTokens) && value != "" {
+	if nonNegativeIntKeys[key] && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}

--- a/internal/brain/settings/settings_test.go
+++ b/internal/brain/settings/settings_test.go
@@ -96,3 +96,33 @@ func TestExecutorKnobDefaults(t *testing.T) {
 		t.Fatalf("ExecutorThinkingTokens = %d, want 0", got)
 	}
 }
+
+// TestMissionCeilingDefaults pins the issue #718 accessors: with no
+// row set, every mission retry ceiling reads its built-in default.
+func TestMissionCeilingDefaults(t *testing.T) {
+	s := degradedStore(t)
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{ValueExecutorWorkerMaxTurns, s.ExecutorWorkerMaxTurns(ctx), DefaultExecutorWorkerMaxTurns},
+		{ValueMissionDefaultMaxIterations, s.MissionDefaultMaxIterations(ctx), DefaultMissionMaxIterations},
+		{ValueMissionBackoffFailures, s.MissionBackoffFailures(ctx), DefaultMissionBackoffFailures},
+		{ValueMissionStallRounds, s.MissionStallRounds(ctx), DefaultMissionStallRounds},
+		{ValueMissionHarnessRetryCap, s.MissionHarnessRetryCap(ctx), DefaultMissionHarnessRetryCap},
+		{ValueMissionAutoResumeBackoffMax, s.MissionAutoResumeBackoffMax(ctx), DefaultMissionAutoResumeBackoffMax},
+		{ValueMissionAutoResumeInfraMax, s.MissionAutoResumeInfraMax(ctx), DefaultMissionAutoResumeInfraMax},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, tc.got, tc.want)
+		}
+		if !knownValueKeys[tc.name] {
+			t.Errorf("%s is not in knownValueKeys, so it cannot be set", tc.name)
+		}
+		if !nonNegativeIntKeys[tc.name] {
+			t.Errorf("%s is not validated as a non-negative integer", tc.name)
+		}
+	}
+}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -710,6 +710,7 @@ CREATE TABLE IF NOT EXISTS missions (
     -- resume, 'fresh' starts every unit cold so only the packet's
     -- progress notes and recent commits carry over.
     executor_session_policy text NOT NULL DEFAULT '',
+    harness_retries integer NOT NULL DEFAULT 0,
     -- Mission worker turns run through loop.Agent same as chat, but
     -- tool-call bookkeeping (session_events, tools audit) hard-requires
     -- a real session_id uuid FK -- a mission has no chat session of its

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -26,3 +26,10 @@ WHERE plan ? 'units' AND jsonb_typeof(plan->'units') = 'array'
 -- today's resume behaviour, 'fresh' starts every unit cold).
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS executor_session_policy text NOT NULL DEFAULT '';
 ```
+
+```sql
+-- issue #718: lifetime count of retries the harness attributed to
+-- itself (unreadable sentinel, runner error, executor death). They
+-- spend no iteration, so mission_harness_retry_cap is their ceiling.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS harness_retries integer NOT NULL DEFAULT 0;
+```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -745,6 +745,17 @@ export interface ReviewFinding {
   untouched_rounds?: number
 }
 
+// CriterionVerdict is the reviewer's answer for one unit acceptance
+// criterion (missions.CriterionVerdict, issue #718), carried on a
+// mission.review_verdict event's criteria field. unit is the plan
+// index, criterion the zero-based index into that unit's criteria.
+export interface CriterionVerdict {
+  unit: number
+  criterion: number
+  status: 'met' | 'not_met' | 'cannot_tell'
+  evidence?: string
+}
+
 // Mission is one long-running, agent-driven unit of work
 // (internal/brain/missions): discover -> plan -> build -> prove ->
 // result under a state machine.
@@ -805,6 +816,10 @@ export interface Mission {
   consecutive_failures: number
   last_gap_fingerprint?: string
   stall_count: number
+  // harness_retries counts the retries the harness attributed to itself
+  // (issue #718): they spend no iteration, so they have their own cap
+  // (settings.mission_harness_retry_cap) and nothing resets them.
+  harness_retries?: number
   budget_amount?: number
   budget_currency?: string
   route: string


### PR DESCRIPTION
## Summary

Closes #718 (G8 and G9, the last open gaps) and adds the retry-bound audit fixes that fell out of reviewing them.

### G8: harness-caused retries keep the iteration budget
`StepInput.HarnessCaused` marks a forced no-sentinel retry and every runner-error worker failure (turn error, executor died, idle timeout, a CLI run ending on its turn cap). They spend no `max_iterations`. A lifetime `harness_retries` counter (new column, ALTER in `scripts/pending-alters.md`) parks the mission as `no_progress` / `harness_retries_exhausted` at the cap; it is checked before the backoff brake because `ConsecutiveFailures` survives a resume, and resume, replan and phase changes never reset it. Stall and backoff brakes are unchanged; planless flows take the no-progress pause instead of the replan they cannot reach.

### G9: per-criterion reviewer rubric
The review verdict schema (native tool and delegated CLI result, one shape) gains `criteria`: one entry per acceptance criterion per unit under review, `met` / `not_met` / `cannot_tell`, with cited evidence. Enforced in Go: any `not_met` with evidence opens a blocking finding and forces rework even on "approve"; `cannot_tell` and evidence-less `not_met` open minor findings; criteria on units outside the round are ignored; findings-only rounds carry no rubric. The rubric rides on the `mission.review_verdict` payload and is mirrored in the web types. Criteria stay optional so existing fixtures parse.

### Retry bounds
Audit result: worker mistakes were already bounded at 3, but harness-caused failures could reach 6 to 12 CLI runs through the auto-resume ladders, and delegated worker runs had no turn cap. Fixed by the counter above and `executor_worker_max_turns` (Claude Code `--max-turns`, default 40; other adapters keep the idle timeout).

### Configurable ceilings
Every retry, iteration and auto-resume ceiling is now a setting with today's value as its default; zero or unset falls back to the default so no brake can be disabled by accident.

| Key | Default |
|---|---|
| `mission_default_max_iterations` | 3 |
| `mission_backoff_failures` | 3 |
| `mission_stall_rounds` | 2 |
| `mission_harness_retry_cap` | 3 |
| `mission_auto_resume_backoff_max` | 4 |
| `mission_auto_resume_infra_max` | 3 |
| `executor_worker_max_turns` | 40 |

## Verification
- `make build vet test lint`: green, 0 issues. Web build/lint/test green.
- `make canary-coding`: PASS on the final build (and on each intermediate build).
- Live claude-cli mission on the eval slice: reviewer answered 6/6 criteria `met` with file and line evidence, approved, done in 4:41.
- Homelab needs the `harness_retries` ALTER from `scripts/pending-alters.md` before the next release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791833979&installation_model_id=431401&pr_number=722&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F722&signature=243e67dd43bace86b935356cf4f48ff1277d20bc34e129f61d805de0bf8c2e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->