### PR TITLE
feat(connectors): read-only pull request tools on the github kind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ First run: `cp deploy/env.example deploy/.env` and set
   (google/microsoft/github/mcp/imap/caldav, unified capability tools:
   `search_mail`, `read_mail`, `send_mail`, `list_calendar_events`,
   `create_calendar_event` route to the right connector/account via an
-  `account` parameter — see `manager.go`'s `aggregateTools`),
+  `account` parameter — see `manager.go`'s `aggregateTools`; the
+  `github` kind also serves read-only PR tools in `github_tools.go`),
   `destinations` (mission result delivery: email/webhook/
   telegram/github, the last pushing/opening a PR through a github
   connector via `GitHubAdapter`), `kb` (knowledge-base collections/documents; image

--- a/internal/brain/connectors/github.go
+++ b/internal/brain/connectors/github.go
@@ -65,9 +65,10 @@ const (
 	githubRepoMaxRepos = 300
 )
 
-// GitHubBuilder returns the Builder for kind='github'. The source
-// serves zero tools by design: identity/credential connector only,
-// chat tools stay on the MCP-based GitHub connector.
+// GitHubBuilder returns the Builder for kind='github'. The source is
+// the identity/credential connector missions clone, push, and open PRs
+// through, plus the read-only pull request tools in github_tools.go
+// (issue #727). Write tools stay on the MCP-based GitHub connector.
 func GitHubBuilder(client *http.Client) Builder {
 	if client == nil {
 		client = &http.Client{}
@@ -80,8 +81,9 @@ func GitHubBuilder(client *http.Client) Builder {
 	}
 }
 
-// githubSource is a built github-kind connector: no tools, Test
-// resolves the PAT and confirms it authenticates against the GitHub API.
+// githubSource is a built github-kind connector: read-only PR tools,
+// and a Test that resolves the PAT and confirms it authenticates
+// against the GitHub API.
 type githubSource struct {
 	name          string
 	credentialRef string
@@ -89,8 +91,13 @@ type githubSource struct {
 	client        *http.Client
 }
 
-// Tools is empty: identity/credential connector, no chat tools.
-func (s *githubSource) Tools() []*tools.Tool { return nil }
+// Tools is the read-only pull request surface (github_tools.go).
+func (s *githubSource) Tools() []*tools.Tool { return s.prTools() }
+
+// AccountInfo reports the kind and, since the PAT's login is only
+// known after a network call, no email: the aggregated description
+// then lists the connector by name alone.
+func (s *githubSource) AccountInfo() (kind, email string) { return "github", "" }
 
 func (s *githubSource) Test(ctx context.Context) error {
 	token, err := s.resolve(ctx, s.credentialRef)
@@ -456,10 +463,17 @@ func resolveEmail(ctx context.Context, client *http.Client, token string, user g
 	return fmt.Sprintf("%d+%s@users.noreply.github.com", user.ID, user.Login), nil
 }
 
-// githubRequest issues one authenticated GitHub API GET. The token
-// never appears in an error: only the status code and a short body
-// snippet are surfaced.
+// githubRequest issues one authenticated GitHub API GET for JSON. The
+// token never appears in an error: only the status code and a short
+// body snippet are surfaced.
 func githubRequest(ctx context.Context, client *http.Client, token, path string) (*http.Response, error) {
+	return githubRequestAccept(ctx, client, token, path, "application/vnd.github+json")
+}
+
+// githubRequestAccept is githubRequest with an explicit Accept media
+// type, for the endpoints that render a non-JSON body on request
+// (get_pull_request_diff's application/vnd.github.diff).
+func githubRequestAccept(ctx context.Context, client *http.Client, token, path, accept string) (*http.Response, error) {
 	cctx, cancel := context.WithTimeout(ctx, githubCallTimeout)
 	req, err := http.NewRequestWithContext(cctx, http.MethodGet, githubAPIBase+path, nil)
 	if err != nil {
@@ -467,7 +481,7 @@ func githubRequest(ctx context.Context, client *http.Client, token, path string)
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Accept", accept)
 	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/brain/connectors/github_test.go
+++ b/internal/brain/connectors/github_test.go
@@ -196,7 +196,7 @@ func TestGitHubBuilderRequiresCredentialRef(t *testing.T) {
 	}
 }
 
-func TestGitHubSourceServesNoTools(t *testing.T) {
+func TestGitHubSourceServesReadOnlyPRTools(t *testing.T) {
 	t.Parallel()
 	b := GitHubBuilder(nil)
 	src, err := b(t.Context(), Connector{Name: "gh", Kind: "github", CredentialRef: "GH_PAT"},
@@ -204,8 +204,18 @@ func TestGitHubSourceServesNoTools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
-	if got := src.Tools(); len(got) != 0 {
-		t.Fatalf("Tools() = %v, want none: github is identity-only in this slice", got)
+	want := []string{"list_pull_requests", "get_pull_request", "get_pull_request_diff", "list_pull_request_comments"}
+	got := src.Tools()
+	if len(got) != len(want) {
+		t.Fatalf("Tools() has %d tools, want %d", len(got), len(want))
+	}
+	for i, tl := range got {
+		if tl.Name != want[i] {
+			t.Errorf("Tools()[%d] = %s, want %s", i, tl.Name, want[i])
+		}
+		if !tl.ReadOnly {
+			t.Errorf("%s must be ReadOnly: it is a pure GET and missions rely on the marker", tl.Name)
+		}
 	}
 }
 

--- a/internal/brain/connectors/github_tools.go
+++ b/internal/brain/connectors/github_tools.go
@@ -1,0 +1,321 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// Pull request read tools on the github kind (issue #727). Every tool
+// here is a pure GET against the REST API with the connector's PAT
+// resolved at call time, and is marked ReadOnly so a mission turn can
+// use it through missions' connector-reads resolver. Writes (comment,
+// approve, merge) deliberately have no tool here: chat reaches them
+// through the GitHub MCP connector, missions through destinations.
+const (
+	githubPRListDefault = 10
+	githubPRListMax     = 50
+	// githubDiffMaxBytes caps get_pull_request_diff's body before it
+	// reaches the loop's own result cap, so a huge diff is cut with an
+	// explicit marker instead of silently.
+	githubDiffMaxBytes = 200 << 10
+	// githubCommentsPerPage is the max GitHub allows; one page per
+	// comment kind is all list_pull_request_comments reads.
+	githubCommentsPerPage = 100
+
+	githubDiffMediaType = "application/vnd.github.diff"
+)
+
+// githubRepoArg matches the "owner/name" form every PR tool takes.
+var githubRepoArg = regexp.MustCompile(`^([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$`)
+
+// splitRepoArg validates an "owner/name" argument.
+func splitRepoArg(repo string) (owner, name string, err error) {
+	m := githubRepoArg.FindStringSubmatch(strings.TrimSpace(repo))
+	if m == nil {
+		return "", "", fmt.Errorf("repo must be \"owner/name\", got %q", repo)
+	}
+	return m[1], m[2], nil
+}
+
+// prTools is the github kind's read-only tool surface.
+func (s *githubSource) prTools() []*tools.Tool {
+	return []*tools.Tool{s.listPullRequests(), s.getPullRequest(), s.getPullRequestDiff(), s.listPullRequestComments()}
+}
+
+// githubPullRequest is the subset of a pull request object the read
+// tools render.
+type githubPullRequest struct {
+	Number         int    `json:"number"`
+	Title          string `json:"title"`
+	State          string `json:"state"`
+	Draft          bool   `json:"draft"`
+	Merged         bool   `json:"merged"`
+	MergeableState string `json:"mergeable_state"`
+	Body           string `json:"body"`
+	HTMLURL        string `json:"html_url"`
+	CreatedAt      string `json:"created_at"`
+	UpdatedAt      string `json:"updated_at"`
+	Commits        int    `json:"commits"`
+	Additions      int    `json:"additions"`
+	Deletions      int    `json:"deletions"`
+	ChangedFiles   int    `json:"changed_files"`
+	User           struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Head struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+// githubComment is one issue or review comment on a pull request;
+// Path/Line are set only on review comments.
+type githubComment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
+	Path      string `json:"path"`
+	Line      int    `json:"line"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+func (s *githubSource) listPullRequests() *tools.Tool {
+	return &tools.Tool{
+		Name:        "list_pull_requests",
+		ReadOnly:    true,
+		Description: "List pull requests in a GitHub repository, most recently updated first, with number, state, author, title, and head/base branches. Use this to find a PR by title or branch before reading it with get_pull_request. Do not use shell, git, or curl to reach the GitHub API; this tool carries the connected account's credentials.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{
+			"repo":{"type":"string","description":"owner/name"},
+			"state":{"type":"string","enum":["open","closed","all"],"description":"defaults to open"},
+			"max_results":{"type":"integer","minimum":1,"maximum":50}
+		},"required":["repo"],"additionalProperties":false}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var in struct {
+				Repo       string `json:"repo"`
+				State      string `json:"state"`
+				MaxResults int    `json:"max_results"`
+			}
+			if err := json.Unmarshal(args, &in); err != nil {
+				return "", err
+			}
+			owner, name, err := splitRepoArg(in.Repo)
+			if err != nil {
+				return "", err
+			}
+			if in.State == "" {
+				in.State = "open"
+			}
+			if in.MaxResults <= 0 {
+				in.MaxResults = githubPRListDefault
+			}
+			if in.MaxResults > githubPRListMax {
+				in.MaxResults = githubPRListMax
+			}
+			var prs []githubPullRequest
+			path := fmt.Sprintf("/repos/%s/%s/pulls?state=%s&sort=updated&direction=desc&per_page=%d", owner, name, in.State, in.MaxResults)
+			if err := s.getJSON(ctx, path, "list pull requests", &prs); err != nil {
+				return "", err
+			}
+			if len(prs) == 0 {
+				return fmt.Sprintf("no %s pull requests in %s/%s", in.State, owner, name), nil
+			}
+			var b strings.Builder
+			for _, pr := range prs {
+				state := pr.State
+				if pr.Draft {
+					state = "draft"
+				}
+				fmt.Fprintf(&b, "#%d [%s] %s (%s) %s -> %s\n", pr.Number, state, pr.Title, pr.User.Login, pr.Head.Ref, pr.Base.Ref)
+			}
+			return strings.TrimRight(b.String(), "\n"), nil
+		},
+	}
+}
+
+func (s *githubSource) getPullRequest() *tools.Tool {
+	return &tools.Tool{
+		Name:        "get_pull_request",
+		ReadOnly:    true,
+		Description: "Read one pull request's metadata: title, author, state, head/base branches and head commit, mergeable state, commit and changed-file counts, and the full description. Use get_pull_request_diff for the code changes and list_pull_request_comments for the discussion; this tool returns neither.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{
+			"repo":{"type":"string","description":"owner/name"},
+			"number":{"type":"integer","minimum":1}
+		},"required":["repo","number"],"additionalProperties":false}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			owner, name, number, err := prArgs(args)
+			if err != nil {
+				return "", err
+			}
+			var pr githubPullRequest
+			if err := s.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, name, number), "get pull request", &pr); err != nil {
+				return "", err
+			}
+			state := pr.State
+			switch {
+			case pr.Merged:
+				state = "merged"
+			case pr.Draft:
+				state = "draft"
+			}
+			var b strings.Builder
+			fmt.Fprintf(&b, "#%d %s\n", pr.Number, pr.Title)
+			fmt.Fprintf(&b, "author: %s\nstate: %s\n", pr.User.Login, state)
+			fmt.Fprintf(&b, "head: %s (%s)\nbase: %s\n", pr.Head.Ref, pr.Head.SHA, pr.Base.Ref)
+			if pr.MergeableState != "" {
+				fmt.Fprintf(&b, "mergeable_state: %s\n", pr.MergeableState)
+			}
+			fmt.Fprintf(&b, "commits: %d, files changed: %d, +%d/-%d\n", pr.Commits, pr.ChangedFiles, pr.Additions, pr.Deletions)
+			fmt.Fprintf(&b, "created: %s, updated: %s\nurl: %s\n", pr.CreatedAt, pr.UpdatedAt, pr.HTMLURL)
+			if strings.TrimSpace(pr.Body) != "" {
+				fmt.Fprintf(&b, "\n%s\n", strings.TrimSpace(pr.Body))
+			}
+			return strings.TrimRight(b.String(), "\n"), nil
+		},
+	}
+}
+
+func (s *githubSource) getPullRequestDiff() *tools.Tool {
+	return &tools.Tool{
+		Name:        "get_pull_request_diff",
+		ReadOnly:    true,
+		Description: "Read a pull request's unified diff, the same text git diff base...head would print. Use this to review the actual code changes. Large diffs are cut at a fixed size with a marker saying how much was omitted; review what is returned rather than retrying.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{
+			"repo":{"type":"string","description":"owner/name"},
+			"number":{"type":"integer","minimum":1}
+		},"required":["repo","number"],"additionalProperties":false}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			owner, name, number, err := prArgs(args)
+			if err != nil {
+				return "", err
+			}
+			token, err := s.resolve(ctx, s.credentialRef)
+			if err != nil {
+				return "", fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+			}
+			resp, err := githubRequestAccept(ctx, s.client, token, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, name, number), githubDiffMediaType)
+			if err != nil {
+				return "", err
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				return "", fmt.Errorf("get pull request diff: %w", githubStatusError(resp))
+			}
+			// Read one byte past the cap so a diff exactly at the cap is
+			// not reported as truncated.
+			body, err := io.ReadAll(io.LimitReader(resp.Body, githubDiffMaxBytes+1))
+			if err != nil {
+				return "", fmt.Errorf("get pull request diff: read response: %w", err)
+			}
+			if len(body) <= githubDiffMaxBytes {
+				if len(body) == 0 {
+					return "empty diff", nil
+				}
+				return string(body), nil
+			}
+			omitted, _ := io.Copy(io.Discard, resp.Body)
+			omitted++ // the one byte read past the cap
+			return fmt.Sprintf("%s\n\n[diff truncated at %d bytes; %d more bytes omitted]", body[:githubDiffMaxBytes], githubDiffMaxBytes, omitted), nil
+		},
+	}
+}
+
+func (s *githubSource) listPullRequestComments() *tools.Tool {
+	return &tools.Tool{
+		Name:        "list_pull_request_comments",
+		ReadOnly:    true,
+		Description: "List the discussion on a pull request in chronological order: conversation comments and inline review comments (marked with their file and line). Use this to see reviewer feedback and whether it was addressed. This tool is read-only; it cannot post a comment.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{
+			"repo":{"type":"string","description":"owner/name"},
+			"number":{"type":"integer","minimum":1}
+		},"required":["repo","number"],"additionalProperties":false}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			owner, name, number, err := prArgs(args)
+			if err != nil {
+				return "", err
+			}
+			var issue, review []githubComment
+			if err := s.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/comments?per_page=%d", owner, name, number, githubCommentsPerPage), "list pull request comments", &issue); err != nil {
+				return "", err
+			}
+			if err := s.getJSON(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d/comments?per_page=%d", owner, name, number, githubCommentsPerPage), "list pull request comments", &review); err != nil {
+				return "", err
+			}
+			type entry struct {
+				at, text string
+			}
+			entries := make([]entry, 0, len(issue)+len(review))
+			for _, c := range issue {
+				entries = append(entries, entry{c.CreatedAt, fmt.Sprintf("[%s] %s (comment):\n%s", c.CreatedAt, c.User.Login, strings.TrimSpace(c.Body))})
+			}
+			for _, c := range review {
+				where := c.Path
+				if c.Line > 0 {
+					where = fmt.Sprintf("%s:%d", c.Path, c.Line)
+				}
+				entries = append(entries, entry{c.CreatedAt, fmt.Sprintf("[%s] %s (review on %s):\n%s", c.CreatedAt, c.User.Login, where, strings.TrimSpace(c.Body))})
+			}
+			if len(entries) == 0 {
+				return fmt.Sprintf("no comments on %s/%s#%d", owner, name, number), nil
+			}
+			sort.SliceStable(entries, func(i, j int) bool { return entries[i].at < entries[j].at })
+			parts := make([]string, len(entries))
+			for i, e := range entries {
+				parts[i] = e.text
+			}
+			return strings.Join(parts, "\n\n"), nil
+		},
+	}
+}
+
+// prArgs decodes the shared {repo, number} argument shape.
+func prArgs(args json.RawMessage) (owner, name string, number int, err error) {
+	var in struct {
+		Repo   string `json:"repo"`
+		Number int    `json:"number"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return "", "", 0, err
+	}
+	owner, name, err = splitRepoArg(in.Repo)
+	if err != nil {
+		return "", "", 0, err
+	}
+	if in.Number < 1 {
+		return "", "", 0, fmt.Errorf("number must be a positive pull request number, got %d", in.Number)
+	}
+	return owner, name, in.Number, nil
+}
+
+// getJSON resolves the PAT, GETs path, and decodes a 200 body into
+// out; op prefixes errors the way the other github helpers do.
+func (s *githubSource) getJSON(ctx context.Context, path, op string, out any) error {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	resp, err := githubRequest(ctx, s.client, token, path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: %w", op, githubStatusError(resp))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("%s: decode response: %w", op, err)
+	}
+	return nil
+}

--- a/internal/brain/connectors/github_tools_test.go
+++ b/internal/brain/connectors/github_tools_test.go
@@ -1,0 +1,355 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// githubToolsSource builds a github source against the fake server
+// with a fixed token, returning its tools by name.
+func githubToolsSource(t *testing.T, handler http.HandlerFunc) map[string]*tools.Tool {
+	t.Helper()
+	githubFakeServer(t, handler)
+	src, err := GitHubBuilder(nil)(t.Context(), Connector{Name: "gh", Kind: "github", CredentialRef: "GH_PAT"},
+		func(_ context.Context, _ string) (string, error) { return "secret-token", nil })
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	out := map[string]*tools.Tool{}
+	for _, tl := range src.Tools() {
+		out[tl.Name] = tl
+	}
+	return out
+}
+
+// requireAuth fails the request unless the fake token is present, so
+// every tool test also proves the PAT is sent.
+func requireAuth(t *testing.T, r *http.Request) bool {
+	t.Helper()
+	if r.Header.Get("Authorization") != "Bearer secret-token" {
+		t.Errorf("%s: Authorization = %q", r.URL.Path, r.Header.Get("Authorization"))
+		return false
+	}
+	return true
+}
+
+func TestSplitRepoArg(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		in, owner, name string
+		wantErr         bool
+	}{
+		{in: "octo/hello.world", owner: "octo", name: "hello.world"},
+		{in: " octo/repo-1 ", owner: "octo", name: "repo-1"},
+		{in: "octo", wantErr: true},
+		{in: "octo/a/b", wantErr: true},
+		{in: "https://github.com/octo/repo", wantErr: true},
+		{in: "", wantErr: true},
+	} {
+		owner, name, err := splitRepoArg(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%q: err = %v, wantErr %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if owner != tc.owner || name != tc.name {
+			t.Errorf("%q: got %s/%s, want %s/%s", tc.in, owner, name, tc.owner, tc.name)
+		}
+	}
+}
+
+func TestListPullRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     string
+		handler  http.HandlerFunc
+		want     []string
+		wantErr  string
+		wantPath string
+	}{
+		{
+			name: "renders number, state, author, branches",
+			args: `{"repo":"octo/repo"}`,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if !requireAuth(t, r) {
+					return
+				}
+				if r.URL.Query().Get("state") != "open" || r.URL.Query().Get("per_page") != "10" {
+					t.Errorf("query = %s", r.URL.RawQuery)
+				}
+				_, _ = w.Write([]byte(`[
+					{"number":7,"title":"Add thing","state":"open","draft":false,"user":{"login":"alice"},"head":{"ref":"feat/x"},"base":{"ref":"main"}},
+					{"number":5,"title":"WIP","state":"open","draft":true,"user":{"login":"bob"},"head":{"ref":"wip"},"base":{"ref":"main"}}
+				]`))
+			},
+			want: []string{"#7 [open] Add thing (alice) feat/x -> main", "#5 [draft] WIP (bob) wip -> main"},
+		},
+		{
+			name: "state and max_results pass through, capped",
+			args: `{"repo":"octo/repo","state":"closed","max_results":500}`,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("state") != "closed" || r.URL.Query().Get("per_page") != "50" {
+					t.Errorf("query = %s", r.URL.RawQuery)
+				}
+				_, _ = w.Write([]byte(`[]`))
+			},
+			want: []string{"no closed pull requests in octo/repo"},
+		},
+		{
+			name:    "malformed repo",
+			args:    `{"repo":"not-a-repo"}`,
+			wantErr: `repo must be "owner/name"`,
+		},
+		{
+			name:    "malformed json",
+			args:    `{"repo":`,
+			wantErr: "unexpected end of JSON",
+		},
+		{
+			name: "401 never leaks token or body",
+			args: `{"repo":"octo/repo"}`,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+			},
+			wantErr: "GitHub token invalid or expired",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := tc.handler
+			if handler == nil {
+				handler = func(_ http.ResponseWriter, r *http.Request) { t.Errorf("unexpected request %s", r.URL.Path) }
+			}
+			tl := githubToolsSource(t, handler)["list_pull_requests"]
+			got, err := tl.Execute(t.Context(), json.RawMessage(tc.args))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				if strings.Contains(err.Error(), "secret-token") || strings.Contains(err.Error(), "Bad credentials") {
+					t.Fatalf("error leaks token or body: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if want := strings.Join(tc.want, "\n"); got != want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestGetPullRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    string
+		handler http.HandlerFunc
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "renders metadata and body",
+			args: `{"repo":"octo/repo","number":7}`,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if !requireAuth(t, r) {
+					return
+				}
+				if r.URL.Path != "/repos/octo/repo/pulls/7" {
+					t.Errorf("path = %s", r.URL.Path)
+				}
+				_, _ = w.Write([]byte(`{"number":7,"title":"Add thing","state":"open","merged":false,"mergeable_state":"clean",
+					"body":"Does the thing.\n","html_url":"https://github.com/octo/repo/pull/7","created_at":"2026-09-01T00:00:00Z","updated_at":"2026-09-02T00:00:00Z",
+					"commits":2,"additions":10,"deletions":3,"changed_files":4,"user":{"login":"alice"},
+					"head":{"ref":"feat/x","sha":"abc123"},"base":{"ref":"main"}}`))
+			},
+			want: []string{
+				"#7 Add thing", "author: alice", "state: open", "head: feat/x (abc123)", "base: main", "mergeable_state: clean",
+				"commits: 2, files changed: 4, +10/-3", "created: 2026-09-01T00:00:00Z, updated: 2026-09-02T00:00:00Z", "url: https://github.com/octo/repo/pull/7",
+				"", "Does the thing.",
+			},
+		},
+		{
+			name: "merged wins over state, empty body omitted",
+			args: `{"repo":"octo/repo","number":8}`,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"number":8,"title":"Done","state":"closed","merged":true,"user":{"login":"alice"},"head":{"ref":"h","sha":"s"},"base":{"ref":"main"}}`))
+			},
+			want: []string{"#8 Done", "author: alice", "state: merged", "head: h (s)", "base: main", "commits: 0, files changed: 0, +0/-0", "created: , updated: ", "url: "},
+		},
+		{
+			name: "404 surfaces status and message",
+			args: `{"repo":"octo/repo","number":404}`,
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+			},
+			wantErr: "get pull request: github: status 404: Not Found",
+		},
+		{
+			name:    "number required",
+			args:    `{"repo":"octo/repo"}`,
+			wantErr: "number must be a positive pull request number",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := tc.handler
+			if handler == nil {
+				handler = func(_ http.ResponseWriter, r *http.Request) { t.Errorf("unexpected request %s", r.URL.Path) }
+			}
+			tl := githubToolsSource(t, handler)["get_pull_request"]
+			got, err := tl.Execute(t.Context(), json.RawMessage(tc.args))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if want := strings.Join(tc.want, "\n"); got != want {
+				t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestGetPullRequestDiff(t *testing.T) {
+	small := "diff --git a/x b/x\n+hello\n"
+	big := strings.Repeat("x", githubDiffMaxBytes+500)
+	for _, tc := range []struct {
+		name    string
+		body    string
+		status  int
+		want    string
+		wantErr string
+	}{
+		{name: "returns diff verbatim", body: small, want: small},
+		{name: "exactly at cap is not truncated", body: strings.Repeat("y", githubDiffMaxBytes), want: strings.Repeat("y", githubDiffMaxBytes)},
+		{name: "over cap is cut with marker", body: big, want: big[:githubDiffMaxBytes] + "\n\n[diff truncated at 204800 bytes; 500 more bytes omitted]"},
+		{name: "empty diff", body: "", want: "empty diff"},
+		{name: "404", status: http.StatusNotFound, body: `{"message":"Not Found"}`, wantErr: "get pull request diff: github: status 404: Not Found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tl := githubToolsSource(t, func(w http.ResponseWriter, r *http.Request) {
+				if !requireAuth(t, r) {
+					return
+				}
+				if r.Header.Get("Accept") != githubDiffMediaType {
+					t.Errorf("Accept = %q, want %q", r.Header.Get("Accept"), githubDiffMediaType)
+				}
+				if r.URL.Path != "/repos/octo/repo/pulls/7" {
+					t.Errorf("path = %s", r.URL.Path)
+				}
+				if tc.status != 0 {
+					w.WriteHeader(tc.status)
+				}
+				_, _ = w.Write([]byte(tc.body))
+			})["get_pull_request_diff"]
+			got, err := tl.Execute(t.Context(), json.RawMessage(`{"repo":"octo/repo","number":7}`))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %d bytes ending %q, want %d bytes ending %q", len(got), tail(got), len(tc.want), tail(tc.want))
+			}
+		})
+	}
+}
+
+func tail(s string) string {
+	if len(s) > 60 {
+		return s[len(s)-60:]
+	}
+	return s
+}
+
+func TestListPullRequestComments(t *testing.T) {
+	t.Run("merges issue and review comments chronologically", func(t *testing.T) {
+		tl := githubToolsSource(t, func(w http.ResponseWriter, r *http.Request) {
+			if !requireAuth(t, r) {
+				return
+			}
+			switch r.URL.Path {
+			case "/repos/octo/repo/issues/7/comments":
+				_, _ = w.Write([]byte(`[{"id":1,"body":"Looks good overall.","created_at":"2026-09-02T10:00:00Z","user":{"login":"bob"}}]`))
+			case "/repos/octo/repo/pulls/7/comments":
+				_, _ = w.Write([]byte(`[
+					{"id":2,"body":"Nit: rename.","created_at":"2026-09-01T09:00:00Z","path":"main.go","line":12,"user":{"login":"carol"}},
+					{"id":3,"body":"Whole-file note.","created_at":"2026-09-03T09:00:00Z","path":"README.md","user":{"login":"carol"}}
+				]`))
+			default:
+				t.Errorf("unexpected path %s", r.URL.Path)
+			}
+		})["list_pull_request_comments"]
+		got, err := tl.Execute(t.Context(), json.RawMessage(`{"repo":"octo/repo","number":7}`))
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		want := strings.Join([]string{
+			"[2026-09-01T09:00:00Z] carol (review on main.go:12):\nNit: rename.",
+			"[2026-09-02T10:00:00Z] bob (comment):\nLooks good overall.",
+			"[2026-09-03T09:00:00Z] carol (review on README.md):\nWhole-file note.",
+		}, "\n\n")
+		if got != want {
+			t.Fatalf("got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+	t.Run("no comments", func(t *testing.T) {
+		tl := githubToolsSource(t, func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`[]`)) })["list_pull_request_comments"]
+		got, err := tl.Execute(t.Context(), json.RawMessage(`{"repo":"octo/repo","number":7}`))
+		if err != nil || got != "no comments on octo/repo#7" {
+			t.Fatalf("got %q, %v", got, err)
+		}
+	})
+	t.Run("error on second call propagates", func(t *testing.T) {
+		tl := githubToolsSource(t, func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.URL.Path, "/pulls/") {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"Resource not accessible by personal access token"}`))
+				return
+			}
+			_, _ = w.Write([]byte(`[]`))
+		})["list_pull_request_comments"]
+		_, err := tl.Execute(t.Context(), json.RawMessage(`{"repo":"octo/repo","number":7}`))
+		if err == nil || !strings.Contains(err.Error(), "list pull request comments: github: status 403: Resource not accessible") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+// TestGitHubPRToolsReachMissions pins the whole reason for this
+// surface: through the manager, every github tool lands in
+// ReadOnlyTools under its raw name, so missions' connector-reads
+// resolver can offer it.
+func TestGitHubPRToolsReachMissions(t *testing.T) {
+	t.Parallel()
+	src, err := GitHubBuilder(nil)(t.Context(), Connector{Name: "gh", Kind: "github", CredentialRef: "GH_PAT"},
+		func(_ context.Context, _ string) (string, error) { return "tok", nil })
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{"gh": src}
+	got := map[string]bool{}
+	for _, tl := range m.ReadOnlyTools() {
+		got[tl.Name] = true
+	}
+	for _, name := range []string{"list_pull_requests", "get_pull_request", "get_pull_request_diff", "list_pull_request_comments"} {
+		if !got[name] {
+			t.Errorf("ReadOnlyTools lacks %s: got %v", name, got)
+		}
+	}
+}

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -716,10 +716,10 @@ type identifier interface {
 
 // TestIdentity is Test plus, for a kind that can report one (github,
 // microsoft, google), the resolved identity — the evidence a working
-// credential was configured, since a github connector serves no tools
-// to prove itself with otherwise (microsoft's tools require a scope
-// the operator may not have granted, so the identity check is useful
-// there too). identity is nil for kinds with no identity concept.
+// credential was configured, since a github connector's tools only
+// prove themselves against a repo the operator names (microsoft's
+// tools require a scope the operator may not have granted, so the
+// identity check is useful there too). identity is nil for kinds with no identity concept.
 func (m *Manager) TestIdentity(ctx context.Context, id string) (*GitHubIdentity, error) {
 	c, err := m.rows.Get(ctx, id)
 	if err != nil {

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -389,7 +389,7 @@ function ConnectorEditForm({
               <div className="space-y-3">
                 <p className="text-sm text-muted-foreground">
                   {connector.kind === 'github' ? (
-                    'Identity for mission clone/push/PR use, no chat tools.'
+                    'Identity for mission clone/push/PR use, plus read-only pull request tools.'
                   ) : connector.kind === 'imap' ? (
                     <>
                       <span className="font-mono">

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -149,7 +149,7 @@ function ConnectorCard({
         ? (connector.config.scopes as string[] | undefined)?.map((s) => s.split('/').pop()).join(', ')
         : connector.kind === 'imap' || connector.kind === 'caldav'
           ? String(connector.config.username ?? '')
-          : 'Identity for mission use, no chat tools'
+          : 'Identity for mission use, read-only pull request tools'
 
   return (
     <EntityCard

--- a/web/src/components/settings/connectorPresets.ts
+++ b/web/src/components/settings/connectorPresets.ts
@@ -87,7 +87,7 @@ export const connectorPresets: ConnectorPreset[] = [
     id: 'github-account',
     name: 'GitHub',
     kind: 'github',
-    description: 'Identity for mission clone/push/PR, no chat tools',
+    description: 'Identity for mission clone/push/PR, read-only pull request tools',
     logo: 'github',
     brandColor: '#24292F',
     tokenPlaceholder: 'ghp_… or github_pat_…',


### PR DESCRIPTION
Closes #727. Groundwork for #656.

The `github` connector kind was identity-only: it cloned, pushed, and opened PRs for missions but served no agent tools. PR reads existed only on the GitHub MCP connector, which `aggregateTools` strips from `ReadOnlyTools` because a remote server's read-only claim cannot be verified. A mission asked to review a PR had no path to it.

This adds four read-only tools to the native kind, so `ReadOnly: true` is Timothy's own Go code and the existing `missionConnectorReadsResolver` hands them to mission turns unchanged:

- `list_pull_requests`: state filter, bounded page size, newest updated first
- `get_pull_request`: metadata, mergeable state, counts, description
- `get_pull_request_diff`: unified diff via `application/vnd.github.diff`, cut at 200 KiB with an omitted-bytes marker
- `list_pull_request_comments`: issue and review comments merged chronologically, review comments marked with file and line

All take `repo` as `owner/name` and resolve the PAT per call through `credential_ref`. No write tools: chat reaches those through the GitHub MCP connector, missions through destinations. Web copy no longer says "no chat tools".

Tests: table-driven per tool against `httptest` (malformed args, 401 without token or body leakage, 404, diff at and over the cap, comment ordering) plus a manager-level check that all four land in `ReadOnlyTools`. `make build test vet lint` and the web build, lint, and tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791843128&installation_model_id=431401&pr_number=728&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F728&signature=eb36414f4dfcb32c4bf138cb7d35a8bc6535295a301cf6b5773f41e73bb43e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->