### PR TITLE
fix(missions): reject unknown fields on mission create

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -613,7 +613,13 @@ type missionAttachmentInput struct {
 // turn happen in the background; this returns {id} immediately.
 func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	var req createMissionRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// Unknown fields are rejected rather than dropped: a misspelled or
+	// invented key (a "sources" array, "repoURL" for "repo_url") used to
+	// create a mission that silently lost the setting and only failed
+	// minutes later, mid-run, with an unrelated reason.
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -423,6 +423,48 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 	}
 }
 
+// TestMissionsCreateRejectsUnknownFields covers the strict decode: a
+// key the request struct doesn't carry (an invented "sources" array, a
+// misspelled "repoURL") 400s at decode time instead of being dropped,
+// which used to create a mission missing the setting the caller thought
+// they'd sent and fail it minutes later for an unrelated reason.
+func TestMissionsCreateRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+
+	post := func(body string) (int, string) {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, "", nil)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	for _, body := range []string{
+		`{"goal":"g","kind":"coding","sources":[{"source":"github","repo_url":"https://github.com/o/r"}]}`,
+		`{"goal":"g","kind":"coding","repoURL":"https://github.com/o/r"}`,
+	} {
+		code, got := post(body)
+		if code != 400 {
+			t.Fatalf("%s = %d, want 400", body, code)
+		}
+		if !strings.Contains(got, "unknown field") {
+			t.Fatalf("%s error = %q, want an unknown field message", body, got)
+		}
+	}
+
+	// A body of known keys only still reaches goal validation rather
+	// than tripping the decoder.
+	if code, got := post(`{"kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`); code != 400 || !strings.Contains(got, "goal is required") {
+		t.Fatalf("known-keys body = %d %q, want 400 goal is required", code, got)
+	}
+}
+
 // TestMissionsCreateValidatesParentMission covers the follow-up gate:
 // an unresolvable parent_mission_id 400s ("parent mission not found")
 // before Driver.Create is ever reached — against a degraded pool


### PR DESCRIPTION
Closes #723

`POST /v1/missions` decoded with a plain `json.Decoder`, so any key the request struct does not define was silently dropped. A mistyped or invented field produced a mission missing the setting the caller meant to send, which then failed minutes later for an unrelated reason.

Found during the #718 harness eval: the eval script sent a `sources` array instead of top-level `repo_url`/`connector_id`, got a mission with an empty self-initialized repo, and only learned about it when discover and plan finished and the mission failed `plan_infeasible`.

## Changes

- `create()` decodes with `DisallowUnknownFields()`, matching the four existing strict decoders in the repo (plan JSON, extract, sandboxd, turn memory). Unknown keys now 400 at decode time with the field named.
- `TestMissionsCreateRejectsUnknownFields` covers an invented `sources` array, a `repoURL` typo, and a known-keys control body that still reaches goal validation.

Web's `CreateMissionInput` and the canary scripts send known keys only, so both keep working unchanged.

## Verify

`make build test vet lint` green, 0 lint issues.